### PR TITLE
MLPAB-148 - Fix - When destroying a PR environment, init before destroy

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -48,13 +48,13 @@ jobs:
           echo ${workspace}
     outputs:
           environment_workspace_name: ${{ steps.name_workspace.outputs.name }}
+
   cleanup_workspace:
     runs-on: ubuntu-latest
     needs: generate_environment_workspace_name
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -63,11 +63,12 @@ jobs:
           aws-region: eu-west-1
           role-duration-seconds: 3600
           role-session-name: OPGModernisingLPATerraformGithubAction
-
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
-
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ./terraform/environment
       - name: Destroy PR Terraform Workspaces
         working-directory: ./terraform/environment
         run: |


### PR DESCRIPTION
# Purpose

New Destroy PR env on merge workflow failed to start destroy

Fixes MLPAB-148

## Approach

- insert a terraform init step

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
