### PR TITLE
MLPAB-216 - Use OIDC connector role for ecr push actions

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -37,12 +37,13 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-ci
+          role-to-assume: arn:aws:iam::311462405659:role/github-actions-ecr-push
+          # role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-ci
           role-duration-seconds: 900
-          role-session-name: OPGModernisingLPATerraformGithubAction
+          # role-session-name: OPGModernisingLPATerraformGithubAction
       - name: ECR Login
         id: login_ecr
         uses: aws-actions/amazon-ecr-login@v1.5.1


### PR DESCRIPTION
# Purpose

Replace AWS access keys with OIDC connector roles for github actions, starting with the AWS ECR push action.

Fixes MLPAB-216

## Approach

- replace access key and key secret with a federated role to assume.

## Learning

- https://github.com/aws-actions/configure-aws-credentials#assuming-a-role

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
