### PR TITLE
MLPAB-360 - Create a role for SNS feedback

### DIFF
--- a/terraform/account/iam_sns_delivery_notifications_role.tf
+++ b/terraform/account/iam_sns_delivery_notifications_role.tf
@@ -1,0 +1,53 @@
+resource "aws_iam_role" "sns_success_feedback" {
+  provider           = aws.global
+  name               = "sns-success-feedback-role"
+  assume_role_policy = data.aws_iam_policy_document.sns_feedback_assume_policy.json
+}
+
+resource "aws_iam_role" "sns_failure_feedback" {
+  provider           = aws.global
+  name               = "sns-failure-feedback-role"
+  assume_role_policy = data.aws_iam_policy_document.sns_feedback_assume_policy.json
+}
+
+resource "aws_iam_role_policy" "sns_success_feedback" {
+  provider = aws.global
+  name     = "sns-delivery-notifcations-role"
+  policy   = data.aws_iam_policy_document.sns_feedback_actions.json
+  role     = aws_iam_role.sns_success_feedback.id
+}
+
+resource "aws_iam_role_policy" "sns_failure_feedback" {
+  provider = aws.global
+  name     = "sns-delivery-notifcations-role"
+  policy   = data.aws_iam_policy_document.sns_feedback_actions.json
+  role     = aws_iam_role.sns_failure_feedback.id
+}
+
+data "aws_iam_policy_document" "sns_feedback_assume_policy" {
+  provider = aws.global
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sns_feedback_actions" {
+  provider = aws.global
+  statement {
+    effect    = "Allow"
+    resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutMetricFilter",
+      "logs:PutRetentionPolicy"
+    ]
+  }
+}

--- a/terraform/account/iam_sns_feedback_role.tf
+++ b/terraform/account/iam_sns_feedback_role.tf
@@ -1,12 +1,12 @@
 resource "aws_iam_role" "sns_success_feedback" {
   provider           = aws.global
-  name               = "sns-success-feedback-role"
+  name               = "SNSSuccessFeedback"
   assume_role_policy = data.aws_iam_policy_document.sns_feedback_assume_policy.json
 }
 
 resource "aws_iam_role" "sns_failure_feedback" {
   provider           = aws.global
-  name               = "sns-failure-feedback-role"
+  name               = "SNSFailureFeedback"
   assume_role_policy = data.aws_iam_policy_document.sns_feedback_assume_policy.json
 }
 
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "sns_feedback_assume_policy" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      identifiers = ["ecs-tasks.amazonaws.com"]
+      identifiers = ["sns.amazonaws.com"]
       type        = "Service"
     }
   }


### PR DESCRIPTION
# Purpose

Logging is an important part of maintaining the reliability, availability, and performance of services. Logging message delivery status helps provide operational insights, such as the following:

- Knowing whether a message was delivered to the Amazon SNS endpoint.
- Identifying the response sent from the Amazon SNS endpoint to Amazon SNS.
- Determining the message dwell time (the time between the publish timestamp and the hand off to an Amazon SNS endpoint).

Fixes MLPAB-360

## Approach

- Create a new IAM role with assume role policy for SNS
- Attach a policy for reporting SNS feedback

## Learning

- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#sns-2-remediation
- https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html

## Checklist

* [x] I have performed a self-review of my own code