### PR TITLE
MLPAB-254 - Manage account configuration for second region

### DIFF
--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,9 +1,24 @@
 module "eu_west_1" {
   source             = "./region"
+  count              = contains(local.account.regions, "eu-west-1") ? 1 : 0
   network_cidr_block = "10.162.0.0/16"
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
   }
+}
 
+module "eu_west_2" {
+  source             = "./region"
+  count              = contains(local.account.regions, "eu-west-2") ? 1 : 0
+  network_cidr_block = "10.162.0.0/16"
+  providers = {
+    aws.region     = aws.eu_west_1
+    aws.management = aws.management_eu_west_1
+  }
+}
+
+moved {
+  from = module.eu_west_1
+  to   = module.eu_west_1[0]
 }

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -13,8 +13,8 @@ module "eu_west_2" {
   count              = contains(local.account.regions, "eu-west-2") ? 1 : 0
   network_cidr_block = "10.162.0.0/16"
   providers = {
-    aws.region     = aws.eu_west_1
-    aws.management = aws.management_eu_west_1
+    aws.region     = aws.eu_west_2
+    aws.management = aws.management_eu_west_2
   }
 }
 

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -4,7 +4,6 @@
       "account_id": "653761790766",
       "account_name": "development",
       "is_production": false,
-      "eu_west_2_enabled": false,
       "regions": [
         "eu-west-1"
       ]
@@ -13,7 +12,6 @@
       "account_id": "792093328875",
       "account_name": "preproduction",
       "is_production": false,
-      "eu_west_2_enabled": false,
       "regions": [
         "eu-west-1"
       ]
@@ -22,7 +20,6 @@
       "account_id": "313879017102",
       "account_name": "production",
       "is_production": true,
-      "eu_west_2_enabled": false,
       "regions": [
         "eu-west-1"
       ]

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -4,19 +4,28 @@
       "account_id": "653761790766",
       "account_name": "development",
       "is_production": false,
-      "eu_west_2_enabled": false
+      "eu_west_2_enabled": false,
+      "regions": [
+        "eu-west-1"
+      ]
     },
     "preproduction": {
       "account_id": "792093328875",
       "account_name": "preproduction",
       "is_production": false,
-      "eu_west_2_enabled": false
+      "eu_west_2_enabled": false,
+      "regions": [
+        "eu-west-1"
+      ]
     },
     "production": {
       "account_id": "313879017102",
       "account_name": "production",
       "is_production": true,
-      "eu_west_2_enabled": false
+      "eu_west_2_enabled": false,
+      "regions": [
+        "eu-west-1"
+      ]
     }
   }
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -3,17 +3,20 @@
     "development": {
       "account_id": "653761790766",
       "account_name": "development",
-      "is_production": false
+      "is_production": false,
+      "eu_west_2_enabled": false
     },
     "preproduction": {
       "account_id": "792093328875",
       "account_name": "preproduction",
-      "is_production": false
+      "is_production": false,
+      "eu_west_2_enabled": false
     },
     "production": {
       "account_id": "313879017102",
       "account_name": "production",
-      "is_production": true
+      "is_production": true,
+      "eu_west_2_enabled": false
     }
   }
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -9,6 +9,7 @@ variable "accounts" {
       account_name      = string
       is_production     = bool
       eu_west_2_enabled = bool
+      regions           = list(string)
     })
   )
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -5,11 +5,10 @@ output "workspace_name" {
 variable "accounts" {
   type = map(
     object({
-      account_id        = string
-      account_name      = string
-      is_production     = bool
-      eu_west_2_enabled = bool
-      regions           = list(string)
+      account_id    = string
+      account_name  = string
+      is_production = bool
+      regions       = list(string)
     })
   )
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -5,9 +5,10 @@ output "workspace_name" {
 variable "accounts" {
   type = map(
     object({
-      account_id    = string
-      account_name  = string
-      is_production = bool
+      account_id        = string
+      account_name      = string
+      is_production     = bool
+      eu_west_2_enabled = bool
     })
   )
 }


### PR DESCRIPTION
# Purpose

We want to be ready to deploy to a second region

Fixes MLPAB-254

## Approach

- Add an input variable to define regions we should deploy to
- Define eu-west-1 as a region we deploy to
- Define a second region instance of the region module (without requiring the deployment there)

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
