### PR TITLE
allow kms list permissions generally

### DIFF
--- a/terraform/account/cloudwatch_kms.tf
+++ b/terraform/account/cloudwatch_kms.tf
@@ -72,7 +72,6 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
       "kms:DescribeKey",
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
-      "kms:ListResourceTags",
       "kms:List*",
     ]
 

--- a/terraform/account/cloudwatch_kms.tf
+++ b/terraform/account/cloudwatch_kms.tf
@@ -73,6 +73,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
       "kms:ListResourceTags",
+      "kms:List*",
     ]
 
     principals {

--- a/terraform/account/dynamodb_kms.tf
+++ b/terraform/account/dynamodb_kms.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "dynamodb_kms" {
       "kms:DescribeKey",
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
-      "kms:ListResourceTags",
+      "kms:List*",
     ]
 
     principals {

--- a/terraform/account/secrets_manager_kms.tf
+++ b/terraform/account/secrets_manager_kms.tf
@@ -93,6 +93,7 @@ data "aws_iam_policy_document" "secrets_manager_kms" {
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
       "kms:ListResourceTags",
+      "kms:List*",
     ]
 
     principals {

--- a/terraform/account/secrets_manager_kms.tf
+++ b/terraform/account/secrets_manager_kms.tf
@@ -92,7 +92,6 @@ data "aws_iam_policy_document" "secrets_manager_kms" {
       "kms:DescribeKey",
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
-      "kms:ListResourceTags",
       "kms:List*",
     ]
 


### PR DESCRIPTION
# Purpose

Fix issue of alarms raised for unauthorised actions that should be permitted.

```
User: access-analyzer is not authorized to perform: kms:ListGrants on resource: arn:aws:kms:::key/ because no resource-based policy allows the kms:ListGrants action
```

Fixes MLPAB-269

## Approach

 - Allow list actions generally

## Learning

- https://docs.aws.amazon.com/service-authorization/latest/reference/list_awskeymanagementservice.html

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
