### PR TITLE
MLPAB-344 - Update Network ACLs to apply to IPv6 CIDR range

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.36.1"
-  constraints = "4.36.1"
+  constraints = ">= 2.7.0, 4.36.1"
   hashes = [
     "h1:04NI9x34nwhgghwevSGdsjssqy5zzvMsQg2Qjpmx/n0=",
     "h1:1NFINTm0Y33TjZSyP+WzCDWdAvIc/3bMtgz2UxjAJyA=",
@@ -16,5 +16,17 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:joU7IYfdBSy43Ln1pDjpDJcDZPcHriVS6MG/OFtR+I4=",
     "h1:sN3HFvBwuCn+ipD9Ti5OnBJ+V9CzUXviJ2py6tiCK6Q=",
     "h1:va/AI4uM9KESgTCBXcYAhCf5iGoQ/T5mPZNT0qVLEpw=",
+    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
+    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
+    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
+    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
+    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
+    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
+    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
+    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
+    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
+    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
   ]
 }

--- a/terraform/account/region/default_vpc.tf
+++ b/terraform/account/region/default_vpc.tf
@@ -46,7 +46,28 @@ resource "aws_default_network_acl" "default" {
     rule_no    = 100
     to_port    = 0
   }
-
+  ingress {
+    action          = "deny"
+    cidr_block      = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
+    ipv6_cidr_block = "::/0"
+    from_port       = 22
+    icmp_code       = 0
+    icmp_type       = 0
+    protocol        = "6"
+    rule_no         = 120
+    to_port         = 22
+  }
+  ingress {
+    action          = "deny"
+    cidr_block      = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
+    ipv6_cidr_block = "::/0"
+    from_port       = 3389
+    icmp_code       = 0
+    icmp_type       = 0
+    protocol        = "6"
+    rule_no         = 130
+    to_port         = 3389
+  }
   ingress {
     action     = "allow"
     cidr_block = "0.0.0.0/0"
@@ -54,30 +75,9 @@ resource "aws_default_network_acl" "default" {
     icmp_code  = 0
     icmp_type  = 0
     protocol   = "-1" #tfsec:ignore:aws-ec2-no-excessive-port-access
-    rule_no    = 100
+    rule_no    = 160
     to_port    = 0
   }
-  ingress {
-    action     = "deny"
-    cidr_block = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
-    from_port  = 22
-    icmp_code  = 0
-    icmp_type  = 0
-    protocol   = "6"
-    rule_no    = 120
-    to_port    = 22
-  }
-  ingress {
-    action     = "deny"
-    cidr_block = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
-    from_port  = 3389
-    icmp_code  = 0
-    icmp_type  = 0
-    protocol   = "6"
-    rule_no    = 130
-    to_port    = 3389
-  }
-
 }
 
 resource "aws_flow_log" "default_vpc" {

--- a/terraform/account/region/default_vpc.tf
+++ b/terraform/account/region/default_vpc.tf
@@ -47,25 +47,43 @@ resource "aws_default_network_acl" "default" {
     to_port    = 0
   }
   ingress {
+    action     = "deny"
+    cidr_block = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
+    from_port  = 22
+    icmp_code  = 0
+    icmp_type  = 0
+    protocol   = "6"
+    rule_no    = 120
+    to_port    = 22
+  }
+  ingress {
+    action     = "deny"
+    cidr_block = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
+    from_port  = 3389
+    icmp_code  = 0
+    icmp_type  = 0
+    protocol   = "6"
+    rule_no    = 130
+    to_port    = 3389
+  }
+  ingress {
     action          = "deny"
-    cidr_block      = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
     ipv6_cidr_block = "::/0"
     from_port       = 22
     icmp_code       = 0
     icmp_type       = 0
     protocol        = "6"
-    rule_no         = 120
+    rule_no         = 125
     to_port         = 22
   }
   ingress {
     action          = "deny"
-    cidr_block      = "0.0.0.0/0" #tfsec:ignore:aws-ec2-no-public-ingress-acl
     ipv6_cidr_block = "::/0"
     from_port       = 3389
     icmp_code       = 0
     icmp_type       = 0
     protocol        = "6"
-    rule_no         = 130
+    rule_no         = 135
     to_port         = 3389
   }
   ingress {


### PR DESCRIPTION
# Purpose

Access to remote server administration ports, such as port 22 (SSH) and port 3389 (RDP), should not be publicly accessible, as this may allow unintended access to resources within your VPC.

Fixes MLPAB-344

## Approach

- reorder rule so that the allow traffic rule is after deny traffic rules
- add ipv6_cidr_block to each deny rule


## Checklist

* [x] I have performed a self-review of my own code