### PR TITLE
MLPAB-149 - Bug - Configure healthcheck to hit /start

### DIFF
--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -8,8 +8,9 @@ resource "aws_lb_target_group" "app" {
   depends_on           = [aws_lb.app]
 
   health_check {
-    enabled = true
-    path    = "/"
+    enabled  = true
+    path     = "/start"
+    protocol = "HTTPS"
   }
 
   provider = aws.region

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -8,9 +8,8 @@ resource "aws_lb_target_group" "app" {
   depends_on           = [aws_lb.app]
 
   health_check {
-    enabled  = true
-    path     = "/start"
-    protocol = "HTTPS"
+    enabled = true
+    path    = "/start"
   }
 
   provider = aws.region


### PR DESCRIPTION
# Purpose

Health-checks are currently failing for receiving a non-200 response

Fixes MLPAB-149

## Approach

- Configure ALP target group health-check to use /start

## Learning

A reminder that health-checks are being performed inside the network, so only the redirect from / to /start was causing an issue, not any of the protocol or port redirects performed by the load-balancer listener rules.

- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~