### PR TITLE
MLPAB-255 - Manage environment configuration for second region

### DIFF
--- a/docs/runbooks/deployment_into_additional_regions.md
+++ b/docs/runbooks/deployment_into_additional_regions.md
@@ -12,7 +12,7 @@ The terraform configuration includes a definition for a London region that can b
 
 Raise a pull request to set `region_replica_enabled` and `stream_enabled` to `true` if not already set to true.
 
-To activate and provision account resources into a second region, add `eu-west-2` to the `regions` variable list in `terraform/account/terraform.tfvars.json` for each account.
+To activate and provision account resources into a second region, raise a pull request to add `eu-west-2` to the `regions` variable list in `terraform/account/terraform.tfvars.json` for each account.
 
 ```json
 "regions": [
@@ -21,7 +21,7 @@ To activate and provision account resources into a second region, add `eu-west-2
 ]
 ```
 
-To activate and provision environment resources into a second region, add `eu-west-2` to the `regions` variable list in `terraform/environment/terraform.tfvars.json` for each account.
+To activate and provision environment resources into a second region, raise a pull request to add `eu-west-2` to the `regions` variable list in `terraform/environment/terraform.tfvars.json` for each account.
 
 ```json
 "regions": [
@@ -30,11 +30,4 @@ To activate and provision environment resources into a second region, add `eu-we
 ]
 ```
 
-
-Apply this change using an approved pull request.
-
-To deploy
-
-## Deploying into other additional regions
-
-How to add an additional region
+The path to live for each of these 3 pull requests will carry out the provisioning and deployments.

--- a/docs/runbooks/deployment_into_additional_regions.md
+++ b/docs/runbooks/deployment_into_additional_regions.md
@@ -8,7 +8,11 @@ This is so the modernising-lpa service can be made highly available (deployed in
 
 ## Deploying into London (eu-west-2)
 
-The terraform configuration includes a definition for a London region that can be "activated". For environment activation, dynamodb table replication must be enabled first.
+The terraform configuration includes a definition for a London region that can be "activated". There is a dependency chain for the configurations, so the steps must be completed (as in applied by the path to live) in this order to succeed;
+
+1. Environment Dynamodb table replication must be enabled first.
+2. Account region must be provisioned second
+3. Environment region must be provisioned third
 
 Raise a pull request to set `region_replica_enabled` and `stream_enabled` to `true` if not already set to true.
 

--- a/docs/runbooks/deployment_into_additional_regions.md
+++ b/docs/runbooks/deployment_into_additional_regions.md
@@ -1,0 +1,40 @@
+# Deploying into additional regions
+
+The infrastructure for this project is structured to allow for regional resources such as networks, certificates, and appplication deployment to be provisioned in additional regions.
+
+Other resources such as backup vaults, DNS records and databases are treated as "single entity" global resources with configuration for multi-region replication.
+
+This is so the modernising-lpa service can be made highly available (deployed in and served from multiple places) or to enable a disaster recovery plan with low recovery time and point objectives.
+
+## Deploying into London (eu-west-2)
+
+The terraform configuration includes a definition for a London region that can be "activated". For environment activation, dynamodb table replication must be enabled first.
+
+Raise a pull request to set `region_replica_enabled` and `stream_enabled` to `true` if not already set to true.
+
+To activate and provision account resources into a second region, add `eu-west-2` to the `regions` variable list in `terraform/account/terraform.tfvars.json` for each account.
+
+```json
+"regions": [
+  "eu-west-1",
+  "eu-west-2"
+]
+```
+
+To activate and provision environment resources into a second region, add `eu-west-2` to the `regions` variable list in `terraform/environment/terraform.tfvars.json` for each account.
+
+```json
+"regions": [
+  "eu-west-1",
+  "eu-west-2"
+]
+```
+
+
+Apply this change using an approved pull request.
+
+To deploy
+
+## Deploying into other additional regions
+
+How to add an additional region

--- a/terraform/environment/config_file.tf
+++ b/terraform/environment/config_file.tf
@@ -7,6 +7,6 @@ locals {
   environment_config = {
     region                              = "eu-west-1"
     account_id                          = local.environment.account_id
-    app_load_balancer_security_group_id = module.eu_west_1.app_load_balancer_security_group.id
+    app_load_balancer_security_group_id = module.eu_west_1[0].app_load_balancer_security_group.id
   }
 }

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -16,8 +16,8 @@ resource "aws_route53_record" "app" {
 
   alias {
     evaluate_target_health = false
-    name                   = module.eu_west_1.app_load_balancer.dns_name
-    zone_id                = module.eu_west_1.app_load_balancer.zone_id
+    name                   = module.eu_west_1[0].app_load_balancer.dns_name
+    zone_id                = module.eu_west_1[0].app_load_balancer.zone_id
   }
 
   lifecycle {

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -47,7 +47,7 @@ module "eu_west_2" {
   }
 }
 
-# moved {
-#   from = module.eu_west_1
-#   to   = module.eu_west_1[0]
-# }
+moved {
+  from = module.eu_west_1
+  to   = module.eu_west_1[0]
+}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -8,7 +8,8 @@ module "allow_list" {
 }
 
 module "eu_west_1" {
-  source             = "./region"
+  source = "./region"
+  # count              = contains(local.environment.regions, "eu-west-1") ? 1 : 0
   ecs_execution_role = aws_iam_role.execution_role
   ecs_task_roles = {
     app = aws_iam_role.app_task_role
@@ -25,3 +26,28 @@ module "eu_west_1" {
     aws.region = aws.eu_west_1
   }
 }
+
+module "eu_west_2" {
+  source             = "./region"
+  count              = contains(local.environment.regions, "eu-west-2") ? 1 : 0
+  ecs_execution_role = aws_iam_role.execution_role
+  ecs_task_roles = {
+    app = aws_iam_role.app_task_role
+  }
+  application_log_retention_days  = local.environment.cloudwatch_log_groups.application_log_retention_days
+  ecs_capacity_provider           = local.ecs_capacity_provider
+  app_service_repository_url      = data.aws_ecr_repository.app.repository_url
+  app_service_container_version   = var.container_version
+  ingress_allow_list_cidr         = module.allow_list.moj_sites
+  alb_deletion_protection_enabled = local.environment.application_load_balancer.deletion_protection_enabled
+  lpas_table                      = aws_dynamodb_table.lpas_table
+  app_env_vars                    = local.environment.app.env
+  providers = {
+    aws.region = aws.eu_west_2
+  }
+}
+
+# moved {
+#   from = module.eu_west_1
+#   to   = module.eu_west_1[0]
+# }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -8,8 +8,8 @@ module "allow_list" {
 }
 
 module "eu_west_1" {
-  source = "./region"
-  # count              = contains(local.environment.regions, "eu-west-1") ? 1 : 0
+  source             = "./region"
+  count              = contains(local.environment.regions, "eu-west-1") ? 1 : 0
   ecs_execution_role = aws_iam_role.execution_role
   ecs_task_roles = {
     app = aws_iam_role.app_task_role

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -4,6 +4,9 @@
       "account_id": "653761790766",
       "account_name": "development",
       "is_production": false,
+      "regions": [
+        "eu-west-1"
+      ],
       "app": {
         "env": {
           "app_public_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk"
@@ -31,6 +34,9 @@
       "account_id": "792093328875",
       "account_name": "preproduction",
       "is_production": false,
+      "regions": [
+        "eu-west-1"
+      ],
       "app": {
         "env": {
           "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk"
@@ -58,6 +64,9 @@
       "account_id": "313879017102",
       "account_name": "production",
       "is_production": true,
+      "regions": [
+        "eu-west-1"
+      ],
       "app": {
         "env": {
           "app_public_url": "https://app.modernising.opg.service.justice.gov.uk"

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -17,6 +17,7 @@ variable "environments" {
       account_id    = string
       account_name  = string
       is_production = bool
+      regions       = list(string)
       app = object({
         env = object({
           app_public_url = string


### PR DESCRIPTION
# Purpose

We want to be ready to deploy to a second region

Fixes MLPAB-255

## Approach

- Add an input variable to define regions we should deploy to
- Define eu-west-1 as a region we deploy to
- Define a second region instance of the region module (without requiring the deployment there)
- Add run-book explaining second region procedure

## Learning

- https://www.terraform.io/language/modules/develop/refactoring#moved-block-syntax

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
