### PR TITLE
MLPAB-299 - Add decrypt permissions for breakglass role on Production

### DIFF
--- a/terraform/account/dynamodb_kms.tf
+++ b/terraform/account/dynamodb_kms.tf
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "dynamodb_kms" {
       "kms:UntagResource",
       "kms:ScheduleKeyDeletion",
       "kms:CancelKeyDeletion",
-      "kms:ReplicateKey"
+      "kms:ReplicateKey",
     ]
 
     principals {
@@ -125,6 +125,24 @@ data "aws_iam_policy_document" "dynamodb_kms" {
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
         "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
       ]
     }
   }
@@ -152,7 +170,7 @@ data "aws_iam_policy_document" "dynamodb_kms_development_account_operator_admin"
       "kms:TagResource",
       "kms:UntagResource",
       "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion"
+      "kms:CancelKeyDeletion",
     ]
 
     principals {


### PR DESCRIPTION
# Purpose

Allow Breakglass role to view DynamoDB data

Fixes MLPAB-299

## Approach

- Add a new statement to the DynamoDB KMS key allowing breakglass to `kms:Decrypt`

## Checklist

* [x] I have performed a self-review of my own code