### PR TITLE
MLPAB-152 - Pass the execution role as a single object rather than attributes

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -146,7 +146,6 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
     resources = [
       data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_arn,
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
 
@@ -161,7 +160,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
     ]
 
     resources = [
-      data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
 

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -3,11 +3,8 @@ locals {
 }
 
 variable "ecs_execution_role" {
-  type = object({
-    id  = string
-    arn = string
-  })
-  description = "ID and ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  type        = any
+  description = "The task execution role that the Amazon ECS container agent and the Docker daemon can assume."
 }
 
 variable "ecs_task_roles" {

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -8,11 +8,8 @@ module "allow_list" {
 }
 
 module "eu_west_1" {
-  source = "./region"
-  ecs_execution_role = {
-    id  = aws_iam_role.execution_role.id
-    arn = aws_iam_role.execution_role.arn
-  }
+  source             = "./region"
+  ecs_execution_role = aws_iam_role.execution_role
   ecs_task_roles = {
     app = aws_iam_role.app_task_role
   }


### PR DESCRIPTION
# Purpose

Simplify the input variables by passing the role rather than the id and arn separately

Fixes MLPAB-152

## Approach

- Use a type of any for the ecs_execution_role variable
- provide the whole role as an input
- Also fix policy statements in task role for encryption and decryption access

## Learning

- https://www.terraform.io/language/values/variables#type-constraints

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
