### PR TITLE
MLPAB-320 - Replace set-output command with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/tags_job.yml
+++ b/.github/workflows/tags_job.yml
@@ -51,7 +51,7 @@ jobs:
           workspace=${workspace//\/}
           workspace=${workspace:0:11}
           workspace=$(echo ${workspace} | tr '[:upper:]' '[:lower:]')
-          echo ::set-output name=name::${workspace}
+          echo "name=${workspace}" >> $GITHUB_OUTPUT
           echo ${workspace}
     outputs:
       environment_workspace_name: ${{ steps.name_workspace.outputs.name }}

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -106,7 +106,7 @@ jobs:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
           TF_VAR_container_version: ${{ inputs.version_tag }}
         run: |
-          echo ::set-output name=workspace_name::$(terraform output -raw workspace_name)
-          echo ::set-output name=container_version::$(terraform output -raw container_version)
-          echo ::set-output name=url::$(terraform output -raw app_fqdn)
+          echo "workspace_name=$(terraform output -raw workspace_name)" >> $GITHUB_OUTPUT
+          echo "container_version=$(terraform output -raw container_version)" >> $GITHUB_OUTPUT
+          echo "url=$(terraform output -raw app_fqdn)" >> $GITHUB_OUTPUT
         working-directory: ./terraform/environment

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -36,7 +36,7 @@ jobs:
           workspace=${workspace//\/}
           workspace=${workspace:0:11}
           workspace=$(echo ${workspace} | tr '[:upper:]' '[:lower:]')
-          echo ::set-output name=name::${workspace}
+          echo "name=${workspace}" >> $GITHUB_OUTPUT
           echo ${workspace}
     outputs:
           environment_workspace_name: ${{ steps.name_workspace.outputs.name }}


### PR DESCRIPTION
# Purpose

To avoid untrusted logged data to use set-stateand set-output workflow commands without the intention of the workflow author we have introduced a [new set of environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) to manage state and output.

Fixes MLPAB-320

## Approach

replace output command with GITHUB_OUTPUT in;

- tags_job.yml
- workflow_destroy_pr_environment.yml
- terraform_environment_job.yml

## Learning

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

## Checklist

* [x] I have performed a self-review of my own code