### PR TITLE
MLPAB-345 - Create lb access logging bucket

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.34.0"
-  constraints = "4.34.0"
+  constraints = ">= 2.7.0, 4.34.0"
   hashes = [
     "h1:7o39TX2bB7zdXLnTHqtBl9fbIKsHZQffU8D0oNmqhW4=",
     "h1:JRqeU/5qR61U+z86mC68C5hp0XHZXxmRK9dupTIAhGg=",
@@ -16,5 +16,17 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:iPEO8U8q3zdcZDfkFqtmdKAlM0kAgkJX8VLSPZxgU/U=",
     "h1:pqlxl+EqK50w6hhdgod2AqOhDEiMHGTPDBOzuHMsEpE=",
     "h1:qRL6DZuaf/6bXmgxYFTjZHoqfDPPfy0xBXNIa4eooEg=",
+    "zh:2bdc9b908008c1e874d8ba7e2cfabd856cafb63c52fef51a1fdeef2f5584bffd",
+    "zh:43c5364e3161be3856e56494cbb8b21d513fc05875f1b40e66e583602154dd0a",
+    "zh:44e763adae92489f223f65866c1f8b5342e7e85b95daa8d1f483a2afb47f7db3",
+    "zh:62bfabb3a1a31814cb3fadc356539d8253b95abacfffd90984affb54c9a53a86",
+    "zh:6495ce67897d2d5648d466c09e8588e837c2878322988738a95c06926044b05d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b1546b2ac61d7cc27a8eba160ae1b6ac581d2c4af824a400d6511e4998da398a",
+    "zh:c8c362c5527f0533bde581e41cdb2bdf42aea557762f326dbfa122fdf001fb10",
+    "zh:c8cc28fb41f73ca09f590bace2204ea325f6116be0bbce6abfebd393d028f12c",
+    "zh:db0601c9bd12ca028d60ac87e85320285ebc64857715f7908dd6a283e5f44d45",
+    "zh:e64d2193236d05348ba2e8b99650d9274e5af80be39b3ee28bbe442b0684d8a3",
+    "zh:ff6228f3751e1f0ee7dc086d09e32d39ca6556f0b5267f36aae67881d29ace94",
   ]
 }

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -1,0 +1,129 @@
+resource "aws_s3_bucket" "access_log" {
+  provider = aws.region
+  bucket   = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-lb-access-logs-${data.aws_region.current.name}"
+}
+
+resource "aws_s3_bucket_acl" "access_log" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+  acl      = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "access_log" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+data "aws_s3_bucket" "s3_access_logging" {
+  provider = aws.region
+  bucket   = "s3-access-logs-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}"
+}
+
+resource "aws_s3_bucket_logging" "access_log" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+
+  target_bucket = data.aws_s3_bucket.s3_access_logging.id
+  target_prefix = "lb-access-log/"
+}
+
+resource "aws_s3_bucket_policy" "access_log" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+  policy   = data.aws_iam_policy_document.access_log.json
+}
+
+data "aws_elb_service_account" "main" {
+  provider = aws.region
+  region   = data.aws_region.current.name
+}
+
+data "aws_iam_policy_document" "access_log" {
+  provider = aws.region
+  statement {
+    sid = "accessLogBucketAccess"
+    resources = [
+      aws_s3_bucket.access_log.arn,
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    principals {
+      identifiers = [data.aws_elb_service_account.main.id]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "accessLogDelivery"
+    resources = [
+      aws_s3_bucket.access_log.arn,
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+  }
+
+  statement {
+    sid = "accessGetAcl"
+    resources = [
+      aws_s3_bucket.access_log.arn
+    ]
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+
+  statement {
+    sid     = "AllowSSLRequestsOnly"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.access_log.arn,
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      values   = ["false"]
+      variable = "aws:SecureTransport"
+    }
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "access_log" {
+  provider                = aws.region
+  bucket                  = aws_s3_bucket.access_log.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -127,3 +127,28 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "log_retention_policy" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.access_log.id
+
+  rule {
+    id     = "retain-logs-for-13-months"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 400
+    }
+
+  }
+}


### PR DESCRIPTION
# Purpose

Elastic Load Balancing provides access logs that capture detailed information about requests sent to your load balancer. Each log contains information such as the time the request was received, the client's IP address, latencies, request paths, and server responses. You can use these access logs to analyze traffic patterns and to troubleshoot issues.

Fixes MLPAB-345

## Approach

- Create an S3 bucket to collect access logs for elastic load balancers

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service

## Checklist

* [ ] I have performed a self-review of my own code