### PR TITLE
MLPAB-285 - Logging of delivery status should be enabled for notification messages sent to a topic

### DIFF
--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -77,10 +77,25 @@ data "aws_kms_alias" "sns_encryption_key_eu_west_1" {
 }
 
 resource "aws_sns_topic" "aws_backup_failure_events" {
-  count             = local.environment.backups.backup_plan_enabled ? 1 : 0
-  name              = "${local.environment_name}-backup-vault-failure-events"
-  kms_master_key_id = data.aws_kms_alias.sns_encryption_key_eu_west_1.target_key_arn
-  provider          = aws.eu_west_1
+  count                                    = local.environment.backups.backup_plan_enabled ? 1 : 0
+  name                                     = "${local.environment_name}-backup-vault-failure-events"
+  kms_master_key_id                        = data.aws_kms_alias.sns_encryption_key_eu_west_1.target_key_arn
+  application_failure_feedback_role_arn    = data.aws_iam_role.sns_failure_feedback.arn
+  application_success_feedback_role_arn    = data.aws_iam_role.sns_success_feedback.arn
+  application_success_feedback_sample_rate = 100
+  firehose_failure_feedback_role_arn       = data.aws_iam_role.sns_failure_feedback.arn
+  firehose_success_feedback_role_arn       = data.aws_iam_role.sns_success_feedback.arn
+  firehose_success_feedback_sample_rate    = 100
+  http_failure_feedback_role_arn           = data.aws_iam_role.sns_failure_feedback.arn
+  http_success_feedback_role_arn           = data.aws_iam_role.sns_success_feedback.arn
+  http_success_feedback_sample_rate        = 100
+  lambda_failure_feedback_role_arn         = data.aws_iam_role.sns_failure_feedback.arn
+  lambda_success_feedback_role_arn         = data.aws_iam_role.sns_success_feedback.arn
+  lambda_success_feedback_sample_rate      = 100
+  sqs_failure_feedback_role_arn            = data.aws_iam_role.sns_failure_feedback.arn
+  sqs_success_feedback_role_arn            = data.aws_iam_role.sns_success_feedback.arn
+  sqs_success_feedback_sample_rate         = 100
+  provider                                 = aws.eu_west_1
 }
 
 data "aws_iam_policy_document" "aws_backup_sns" {

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -78,7 +78,7 @@ data "aws_kms_alias" "sns_encryption_key_eu_west_1" {
 
 resource "aws_sns_topic" "aws_backup_failure_events" {
   count             = local.environment.backups.backup_plan_enabled ? 1 : 0
-  name              = "backup-vault-failure-events"
+  name              = "${local.environment_name}-backup-vault-failure-events"
   kms_master_key_id = data.aws_kms_alias.sns_encryption_key_eu_west_1.target_key_arn
   provider          = aws.eu_west_1
 }

--- a/terraform/environment/iam_sns_feedback_role.tf
+++ b/terraform/environment/iam_sns_feedback_role.tf
@@ -1,0 +1,9 @@
+data "aws_iam_role" "sns_success_feedback" {
+  name     = "SNSSuccessFeedback"
+  provider = aws.global
+}
+
+data "aws_iam_role" "sns_failure_feedback" {
+  provider = aws.global
+  name     = "SNSFailureFeedback"
+}


### PR DESCRIPTION
# Purpose

Logging is an important part of maintaining the reliability, availability, and performance of services. Logging message delivery status helps provide operational insights, such as the following:
- Knowing whether a message was delivered to the Amazon SNS endpoint.
- Identifying the response sent from the Amazon SNS endpoint to Amazon SNS.
- Determining the message dwell time (the time between the publish timestamp and the hand off to an Amazon SNS endpoint).

Fixes MLPAB-285

## Approach

- pull in SNS feedback role
- (temporarily) enable backup plans for PR environments
- enable feedback for each notification type

## Learning

- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#sns-2-remediation
- https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html

## Checklist

* [x] I have turned of backup plans for default environments
* [x] I have performed a self-review of my own code