### PR TITLE
MLAPB-23: Fix empty coverage report in codecov

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -9,11 +9,11 @@ jobs:
       run:
         working-directory: app
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: '^1.18'
-      - uses: actions/checkout@v3
       - name: Run tests and generate coverage report
         run: |
           go test -race -covermode=atomic -coverprofile=coverage.txt -v

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run tests and generate coverage report
         run: |
-          go test -race -covermode=atomic -coverprofile=coverage.out -v
+          go test -race -covermode=atomic -coverprofile=coverage.txt -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -9,11 +9,11 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: '^1.18'
+      - uses: actions/checkout@v3
       - name: Run tests and generate coverage report
         run: |
           go test -race -covermode=atomic -coverprofile=coverage.out -v

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: '^1.18'
       - name: Run tests and generate coverage report
         run: |
-          go test ./... -race -covermode=atomic -coverprofile=coverage.txt -v
+          go test ./... -race -covermode=atomic -coverprofile=coverage.out -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: '^1.18'
       - name: Run tests and generate coverage report
         run: |
-          go test -race -covermode=atomic -coverprofile=coverage.txt -v
+          go test ./... -race -covermode=atomic -coverprofile=coverage.txt -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/app/internal/fake/fake.go
+++ b/app/internal/fake/fake.go
@@ -1,0 +1,5 @@
+package fake
+
+func GoodBye() string {
+	return "See ya!"
+}

--- a/app/internal/fake/fake_test.go
+++ b/app/internal/fake/fake_test.go
@@ -1,0 +1,12 @@
+package fake
+
+import "testing"
+
+func TestGoodBye(t *testing.T) {
+	got := GoodBye()
+	want := "See ya!"
+
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/fake"
+)
 
 func Hello() string {
 	return "Hello, world!"
@@ -8,4 +11,5 @@ func Hello() string {
 
 func main() {
 	fmt.Println(Hello())
+	fmt.Println(fake.GoodBye())
 }


### PR DESCRIPTION
# Purpose

After #5 and #7 we were still getting an error in codecov advising that there was an empty coverage report. This PR ensures we are getting (mostly) the expected coverage for our Go app.

Fixes MLPAB-12

## Learning

It appears that codecov doesn't recognise `main.go` or anything in the `main` package as requiring a coverage figure. As soon as I added a dummy package the coverage stats were recognised. Depending on how logic-heavy our main function is we may need to delve further into why `main` code is ignored but for now we can confirm any other code will be included in our coverage stats.

Once we play the first ticket that involves writing some Go code (and a test) we can drop the `fake` package and test added in this PR.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
