### PR TITLE
MLPAB-158 - Use CMK for DynamoDB encryption

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -34,57 +34,59 @@ jobs:
     name: Create Tags
     uses: ./.github/workflows/tags_job.yml
 
-  go_unit_tests:
-    name: Run Go unit tests
-    uses: ./.github/workflows/go-unit-tests.yml
+  # go_unit_tests:
+  #   name: Run Go unit tests
+  #   uses: ./.github/workflows/go-unit-tests.yml
 
-  docker_build_scan_push:
-    name: Docker Build, Scan and Push
-    uses: ./.github/workflows/docker_job.yml
-    needs: [go_unit_tests, create_tags]
-    with:
-      tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
+  # docker_build_scan_push:
+  #   name: Docker Build, Scan and Push
+  #   uses: ./.github/workflows/docker_job.yml
+  #   needs: [go_unit_tests, create_tags]
+  #   with:
+  #     tag: ${{ needs.create_tags.outputs.version_tag }}
+  #   secrets: inherit
 
-  terraform_account_workflow_development:
-    name: TF Plan Dev Account
-    uses: ./.github/workflows/terraform_account_job.yml
-    with:
-      workspace_name: development
-    secrets: inherit
+  # terraform_account_workflow_development:
+  #   name: TF Plan Dev Account
+  #   uses: ./.github/workflows/terraform_account_job.yml
+  #   with:
+  #     workspace_name: development
+  #   secrets: inherit
 
-  terraform_account_workflow_preproduction:
-    name: TF Plan Preprod Account
-    needs: terraform_account_workflow_development
-    uses: ./.github/workflows/terraform_account_job.yml
-    with:
-      workspace_name: preproduction
-    secrets: inherit
+  # terraform_account_workflow_preproduction:
+  #   name: TF Plan Preprod Account
+  #   needs: terraform_account_workflow_development
+  #   uses: ./.github/workflows/terraform_account_job.yml
+  #   with:
+  #     workspace_name: preproduction
+  #   secrets: inherit
 
-  terraform_account_workflow_production:
-    name: TF Plan Prod Account
-    needs: terraform_account_workflow_development
-    uses: ./.github/workflows/terraform_account_job.yml
-    with:
-      workspace_name: production
-    secrets: inherit
+  # terraform_account_workflow_production:
+  #   name: TF Plan Prod Account
+  #   needs: terraform_account_workflow_development
+  #   uses: ./.github/workflows/terraform_account_job.yml
+  #   with:
+  #     workspace_name: production
+  #   secrets: inherit
 
-  ui_tests_image:
-    name: Run Cypress UI Tests On Images
-    uses: ./.github/workflows/ui_test_job.yml
-    needs: [docker_build_scan_push, create_tags]
-    with:
-      run_against_image: true
-      tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
+  # ui_tests_image:
+  #   name: Run Cypress UI Tests On Images
+  #   uses: ./.github/workflows/ui_test_job.yml
+  #   needs: [docker_build_scan_push, create_tags]
+  #   with:
+  #     run_against_image: true
+  #     tag: ${{ needs.create_tags.outputs.version_tag }}
+  #   secrets: inherit
 
   pr_deploy:
       name: PR Environment Deploy
-      needs: [create_tags, docker_build_scan_push, ui_tests_image]
+      needs: [create_tags]
+      # needs: [create_tags, docker_build_scan_push, ui_tests_image]
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
-        version_tag: ${{ needs.create_tags.outputs.version_tag }}
+        version_tag: latest
+        # version_tag: ${{ needs.create_tags.outputs.version_tag }}
       secrets: inherit
 
   ui_tests_pr_env:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -85,7 +85,7 @@ jobs:
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
-        version_tag: latest
+        version_tag: v0.76.0
         # version_tag: ${{ needs.create_tags.outputs.version_tag }}
       secrets: inherit
 

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -34,59 +34,57 @@ jobs:
     name: Create Tags
     uses: ./.github/workflows/tags_job.yml
 
-  # go_unit_tests:
-  #   name: Run Go unit tests
-  #   uses: ./.github/workflows/go-unit-tests.yml
+  go_unit_tests:
+    name: Run Go unit tests
+    uses: ./.github/workflows/go-unit-tests.yml
 
-  # docker_build_scan_push:
-  #   name: Docker Build, Scan and Push
-  #   uses: ./.github/workflows/docker_job.yml
-  #   needs: [go_unit_tests, create_tags]
-  #   with:
-  #     tag: ${{ needs.create_tags.outputs.version_tag }}
-  #   secrets: inherit
+  docker_build_scan_push:
+    name: Docker Build, Scan and Push
+    uses: ./.github/workflows/docker_job.yml
+    needs: [go_unit_tests, create_tags]
+    with:
+      tag: ${{ needs.create_tags.outputs.version_tag }}
+    secrets: inherit
 
-  # terraform_account_workflow_development:
-  #   name: TF Plan Dev Account
-  #   uses: ./.github/workflows/terraform_account_job.yml
-  #   with:
-  #     workspace_name: development
-  #   secrets: inherit
+  terraform_account_workflow_development:
+    name: TF Plan Dev Account
+    uses: ./.github/workflows/terraform_account_job.yml
+    with:
+      workspace_name: development
+    secrets: inherit
 
-  # terraform_account_workflow_preproduction:
-  #   name: TF Plan Preprod Account
-  #   needs: terraform_account_workflow_development
-  #   uses: ./.github/workflows/terraform_account_job.yml
-  #   with:
-  #     workspace_name: preproduction
-  #   secrets: inherit
+  terraform_account_workflow_preproduction:
+    name: TF Plan Preprod Account
+    needs: terraform_account_workflow_development
+    uses: ./.github/workflows/terraform_account_job.yml
+    with:
+      workspace_name: preproduction
+    secrets: inherit
 
-  # terraform_account_workflow_production:
-  #   name: TF Plan Prod Account
-  #   needs: terraform_account_workflow_development
-  #   uses: ./.github/workflows/terraform_account_job.yml
-  #   with:
-  #     workspace_name: production
-  #   secrets: inherit
+  terraform_account_workflow_production:
+    name: TF Plan Prod Account
+    needs: terraform_account_workflow_development
+    uses: ./.github/workflows/terraform_account_job.yml
+    with:
+      workspace_name: production
+    secrets: inherit
 
-  # ui_tests_image:
-  #   name: Run Cypress UI Tests On Images
-  #   uses: ./.github/workflows/ui_test_job.yml
-  #   needs: [docker_build_scan_push, create_tags]
-  #   with:
-  #     run_against_image: true
-  #     tag: ${{ needs.create_tags.outputs.version_tag }}
-  #   secrets: inherit
+  ui_tests_image:
+    name: Run Cypress UI Tests On Images
+    uses: ./.github/workflows/ui_test_job.yml
+    needs: [docker_build_scan_push, create_tags]
+    with:
+      run_against_image: true
+      tag: ${{ needs.create_tags.outputs.version_tag }}
+    secrets: inherit
 
   pr_deploy:
       name: PR Environment Deploy
-      needs: [create_tags]
-      # needs: [create_tags, docker_build_scan_push, ui_tests_image]
+      needs: [create_tags, docker_build_scan_push, ui_tests_image]
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
-        version_tag: v0.76.0
-        # version_tag: ${{ needs.create_tags.outputs.version_tag }}
+        version_tag: ${{ needs.create_tags.outputs.version_tag }}
       secrets: inherit
 
   ui_tests_pr_env:

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -1,10 +1,16 @@
+data "aws_kms_alias" "dynamodb_encryption_key_eu_west_1" {
+  name     = "alias/${local.default_tags.application}_dynamodb_encryption"
+  provider = aws.eu_west_1
+}
+
 resource "aws_dynamodb_table" "lpas_table" {
   name         = "${local.environment_name}-Lpas"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "Id"
 
   server_side_encryption {
-    enabled = true
+    enabled     = true
+    kms_key_arn = data.aws_kms_alias.dynamodb_encryption_key_eu_west_1.target_key_arn
   }
 
   attribute {

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -99,6 +99,11 @@ data "aws_kms_alias" "secrets_manager_secret_encryption_key" {
   provider = aws.region
 }
 
+data "aws_kms_alias" "dynamodb_encryption_key" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_dynamodb_encryption"
+  provider = aws.region
+}
+
 data "aws_secretsmanager_secret" "private_jwt_key" {
   name     = "private-jwt-key-base64"
   provider = aws.region
@@ -135,6 +140,22 @@ data "aws_iam_policy_document" "task_role_access_policy" {
     effect = "Allow"
 
     actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [
+      data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
+    ]
+  }
+
+  statement {
+    sid    = "DynamoDBEncryptionAccess"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
       "kms:Decrypt",
       "kms:GenerateDataKey",
     ]


### PR DESCRIPTION
# Purpose

Using AWS managed keys does not allow for fine grained control

Fixes MLPAB-158

## Approach

- allow ECS to use DynamoDB encryption key
- use CMK for DynamoDB server side encryption

## Learning

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html#managed-key-customer-managed
-https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#server_side_encryption

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
