### PR TITLE
MLPAB-311 - Remove path filtering from destroy pr env job

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -6,14 +6,6 @@ on:
       - main
     types:
       - closed
-    paths:
-      - 'app/**'
-      - 'web/**'
-      - 'codecept/**'
-      - 'cypress/**'
-      - 'terraform/**'
-      - 'scripts/**'
-      - '.github/workflows/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
# Purpose

Some environments were not destroyed as early as they could have been.

Fixes MLPAB-311

## Approach

- remove paths filter from job

## Checklist

* [x] I have performed a self-review of my own code