### PR TITLE
MLPAB-82 - Add permissions for app ECS to put telemetry to xray

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -101,7 +101,7 @@ data "aws_secretsmanager_secret" "private_jwt_key" {
 
 data "aws_iam_policy_document" "task_role_access_policy" {
   statement {
-    sid    = "xrayaccess"
+    sid    = "XrayAccess"
     effect = "Allow"
 
     actions = [

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -101,6 +101,21 @@ data "aws_secretsmanager_secret" "private_jwt_key" {
 
 data "aws_iam_policy_document" "task_role_access_policy" {
   statement {
+    sid    = "xrayaccess"
+    effect = "Allow"
+
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+      "xray:GetSamplingStatisticSummaries",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid    = "EcsDecryptAccess"
     effect = "Allow"
 


### PR DESCRIPTION
# Purpose

Start the implementation of observability with xRay

Fixes MLPAB-82

## Approach

- Add write permissions for using the X-Ray daemon, AWS CLI, or AWS SDK to upload segment documents and telemetry to the X-Ray API

## Learning

- https://docs.aws.amazon.com/xray/latest/devguide/security_iam_id-based-policy-examples.html

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
