### PR TITLE
MLPA-65 - Create certificate for app ALB

### DIFF
--- a/terraform/account/region/certificate.tf
+++ b/terraform/account/region/certificate.tf
@@ -1,0 +1,38 @@
+data "aws_route53_zone" "modernising_lpa" {
+  provider = aws.management
+  name     = "modernising.opg.service.justice.gov.uk"
+}
+
+locals {
+  dev_wildcard = data.aws_default_tags.current.tags.environment-name == "production" ? "" : "*."
+}
+
+resource "aws_acm_certificate" "app" {
+  domain_name       = "${local.dev_wildcard}app.modernising.opg.service.justice.gov.uk"
+  validation_method = "DNS"
+  provider          = aws.region
+}
+
+resource "aws_acm_certificate_validation" "app" {
+  certificate_arn         = aws_acm_certificate.app.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_app : record.fqdn]
+  provider                = aws.region
+}
+
+resource "aws_route53_record" "certificate_validation_app" {
+  provider = aws.management
+  for_each = {
+    for dvo in aws_acm_certificate.app.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.modernising_lpa.zone_id
+}

--- a/terraform/account/region/terraform.tf
+++ b/terraform/account/region/terraform.tf
@@ -6,6 +6,7 @@ terraform {
       source = "hashicorp/aws"
       configuration_aliases = [
         aws.region,
+        aws.management,
       ]
     }
   }

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -2,7 +2,8 @@ module "eu_west_1" {
   source             = "./region"
   network_cidr_block = "10.162.0.0/16"
   providers = {
-    aws.region = aws.eu_west_1
+    aws.region     = aws.eu_west_1
+    aws.management = aws.management_eu_west_1
   }
 
 }

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -50,6 +50,30 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "management_eu_west_1"
+  region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
+    session_name = "opg-modernising-lpa-terraform-session"
+  }
+}
+
+provider "aws" {
+  alias  = "management_eu_west_2"
+  region = "eu-west-2"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
+    session_name = "opg-modernising-lpa-terraform-session"
+  }
+}
+
+provider "aws" {
   alias  = "global"
   region = "us-east-1"
   default_tags {


### PR DESCRIPTION
# Purpose

Encrypt traffic down to load balancers

Fixes MLPAB-64 MLPAB-65

## Approach

- Create AWS ACM certificate for app
- Create providers for management

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#referencing-domain_validation_options-with-for_each-based-resources

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
