### PR TITLE
MLPAB-283 - Create an vpc inteface endpoint for ec2 with policy

### DIFF
--- a/terraform/account/region/network.tf
+++ b/terraform/account/region/network.tf
@@ -1,6 +1,8 @@
 module "network" {
   source                         = "github.com/ministryofjustice/opg-terraform-aws-network?ref=v1.2.0"
   cidr                           = var.network_cidr_block
+  enable_dns_hostnames           = true
+  enable_dns_support             = true
   default_security_group_ingress = []
   default_security_group_egress  = []
   providers = {

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -1,7 +1,8 @@
 resource "aws_security_group" "vpc_endpoints_private" {
-  name   = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
-  vpc_id = module.network.vpc.id
-  tags   = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
+  name        = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
+  description = "VPC Interface Endpoints Security Group"
+  vpc_id      = module.network.vpc.id
+  tags        = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "vpc_endpoints_private" {
+  provider    = aws.region
   name        = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
   description = "VPC Interface Endpoints Security Group"
   vpc_id      = module.network.vpc.id
@@ -6,6 +7,7 @@ resource "aws_security_group" "vpc_endpoints_private" {
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {
+  provider          = aws.region
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
@@ -16,6 +18,7 @@ resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
+  provider          = aws.region
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
@@ -32,6 +35,7 @@ locals {
 }
 
 resource "aws_vpc_endpoint" "private" {
+  provider = aws.region
   for_each = local.interface_endpoint
 
   vpc_id              = module.network.vpc.id
@@ -39,11 +43,12 @@ resource "aws_vpc_endpoint" "private" {
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
-  subnet_ids          = module.network.application_subnets[*].cidr_block
+  subnet_ids          = module.network.application_subnets[*].id
   tags                = { Name = "${each.value}-private-${data.aws_region.current.name}" }
 }
 
 resource "aws_vpc_endpoint_policy" "ec2" {
+  provider        = aws.region
   vpc_endpoint_id = aws_vpc_endpoint.private["ec2"].id
   policy = jsonencode({
     "Version" : "2012-10-17",

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -1,0 +1,63 @@
+resource "aws_security_group" "vpc_endpoints_private" {
+  name   = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
+  vpc_id = module.network.vpc.id
+  tags   = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.vpc_endpoints_private.id
+  type              = "ingress"
+  cidr_blocks       = module.network.application_subnets[*].cidr_block
+  description       = "Allow Services in Private Subnets of ${data.aws_region.current.name} to connect to VPC Interface Endpoints"
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.vpc_endpoints_private.id
+  type              = "ingress"
+  cidr_blocks       = module.network.public_subnets[*].cidr_block
+  description       = "Allow Services in Public Subnets of ${data.aws_region.current.name} to connect to VPC Interface Endpoints"
+}
+
+locals {
+  interface_endpoint = toset([
+    "ec2",
+  ])
+}
+
+resource "aws_vpc_endpoint" "private" {
+  for_each = local.interface_endpoint
+
+  vpc_id              = module.network.vpc.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
+  subnet_ids          = module.network.application_subnets[*].cidr_block
+  tags                = { Name = "${each.value}-private-${data.aws_region.current.name}" }
+}
+
+resource "aws_vpc_endpoint_policy" "ec2" {
+  vpc_endpoint_id = aws_vpc_endpoint.private["ec2"].id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "AllowAll",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "*"
+        },
+        "Action" : [
+          "ec2:*"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
# Purpose

To improve the security posture of your VPC, you can configure Amazon EC2 to use an interface VPC endpoint. Interface endpoints are powered by AWS PrivateLink, a technology that enables you to access Amazon EC2 API operations privately. It restricts all network traffic between your VPC and Amazon EC2 to the Amazon network. Because endpoints are supported within the same Region only, you cannot create an endpoint between a VPC and a service in a different Region. This prevents unintended Amazon EC2 API calls to other Regions. 

Fixes MLPAB-283

## Approach

- Create a private vpc endpoint for the application subnets and public subnets
- Create a vpc endpoint policy for ec2 allowing any actions (at present)

## Learning

- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-10-remediation
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/interface-vpc-endpoints.html
- https://github.com/ministryofjustice/opg-terraform-aws-network
- https://github.com/ministryofjustice/opg-sirius-infrastructure/blob/main/region/modules/region/vpc_endpoints.tf

## Checklist

* [x] I have performed a self-review of my own code