### PR TITLE
MLPAB-281 - Do not map public IPs on launch of default subnets

### DIFF
--- a/terraform/account/region/network.tf
+++ b/terraform/account/region/network.tf
@@ -19,3 +19,15 @@ resource "aws_default_security_group" "default" {
   ingress  = []
   egress   = []
 }
+
+data "aws_availability_zones" "available" {
+  state    = "available"
+  provider = aws.region
+}
+
+resource "aws_default_subnet" "default" {
+  for_each                = toset(data.aws_availability_zones.available.names)
+  availability_zone       = each.value
+  map_public_ip_on_launch = false
+  provider                = aws.region
+}


### PR DESCRIPTION
# Purpose

All subnets have an attribute that determines whether a network interface created in the subnet automatically receives a public IPv4 address. Instances that are launched into subnets that have this attribute enabled have a public IP address assigned to their primary network interface.

Fixes MLPAB-281

## Approach

- don't assign public IPs in the default subnet of each availability zone

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_subnet
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones
- https://www.terraform.io/language/meta-arguments/for_each

## Checklist

* [x] I have performed a self-review of my own code