### PR TITLE
MLPAB-151 - Create a backup plan for DynamoDB tables

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -16,6 +16,18 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:p5Ma8QZ9f3SJesSzmMn/df9eAUqyOn8KUnjFKFHI3jI=",
     "h1:sQsqR0qAwrW3lL38Rf1yOoBQ8vppK0cVEzs5hZSIWp8=",
     "h1:u0G5dgyBJZgrXicmD/nxSJebNORcQqFkN1jU2emJBUI=",
+    "zh:091615c6dddd556b8cc1cd54e1c5c1fe71b593acebacd0b274a2fed7fc4ca802",
+    "zh:4cc11d7252813b2d7cb52e78b24af8eaf377cc242d1d672a7f8bf680758a4976",
+    "zh:565f46308d6e96a21c273e84e0f73d3f39fd8159fc5aaf41bf65c0b0dd6f1de3",
+    "zh:627b6a5574262b5f07c0e012bcb5c73afd97d90b75389c0ab154b5ae4c0dce8f",
+    "zh:91622572d311c28504fbf14e9364120fbafb3adf8e2d49bfdf014752dac9dac0",
+    "zh:98f37f07628b7c2960335b772a544de6bb90f0f390b9d5fdcc3ac211b9cd7def",
+    "zh:9a6338478ba0e7ca75c5b43e0f91dde12d17273b1dc9934c8ff4d631b8bb837a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1cc1fc49e406cba1e98250bc04a47be0b6babf5bb42f23baa40f2dc7f8b90f7",
+    "zh:a251e933412036426e2f7b090000c198feee114270d5724bcc8dd9d674d43689",
+    "zh:b0ef3b92947cc8cea75634139dfbfcae2207a9cb5c31d827cd34e523ca04e919",
+    "zh:fb9ede02c9291e7677877bc21ec5c094da38e3cd44df91da5af36f504be399be",
   ]
 }
 

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -1,5 +1,5 @@
-data "aws_backup_vault" "main" {
-  name     = "${local.environment.account_name}_main_backup_vault"
+data "aws_backup_vault" "eu-west-1" {
+  name     = "eu-west-1-${local.environment.account_name}_main_backup_vault"
   provider = aws.eu_west_1
 }
 

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -1,9 +1,9 @@
-data "aws_backup_vault" "eu-west-1" {
+data "aws_backup_vault" "eu_west_1" {
   name     = "eu-west-1-${local.environment.account_name}-backup-vault"
   provider = aws.eu_west_1
 }
 
-data "aws_backup_vault" "eu-west-2" {
+data "aws_backup_vault" "eu_west_2" {
   name     = "eu-west-2-${local.environment.account_name}-backup-vault"
   provider = aws.eu_west_2
 }
@@ -23,7 +23,7 @@ resource "aws_backup_plan" "main" {
     rule_name           = "DailyBackups"
     schedule            = "cron(0 5 ? * * *)"
     start_window        = 480
-    target_vault_name   = data.aws_backup_vault.eu-west-1.name
+    target_vault_name   = data.aws_backup_vault.eu_west_1.name
 
     lifecycle {
       cold_storage_after = 0
@@ -33,7 +33,7 @@ resource "aws_backup_plan" "main" {
     dynamic "copy_action" {
       for_each = local.environment.backups.copy_action_enabled ? [1] : []
       content {
-        destination_vault_arn = data.aws_backup_vault.eu-west-2.arn
+        destination_vault_arn = data.aws_backup_vault.eu_west_2.arn
       }
     }
   }
@@ -43,7 +43,7 @@ resource "aws_backup_plan" "main" {
     rule_name           = "Monthly"
     schedule            = "cron(0 5 1 * ? *)"
     start_window        = 480
-    target_vault_name   = data.aws_backup_vault.eu-west-1.name
+    target_vault_name   = data.aws_backup_vault.eu_west_1.name
 
     lifecycle {
       cold_storage_after = 30
@@ -52,7 +52,7 @@ resource "aws_backup_plan" "main" {
     dynamic "copy_action" {
       for_each = local.environment.backups.copy_action_enabled ? [1] : []
       content {
-        destination_vault_arn = data.aws_backup_vault.eu-west-2.arn
+        destination_vault_arn = data.aws_backup_vault.eu_west_2.arn
       }
     }
   }
@@ -108,7 +108,7 @@ resource "aws_sns_topic_policy" "aws_backup_failure_events" {
 
 resource "aws_backup_vault_notifications" "aws_backup_failure_events" {
   count               = local.environment.backups.backup_plan_enabled ? 1 : 0
-  backup_vault_name   = data.aws_backup_vault.eu-west-1.name
+  backup_vault_name   = data.aws_backup_vault.eu_west_1.name
   sns_topic_arn       = aws_sns_topic.aws_backup_failure_events[0].arn
   backup_vault_events = ["BACKUP_JOB_FAILED", "COPY_JOB_FAILED"]
   provider            = aws.eu_west_1

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -59,6 +59,7 @@ resource "aws_backup_selection" "main" {
   provider = aws.eu_west_1
 }
 
+#tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "aws_backup_failure_events" {
   count    = local.environment.backups.backup_plan_enabled ? 1 : 0
   name     = "backup-vault-failure-events"

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -1,5 +1,5 @@
 data "aws_backup_vault" "eu-west-1" {
-  name     = "eu-west-1-${local.environment.account_name}-main-backup-vault"
+  name     = "eu-west-1-${local.environment.account_name}-backup-vault"
   provider = aws.eu_west_1
 }
 

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -66,8 +66,6 @@ resource "aws_sns_topic" "aws_backup_failure_events" {
 }
 
 data "aws_iam_policy_document" "aws_backup_sns" {
-  policy_id = "__default_policy_ID"
-
   statement {
     actions = [
       "SNS:Publish",
@@ -83,8 +81,6 @@ data "aws_iam_policy_document" "aws_backup_sns" {
     resources = [
       aws_sns_topic.aws_backup_failure_events[0].arn,
     ]
-
-    sid = "__default_statement_ID"
   }
 }
 

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -56,4 +56,5 @@ resource "aws_backup_selection" "main" {
   resources = [
     aws_dynamodb_table.lpas_table.arn,
   ]
+  provider = aws.eu_west_1
 }

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -66,6 +66,7 @@ resource "aws_sns_topic" "aws_backup_failure_events" {
 }
 
 data "aws_iam_policy_document" "aws_backup_sns" {
+  count = local.environment.backups.backup_plan_enabled ? 1 : 0
   statement {
     actions = [
       "SNS:Publish",
@@ -87,7 +88,7 @@ data "aws_iam_policy_document" "aws_backup_sns" {
 resource "aws_sns_topic_policy" "aws_backup_failure_events" {
   count    = local.environment.backups.backup_plan_enabled ? 1 : 0
   arn      = aws_sns_topic.aws_backup_failure_events[0].arn
-  policy   = data.aws_iam_policy_document.aws_backup_sns.json
+  policy   = data.aws_iam_policy_document.aws_backup_sns[0].json
   provider = aws.eu_west_1
 }
 

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "aws_backup_sns" {
       aws_sns_topic.aws_backup_failure_events[0].arn,
     ]
   }
+  provider = aws.eu_west_1
 }
 
 resource "aws_sns_topic_policy" "aws_backup_failure_events" {

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -1,9 +1,59 @@
 data "aws_backup_vault" "eu-west-1" {
-  name     = "eu-west-1-${local.environment.account_name}_main_backup_vault"
+  name     = "eu-west-1-${local.environment.account_name}-main-backup-vault"
   provider = aws.eu_west_1
 }
 
 data "aws_iam_role" "aws_backup_role" {
-  name     = "aws_backup_role"
+  name     = "aws-backup-role"
   provider = aws.eu_west_1
+}
+
+resource "aws_backup_plan" "main" {
+  count = local.environment.backups.backup_plan_enabled ? 1 : 0
+  name  = "${local.environment_name}-main-backup-plan"
+
+  rule {
+    completion_window   = 10080
+    recovery_point_tags = {}
+    rule_name           = "DailyBackups"
+    schedule            = "cron(0 5 ? * * *)"
+    start_window        = 480
+    target_vault_name   = data.aws_backup_vault.eu-west-1.name
+
+    lifecycle {
+      cold_storage_after = 0
+      delete_after       = 90
+    }
+    # copy_action {
+    #   destination_vault_arn = ""
+    # }
+  }
+  rule {
+    completion_window   = 10080
+    recovery_point_tags = {}
+    rule_name           = "Monthly"
+    schedule            = "cron(0 5 1 * ? *)"
+    start_window        = 480
+    target_vault_name   = data.aws_backup_vault.eu-west-1.name
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 365
+    }
+    # copy_action {
+    #   destination_vault_arn = ""
+    # }
+  }
+  provider = aws.eu_west_1
+}
+
+resource "aws_backup_selection" "main" {
+  count        = local.environment.backups.backup_plan_enabled ? 1 : 0
+  iam_role_arn = data.aws_iam_role.aws_backup_role.arn
+  name         = "${local.environment_name}_main_backup_selection"
+  plan_id      = aws_backup_plan.main[0].id
+
+  resources = [
+    aws_dynamodb_table.lpas_table.arn,
+  ]
 }

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -1,0 +1,9 @@
+data "aws_backup_vault" "main" {
+  name     = "${local.environment.account_name}_main_backup_vault"
+  provider = aws.eu_west_1
+}
+
+data "aws_iam_role" "aws_backup_role" {
+  name     = "aws_backup_role"
+  provider = aws.eu_west_1
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,6 +9,9 @@
           "app_public_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk"
         }
       },
+      "backups": {
+          "backup_plan_enabled": true
+      },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true
       },
@@ -28,6 +31,9 @@
           "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk"
         }
       },
+      "backups": {
+          "backup_plan_enabled": true
+      },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true
       },
@@ -46,6 +52,9 @@
         "env": {
           "app_public_url": "https://app.modernising.opg.service.justice.gov.uk"
         }
+      },
+      "backups": {
+        "backup_plan_enabled": true
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": false

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -10,7 +10,7 @@
         }
       },
       "backups": {
-          "backup_plan_enabled": true
+          "backup_plan_enabled": false
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -10,7 +10,7 @@
         }
       },
       "backups": {
-          "backup_plan_enabled": true,
+          "backup_plan_enabled": false,
           "copy_action_enabled": false
       },
       "ecs": {
@@ -33,8 +33,8 @@
         }
       },
       "backups": {
-          "backup_plan_enabled": true,
-          "copy_action_enabled": true
+          "backup_plan_enabled": false,
+          "copy_action_enabled": false
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true
@@ -57,7 +57,7 @@
       },
       "backups": {
         "backup_plan_enabled": true,
-        "copy_action_enabled": true
+        "copy_action_enabled": false
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": false

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -10,7 +10,8 @@
         }
       },
       "backups": {
-          "backup_plan_enabled": false
+          "backup_plan_enabled": true,
+          "copy_action_enabled": false
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true
@@ -32,7 +33,8 @@
         }
       },
       "backups": {
-          "backup_plan_enabled": true
+          "backup_plan_enabled": true,
+          "copy_action_enabled": true
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": true
@@ -54,7 +56,8 @@
         }
       },
       "backups": {
-        "backup_plan_enabled": true
+        "backup_plan_enabled": true,
+        "copy_action_enabled": true
       },
       "ecs": {
         "enable_fargate_spot_capacity_provider": false

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -22,6 +22,9 @@ variable "environments" {
           app_public_url = string
         })
       })
+      backups = object({
+        backup_plan_enabled = bool
+      })
       ecs = object({
         enable_fargate_spot_capacity_provider = bool
       })

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -24,6 +24,7 @@ variable "environments" {
       })
       backups = object({
         backup_plan_enabled = bool
+        copy_action_enabled = bool
       })
       ecs = object({
         enable_fargate_spot_capacity_provider = bool


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-151

## Approach

- pull vaults for both regions and backup role
- create a backup plan
- add variable to enable copy action to a second region
- associate resources that are to be backed up
- add a variable to enable backups
- add notifications to AWS SNS (temporary) for backup and copy failures


## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_plan
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_notifications
- https://docs.aws.amazon.com/aws-backup/latest/devguide/sns-notifications.html
- https://www.terraform.io/language/expressions/dynamic-blocks

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
