### PR TITLE
MLPAB-344 - Upgrade network moduleto add new network ACL rules

### DIFF
--- a/terraform/account/region/network.tf
+++ b/terraform/account/region/network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                         = "github.com/ministryofjustice/opg-terraform-aws-network?ref=v1.2.0-MLPAB-344.1"
+  source                         = "github.com/ministryofjustice/opg-terraform-aws-network?ref=v1.2.0"
   cidr                           = var.network_cidr_block
   default_security_group_ingress = []
   default_security_group_egress  = []

--- a/terraform/account/region/network.tf
+++ b/terraform/account/region/network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                         = "github.com/ministryofjustice/opg-terraform-aws-network?ref=v1.1.0"
+  source                         = "github.com/ministryofjustice/opg-terraform-aws-network?ref=v1.2.0-MLPAB-344.1"
   cidr                           = var.network_cidr_block
   default_security_group_ingress = []
   default_security_group_egress  = []


### PR DESCRIPTION
# Purpose

Access to remote server administration ports, such as port 22 (SSH) and port 3389 (RDP), should not be publicly accessible, as this may allow unintended access to resources within your VPC.

Fixes MLPAB-344

## Approach

- upgrade network module

## Learning

- https://github.com/ministryofjustice/opg-terraform-aws-network

## Checklist

* [x] I have performed a self-review of my own code