### PR TITLE
MLAPB-87: Add air auto-reload to dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,43 @@
+FROM node:18.7.0-alpine3.16 as asset-env
+
+WORKDIR /app
+
+RUN mkdir -p web/static
+
+COPY package.json .
+COPY yarn.lock .
+RUN yarn
+
+COPY web/assets web/assets
+RUN yarn build
+
+FROM golang:1.18 as build-env
+
+WORKDIR /app
+
+COPY app/go.mod .
+COPY app/go.sum .
+
+RUN go mod download
+
+COPY /app .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/mlpab
+
+FROM alpine:3.16.1 as production
+
+WORKDIR /go/bin
+
+COPY --from=build-env /go/bin/mlpab /go/bin/mlpab
+COPY --from=asset-env /app/web/static web/static
+COPY web/template web/template
+
+RUN addgroup -S app && \
+    adduser -S -g app app && \
+    chown -R app:app mlpab web/template web/static
+USER app
+
+FROM build-env
+
+# Live reload for Go
+RUN go install github.com/cosmtrek/air@latest

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: app
+    ports:
+      - "5050:5000"
+    depends_on:
+      - oidc-server-mock
+    volumes:
+      - ./app:/app
+    command: air


### PR DESCRIPTION
# Purpose

Enables a watch on the go app so the binary is automatically rebuilt when valid changes are made.

Fixes MLPAB-87

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
