### PR TITLE
MLPAB-153 - Create CMK for SNS

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.33.0"
-  constraints = "4.33.0"
+  constraints = ">= 2.7.0, 4.33.0"
   hashes = [
     "h1:0S9ZXYg6K0CTOJUTQnoH94YrKuOYyJYEcc+hN5qGafA=",
     "h1:2MWU+HIKKivfhY8dAU1cR0xxwlzNrWOZEQs8BApQ/Ao=",
@@ -16,5 +16,17 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:o2tshVKwYkAEleikYznoMAIocaxXEgP0u3NJ8mD+0uw=",
     "h1:rLRYOeKvU17Tky5dleZwTPRoWtbdFTG/jOF/fTP2otY=",
     "h1:zmqtrA0j5isdxWOg4O+XCxiL9Xqkc7XT4SAfiSIAizI=",
+    "zh:421b24e21d7fac4d65d97438d2c0a4effe71d3a1bd15820d6fde2879e49fe817",
+    "zh:4378a84ca8e2a6990f47abc24367b801e884be928671b37ad7b8e7b656f73e48",
+    "zh:54e0d7884edf3cefd096715794d32b6532138dca905f0b2fe84fb2117594293c",
+    "zh:6269a7d0312057db5ded669e9f7f9bd80fb6dcb549b50d8d7f3f3b2a0361b8a5",
+    "zh:67f57d16aa3db493a3174c3c5f30385c7af9767c4e3cdca14e5a4bf384ff59d9",
+    "zh:7d4d4a1d963e431ffdc3348e3a578d3ba0fa782b1f4bf55fd5c0e527d24fed81",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cd8e3d32485acb49c1b06f63916fec8e73a4caa6cf88ae9c4bf236d6f5d9b914",
+    "zh:d586fd01195bd3775346495e61806e79b6012e745dc05e31a30b958acf968abe",
+    "zh:d76122060f25ab87887a743096a42d47ba091c2c019ac13ce6b3973b2babe5a3",
+    "zh:e917d36fe18eddc42ec743b3152b4dcb4853b75ea7a679abd19bdf271bc48221",
+    "zh:eb780860d5c04f43a018aef564e76a2d84e9aa68984fa1f968ca8c09d23a611a",
   ]
 }

--- a/terraform/account/sns_kms.tf
+++ b/terraform/account/sns_kms.tf
@@ -1,0 +1,169 @@
+resource "aws_kms_key" "sns" {
+  description             = "${local.default_tags.application} SNS encryption key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.sns_kms_merged.json : data.aws_iam_policy_document.sns_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+}
+
+resource "aws_kms_replica_key" "sns_replica" {
+  description             = "${local.default_tags.application} SNS multi-region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.sns.arn
+  provider                = aws.eu_west_2
+}
+
+resource "aws_kms_alias" "sns_alias_eu_west_1" {
+  name          = "alias/${local.default_tags.application}_sns_secret_encryption_key"
+  target_key_id = aws_kms_key.sns.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "sns_alias_eu_west_2" {
+  name          = "alias/${local.default_tags.application}_sns_secret_encryption_key"
+  target_key_id = aws_kms_replica_key.sns_replica.key_id
+  provider      = aws.eu_west_2
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "sns_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.sns_kms.json,
+    data.aws_iam_policy_document.sns_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "sns_kms" {
+  provider = aws.global
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_iam_role.aws_backup_role.arn,
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "sns.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:ListResourceTags",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sns_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid    = "Dev Account Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}

--- a/terraform/account/sns_kms.tf
+++ b/terraform/account/sns_kms.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "sns_kms" {
       "kms:DescribeKey",
       "kms:GetKeyPolicy",
       "kms:GetKeyRotationStatus",
-      "kms:ListResourceTags",
+      "kms:List*",
     ]
 
     principals {


### PR DESCRIPTION
# Purpose

AWS SNS topics should be encrypted with a customer managed MKS key

Fixes MLPAB-153

## Approach

- Create a CMK for AWS SNS
- allow backup role to use it for encryption 
- Allow SNS service to use it for decryption

## Learning

- https://aws.amazon.com/blogs/compute/encrypting-messages-published-to-amazon-sns-with-aws-kms/

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~

