### PR TITLE
MLPAB-396 - Create application insights for each app-region

### DIFF
--- a/terraform/environment/cloudwatch_application_insights.tf
+++ b/terraform/environment/cloudwatch_application_insights.tf
@@ -1,0 +1,17 @@
+resource "aws_applicationinsights_application" "environment_eu_west_1" {
+  resource_group_name = "${local.default_tags.environment-name}-environment-eu-west-1"
+  auto_config_enabled = true
+  provider            = aws.eu_west_1
+}
+
+resource "aws_applicationinsights_application" "environment_eu_west_2" {
+  resource_group_name = "${local.default_tags.environment-name}-environment-eu-west-2"
+  auto_config_enabled = true
+  provider            = aws.eu_west_2
+}
+
+resource "aws_applicationinsights_application" "environment_global" {
+  resource_group_name = "${local.default_tags.environment-name}-environment-global"
+  auto_config_enabled = true
+  provider            = aws.global
+}

--- a/terraform/environment/cloudwatch_application_insights.tf
+++ b/terraform/environment/cloudwatch_application_insights.tf
@@ -1,17 +1,23 @@
 resource "aws_applicationinsights_application" "environment_eu_west_1" {
+  count               = local.environment.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = "${local.default_tags.environment-name}-environment-eu-west-1"
   auto_config_enabled = true
+  cwe_monitor_enabled = true
   provider            = aws.eu_west_1
 }
 
 resource "aws_applicationinsights_application" "environment_eu_west_2" {
+  count               = local.environment.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = "${local.default_tags.environment-name}-environment-eu-west-2"
   auto_config_enabled = true
+  cwe_monitor_enabled = true
   provider            = aws.eu_west_2
 }
 
 resource "aws_applicationinsights_application" "environment_global" {
+  count               = local.environment.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = "${local.default_tags.environment-name}-environment-global"
   auto_config_enabled = true
+  cwe_monitor_enabled = true
   provider            = aws.global
 }

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,5 +1,0 @@
-resource "aws_applicationinsights_application" "environment_eu_west_1" {
-  resource_group_name = "${data.aws_default_tags.current.tags.environment-name}-environment-${data.aws_region.current.name}"
-  auto_config_enabled = true
-  provider            = aws.region
-}

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,0 +1,4 @@
+resource "aws_applicationinsights_application" "environment_eu_west_1" {
+  resource_group_name = "${data.aws_default_tags.current.tags.environment-name}-environment-${data.aws_region.current.name}"
+  provider            = aws.region
+}

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,4 +1,5 @@
 resource "aws_applicationinsights_application" "environment_eu_west_1" {
   resource_group_name = "${data.aws_default_tags.current.tags.environment-name}-environment-${data.aws_region.current.name}"
+  auto_config_enabled = true
   provider            = aws.region
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -34,7 +34,8 @@
       },
       "application_load_balancer": {
         "deletion_protection_enabled": false
-      }
+      },
+      "cloudwatch_application_insights_enabled": false
     },
     "ur": {
       "account_id": "653761790766",
@@ -70,7 +71,8 @@
       },
       "application_load_balancer": {
         "deletion_protection_enabled": false
-      }
+      },
+      "cloudwatch_application_insights_enabled": true
     },
     "preproduction": {
       "account_id": "792093328875",
@@ -106,7 +108,8 @@
       },
       "application_load_balancer": {
         "deletion_protection_enabled": false
-      }
+      },
+      "cloudwatch_application_insights_enabled": true
     },
     "production": {
       "account_id": "313879017102",
@@ -142,7 +145,8 @@
       },
       "application_load_balancer": {
         "deletion_protection_enabled": true
-      }
+      },
+      "cloudwatch_application_insights_enabled": true
     }
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -46,6 +46,7 @@ variable "environments" {
       application_load_balancer = object({
         deletion_protection_enabled = bool
       })
+      cloudwatch_application_insights_enabled = bool
     })
   )
 }


### PR DESCRIPTION
# Purpose

Amazon CloudWatch Application Insights facilitates observability for your applications and underlying AWS resources. It helps you set up the best monitors for your application resources to continuously analyze data for signs of problems with your applications. Application Insights, which is powered by [SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/wahtis.html) and other AWS technologies, provides automated dashboards that show potential problems with monitored applications, which help you to quickly isolate ongoing issues with your applications and infrastructure. The enhanced visibility into the health of your applications that Application Insights provides helps reduce mean time to repair (MTTR) to troubleshoot your application issues.

Fixes MLPAB-396

## Approach

- Create application insights for each environment using it's resource group

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/applicationinsights_application
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-application-insights.html

## Checklist

* [x] I have performed a self-review of my own code