### PR TITLE
MLPAB-275 - Enable readonly root filesystem as per FSBP ECS.5

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -203,11 +203,12 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 locals {
   app = jsonencode(
     {
-      cpu         = 1,
-      essential   = true,
-      image       = "${var.app_service_repository_url}:${var.app_service_container_version}",
-      mountPoints = [],
-      name        = "app",
+      cpu                    = 1,
+      essential              = true,
+      image                  = "${var.app_service_repository_url}:${var.app_service_container_version}",
+      mountPoints            = [],
+      readonlyRootFilesystem = true
+      name                   = "app",
       portMappings = [
         {
           containerPort = var.container_port,


### PR DESCRIPTION
# Purpose

Enabling this option reduces security attack vectors since the container instance’s filesystem cannot be tampered with or written to unless it has explicit read-write permissions on its filesystem folder and directories. This control also adheres to the principle of least privilege.

Fixes MLPAB-275

## Approach

- Set `readonlyRootFilesystem` to true in container definition

## Learning

- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ecs-5-remediation

## Checklist

* [x] I have performed a self-review of my own code
