### PR TITLE
MLPAB-63 -  Create a encryption key per account for log encryption

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.18.0"
+  constraints = ">= 2.7.0, 4.18.0"
+  hashes = [
+    "h1:62MWy6fGx/cVk1DnLcc8rUxCCKhi6/R9fi/Af/ph9ag=",
+    "zh:100a11324326bf849b4c85d3c40a81e485726eee99c5a229387b8485a7a8da8b",
+    "zh:2226bbf97101af90e43cd5606d8678f35d7e7b477657d9297c42a1bd2ed42750",
+    "zh:27d51694300c08c32312f8832b889c57a2821dc022d49d38f9b1e14810f8a3fb",
+    "zh:2b8792c76986facfd415f967c5d61022f7ceeaa46c158037fe8939e36d954f99",
+    "zh:3ea787967de772cc3a13469753080c8fa81be5aefc735d3753c7627f63c948e5",
+    "zh:64d58463cbb2b93d5202ef311a101890a1e083f9587f3eabb9f2e26dd0cf8f43",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b10eecf4c034a229712825124e7c0b765c5904648550dc8f844f68638531d337",
+    "zh:d9a3cc46e2746c40ea69bcfb2d12e765ee6bda3e1ed8ce73f272d492ff4836bb",
+    "zh:df625e57aa3b5fb3e4562da44daf6565289818ba2a7e66f86ad968b43fdb5148",
+    "zh:eaaa3a5d2a15a87b346e521872120a3ca7f6777a04226a55f51022eaf4097963",
+    "zh:ec6f4b00ae4f9d536f2a6c2e5a5f149867194268ce9068a9c348bc3e678fbfce",
+  ]
+}

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "cloudwatch" {
-  description             = "${local.mandatory_moj_tags.application} cloudwatch application logs encryption key for ${data.aws_region.eu_west_1.name}"
+  description             = "${local.mandatory_moj_tags.application} cloudwatch application logs encryption key"
   deletion_window_in_days = 10
   enable_key_rotation     = true
   policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.cloudwatch_kms_merged.json : data.aws_iam_policy_document.cloudwatch_kms.json
@@ -7,10 +7,16 @@ resource "aws_kms_key" "cloudwatch" {
   provider                = aws.eu_west_1
 }
 
-resource "aws_kms_alias" "cloudwatch_alias" {
-  name          = "alias/${local.mandatory_moj_tags.application}_cloudwatch_application_logs_encryption_${data.aws_region.eu_west_1.name}"
+resource "aws_kms_alias" "cloudwatch_alias_eu_west_1" {
+  name          = "alias/${local.mandatory_moj_tags.application}_cloudwatch_application_logs_encryption"
   target_key_id = aws_kms_key.cloudwatch.key_id
   provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "cloudwatch_alias_eu_west_2" {
+  name          = "alias/${local.mandatory_moj_tags.application}_cloudwatch_application_logs_encryption"
+  target_key_id = aws_kms_key.cloudwatch.key_id
+  provider      = aws.eu_west_2
 }
 
 # See the following link for further information

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
-        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/${var.default_role}",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
       ]
     }
   }

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -1,0 +1,111 @@
+resource "aws_kms_key" "cloudwatch" {
+  description             = "${local.mandatory_moj_tags.application} cloudwatch application logs encryption key for ${data.aws_region.eu_west_1.name}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.cloudwatch_kms_merged.json : data.aws_iam_policy_document.cloudwatch_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "cloudwatch_alias" {
+  name          = "alias/${local.mandatory_moj_tags.application}_cloudwatch_application_logs_encryption_${data.aws_region.eu_west_1.name}"
+  target_key_id = aws_kms_key.cloudwatch.key_id
+  provider      = aws.eu_west_1
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "cloudwatch_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.cloudwatch_kms.json,
+    data.aws_iam_policy_document.cloudwatch_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "cloudwatch_kms" {
+  provider = aws.global
+  statement {
+    sid       = "Allow Key to be used for Encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.eu_west_1.name}.amazonaws.com",
+        "logs.${data.aws_region.eu_west_2.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/${var.default_role}",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid       = "Dev Account Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -48,3 +48,51 @@ provider "aws" {
     session_name = "opg-modernising-lpa-terraform-session"
   }
 }
+
+provider "aws" {
+  alias  = "global"
+  region = "us-east-1"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
+    session_name = "opg-modernising-lpa-terraform-session"
+  }
+}
+
+data "aws_region" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_caller_identity" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_default_tags" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_region" "eu_west_2" {
+  provider = aws.eu_west_2
+}
+
+data "aws_caller_identity" "eu_west_2" {
+  provider = aws.eu_west_2
+}
+
+data "aws_default_tags" "eu_west_2" {
+  provider = aws.eu_west_2
+}
+
+data "aws_region" "global" {
+  provider = aws.global
+}
+
+data "aws_caller_identity" "global" {
+  provider = aws.global
+}
+
+data "aws_default_tags" "global" {
+  provider = aws.global
+}

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -19,7 +19,7 @@ locals {
   mandatory_moj_tags = {
     business-unit    = "OPG"
     application      = "opg-modernising-lpa"
-    environment-name = local.account_name
+    environment-name = local.account.account_name
     owner            = "OPG Webops: opgteam+modernising-lpa@digital.justice.gov.uk"
     is-production    = local.account.is_production
     runbook          = "https://github.com/ministryofjustice/opg-modernising-lpa"


### PR DESCRIPTION
# Purpose

Create a encryption key per account for log encryption

Fixes MLPAB-63

## Approach

- Add a global aws provider for IAM
- Create a multi-region kms key
- add data sources to retrieve useful attributes for interpolating ARNs

## Learning

- https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
