### PR TITLE
MLPAB-129 - rollback version of github-tag-action

### DIFF
--- a/.github/workflows/tags_job.yml
+++ b/.github/workflows/tags_job.yml
@@ -27,7 +27,7 @@ jobs:
           fi
       - name: Bump version
         id: bump_version
-        uses: anothrNick/github-tag-action@1.39.0
+        uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INITIAL_VERSION: 0.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,7 @@ repos:
       - id: go-fmt # Runs gofmt
       - id: go-imports # Runs gofmt
       - id: go-mod-tidy # Tidies up and removes unused requires in go.mod using go mod tidy
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 32.184.2
+    hooks:
+      - id: renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,8 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": false
-  }
+  },
+  "ignoreDeps": [
+    "eslanothrNick/github-tag-actionint"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,6 @@
     "enabled": false
   },
   "ignoreDeps": [
-    "eslanothrNick/github-tag-actionint"
+    "anothrNick/github-tag-action"
   ]
 }

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -99,6 +99,11 @@ data "aws_secretsmanager_secret" "private_jwt_key" {
   provider = aws.region
 }
 
+data "aws_secretsmanager_secret" "cookie_session_keys" {
+  name     = "cookie-session-keys"
+  provider = aws.region
+}
+
 data "aws_iam_policy_document" "task_role_access_policy" {
   statement {
     sid    = "XrayAccess"
@@ -139,6 +144,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
     resources = [
       data.aws_secretsmanager_secret.private_jwt_key.arn,
+      data.aws_secretsmanager_secret.cookie_session_keys.arn,
     ]
   }
   provider = aws.region

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -140,6 +140,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
     actions = [
       "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
     ]
 
     resources = [


### PR DESCRIPTION
# Purpose

The newer version of the action runs into issues creating new tags frequently

Fixes MLPAB-129

## Approach

- Set version to 1.36.0
- ignore dependency for now
- fix issue with access to cookie secret

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
