### PR TITLE
MLAPB-308: Add gitleaks baseline generator command and ignore baseline

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,7 +8,7 @@ useDefault = true
 [allowlist]
 description = "global allow lists"
 paths = [
-    '''gitleaks.toml''',
+    '''.gitleaks.toml''',
     '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
     '''(go.mod|go.sum)$''',
     '''node_modules''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "Gitleaks custom rules"
+
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+[allowlist]
+description = "global allow lists"
+paths = [
+    '''gitleaks.toml''',
+    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
+    '''(go.mod|go.sum)$''',
+    '''node_modules''',
+    '''gitleaks-baseline.json''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
     - id: git-secrets
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.13.0
+    rev: v8.14.1
     hooks:
     -   id: gitleaks
         entry: gitleaks detect --baseline-path gitleaks-baseline.json

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,7 @@ endif
 
 run-cypress-parallel: ##@testing Runs cypress e2e tests in parallel across 4 processor threads
 	yarn run cypress:parallel
+
+update-gitleaks-baseline: ##@security Updates gitleaks baseline file for false possible and dummy secrets added to version control (requires gitleaks local installation)
+	$(info ${YELLOW}Ensure any newly added leaks in the baseline are false positives or dummy secrets before committing an updated baseline) @echo "\n"  ${WHITE}
+	gitleaks detect --report-path gitleaks-baseline.json

--- a/gitleaks-baseline.json
+++ b/gitleaks-baseline.json
@@ -1,5 +1,24 @@
 [
  {
+  "Description": "JSON Web Token",
+  "StartLine": 59,
+  "EndLine": 59,
+  "StartColumn": 27,
+  "EndColumn": 192,
+  "Match": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmMzM1MTdmZi0yYTg4LTRmNmUtYjg1NS1jNTUwMjY4Y2UwOGEiLCJpYXQiOjE1Nzc5MzQyNDV9.V0iR-Foo_twZdWttAxy4koJoSYJzyZHMr-tJIBwZj8k\"",
+  "Secret": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmMzM1MTdmZi0yYTg4LTRmNmUtYjg1NS1jNTUwMjY4Y2UwOGEiLCJpYXQiOjE1Nzc5MzQyNDV9.V0iR-Foo_twZdWttAxy4koJoSYJzyZHMr-tJIBwZj8k\"",
+  "File": "app/internal/notify/client_test.go",
+  "Commit": "9c2fabcda472f058cbdd87fa2418aee9d1d63976",
+  "Entropy": 5.50842,
+  "Author": "Joshua Hawxwell",
+  "Email": "m@hawx.me",
+  "Date": "2022-10-11T11:02:01Z",
+  "Message": "Add notify client",
+  "Tags": [],
+  "RuleID": "jwt",
+  "Fingerprint": "9c2fabcda472f058cbdd87fa2418aee9d1d63976:app/internal/notify/client_test.go:jwt:59"
+ },
+ {
   "Description": "Generic API Key",
   "StartLine": 14,
   "EndLine": 14,


### PR DESCRIPTION
# Purpose
We're no longer scanning the baseline file with this change which should lead to a slimmer baseline file. I've also added a make command to generate a fresh baseline file for when we accept dummy/false positives in code going forward.

Fixes MLPAB-308