### PR TITLE
MLPAB-287 - Create flow logs for the default VPC

### DIFF
--- a/terraform/account/region/default_vpc.tf
+++ b/terraform/account/region/default_vpc.tf
@@ -91,11 +91,16 @@ resource "aws_flow_log" "default_vpc" {
   max_aggregation_interval = 600
 }
 
+data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
+  name     = var.cloudwatch_log_group_kms_key_alias
+  provider = aws.region
+}
+
 resource "aws_cloudwatch_log_group" "default_vpc_flow_log" {
   provider          = aws.region
   name              = "/aws/vpc-flow-log/${data.aws_vpc.default.id}"
   retention_in_days = 400
-  kms_key_id        = var.flow_log_cloudwatch_log_group_kms_key_id
+  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
 }
 
 resource "aws_iam_role" "default_vpc_flow_log_cloudwatch" {

--- a/terraform/account/region/default_vpc.tf
+++ b/terraform/account/region/default_vpc.tf
@@ -79,3 +79,66 @@ resource "aws_default_network_acl" "default" {
   }
 
 }
+
+resource "aws_flow_log" "default_vpc" {
+  log_destination_type     = "cloud-watch-logs"
+  log_destination          = aws_cloudwatch_log_group.default_vpc_flow_log.arn
+  log_format               = null
+  iam_role_arn             = aws_iam_role.default_vpc_flow_log_cloudwatch.arn
+  traffic_type             = "ALL"
+  vpc_id                   = data.aws_vpc.default.id
+  max_aggregation_interval = 600
+}
+
+resource "aws_cloudwatch_log_group" "default_vpc_flow_log" {
+  name              = "/aws/vpc-flow-log/${data.aws_vpc.default.id}"
+  retention_in_days = 400
+  kms_key_id        = var.flow_log_cloudwatch_log_group_kms_key_id
+}
+
+resource "aws_iam_role" "default_vpc_flow_log_cloudwatch" {
+  name_prefix        = "default-vpc-flow-log-role-"
+  assume_role_policy = data.aws_iam_policy_document.default_vpc_flow_log_cloudwatch_assume_role.json
+}
+
+data "aws_iam_policy_document" "default_vpc_flow_log_cloudwatch_assume_role" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "default_vpc_flow_log_cloudwatch" {
+  role       = aws_iam_role.default_vpc_flow_log_cloudwatch.name
+  policy_arn = aws_iam_policy.default_vpc_flow_log_cloudwatch.arn
+}
+
+resource "aws_iam_policy" "default_vpc_flow_log_cloudwatch" {
+  name_prefix = "vpc-flow-log-to-cloudwatch-"
+  policy      = data.aws_iam_policy_document.default_vpc_flow_log_cloudwatch.json
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "default_vpc_flow_log_cloudwatch" {
+  statement {
+    sid = "AWSDefaultVPCFlowLogsPushToCloudWatch"
+
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/terraform/account/region/default_vpc.tf
+++ b/terraform/account/region/default_vpc.tf
@@ -81,6 +81,7 @@ resource "aws_default_network_acl" "default" {
 }
 
 resource "aws_flow_log" "default_vpc" {
+  provider                 = aws.region
   log_destination_type     = "cloud-watch-logs"
   log_destination          = aws_cloudwatch_log_group.default_vpc_flow_log.arn
   log_format               = null
@@ -91,17 +92,20 @@ resource "aws_flow_log" "default_vpc" {
 }
 
 resource "aws_cloudwatch_log_group" "default_vpc_flow_log" {
+  provider          = aws.region
   name              = "/aws/vpc-flow-log/${data.aws_vpc.default.id}"
   retention_in_days = 400
   kms_key_id        = var.flow_log_cloudwatch_log_group_kms_key_id
 }
 
 resource "aws_iam_role" "default_vpc_flow_log_cloudwatch" {
+  provider           = aws.region
   name_prefix        = "default-vpc-flow-log-role-"
   assume_role_policy = data.aws_iam_policy_document.default_vpc_flow_log_cloudwatch_assume_role.json
 }
 
 data "aws_iam_policy_document" "default_vpc_flow_log_cloudwatch_assume_role" {
+  provider = aws.region
   statement {
     principals {
       type        = "Service"
@@ -115,17 +119,20 @@ data "aws_iam_policy_document" "default_vpc_flow_log_cloudwatch_assume_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "default_vpc_flow_log_cloudwatch" {
+  provider   = aws.region
   role       = aws_iam_role.default_vpc_flow_log_cloudwatch.name
   policy_arn = aws_iam_policy.default_vpc_flow_log_cloudwatch.arn
 }
 
 resource "aws_iam_policy" "default_vpc_flow_log_cloudwatch" {
+  provider    = aws.region
   name_prefix = "vpc-flow-log-to-cloudwatch-"
   policy      = data.aws_iam_policy_document.default_vpc_flow_log_cloudwatch.json
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "default_vpc_flow_log_cloudwatch" {
+  provider = aws.region
   statement {
     sid = "AWSDefaultVPCFlowLogsPushToCloudWatch"
 

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -3,8 +3,8 @@ variable "network_cidr_block" {
   description = "The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv4_netmask_length."
 }
 
-variable "flow_log_cloudwatch_log_group_kms_key_id" {
+variable "cloudwatch_log_group_kms_key_alias" {
   type        = string
   default     = null
-  description = "The ARN of the KMS Key to use when encrypting the Default VPC flow log data."
+  description = "The alias of the KMS Key to use when encrypting Cloudwatch log data."
 }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -2,3 +2,9 @@ variable "network_cidr_block" {
   type        = string
   description = "The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv4_netmask_length."
 }
+
+variable "flow_log_cloudwatch_log_group_kms_key_id" {
+  type        = string
+  default     = null
+  description = "The ARN of the KMS Key to use when encrypting the Default VPC flow log data."
+}

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,8 +1,8 @@
 module "eu_west_1" {
-  source                                   = "./region"
-  count                                    = contains(local.account.regions, "eu-west-1") ? 1 : 0
-  network_cidr_block                       = "10.162.0.0/16"
-  flow_log_cloudwatch_log_group_kms_key_id = aws_kms_key.cloudwatch.id
+  source                             = "./region"
+  count                              = contains(local.account.regions, "eu-west-1") ? 1 : 0
+  network_cidr_block                 = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
@@ -10,9 +10,10 @@ module "eu_west_1" {
 }
 
 module "eu_west_2" {
-  source             = "./region"
-  count              = contains(local.account.regions, "eu-west-2") ? 1 : 0
-  network_cidr_block = "10.162.0.0/16"
+  source                             = "./region"
+  count                              = contains(local.account.regions, "eu-west-2") ? 1 : 0
+  network_cidr_block                 = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
   providers = {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,7 +1,8 @@
 module "eu_west_1" {
-  source             = "./region"
-  count              = contains(local.account.regions, "eu-west-1") ? 1 : 0
-  network_cidr_block = "10.162.0.0/16"
+  source                                   = "./region"
+  count                                    = contains(local.account.regions, "eu-west-1") ? 1 : 0
+  network_cidr_block                       = "10.162.0.0/16"
+  flow_log_cloudwatch_log_group_kms_key_id = aws_kms_key.cloudwatch.id
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1


### PR DESCRIPTION
# Purpose

With the [VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) feature, you can capture information about the IP address traffic going to and from network interfaces in your VPC. After you create a flow log, you can view and retrieve its data in CloudWatch Logs.

Security Hub recommends that you enable flow logging for packet rejects for VPCs. Flow logs provide visibility into network traffic that traverses the VPC and can detect anomalous traffic or provide insight during security workflows.

By default, the record includes values for the different components of the IP address flow, including the source, destination, and protocol. For more information and descriptions of the log fields, see VPC Flow Logs in the Amazon VPC User Guide.

Fixes MLPAB-287

## Approach

- Create flow logs and log groups for the default VPC
- Use the Cloudwatch CMK for flow log encryption

## Learning

based on https://github.com/ministryofjustice/opg-terraform-aws-network/blob/main/vpc-flow-logs.tf

## Checklist

* [ ] I have performed a self-review of my own code