### PR TITLE
MLPAB-421 - Create a KMS key for S3 buckets

### DIFF
--- a/terraform/account/region/data_sources.tf
+++ b/terraform/account/region/data_sources.tf
@@ -2,3 +2,8 @@ data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
   name     = var.cloudwatch_log_group_kms_key_alias
   provider = aws.region
 }
+
+# data "aws_kms_alias" "s3_encryption" {
+#   name     = var.s3_kms_key_alias
+#   provider = aws.region
+# }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -13,3 +13,8 @@ variable "sns_kms_key_alias" {
   description = "The alias of the KMS key used to encrypt the SNS topic"
   type        = string
 }
+
+variable "s3_kms_key_alias" {
+  description = "The alias of the KMS key used to encrypt S3 buckets"
+  type        = string
+}

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -3,6 +3,7 @@ module "eu_west_1" {
   count                              = contains(local.account.regions, "eu-west-1") ? 1 : 0
   network_cidr_block                 = "10.162.0.0/16"
   cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
+  s3_kms_key_alias                   = "alias/${local.default_tags.application}_s3_encryption"
   sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_1.name
   providers = {
     aws.region     = aws.eu_west_1
@@ -16,6 +17,7 @@ module "eu_west_2" {
   count                              = contains(local.account.regions, "eu-west-2") ? 1 : 0
   network_cidr_block                 = "10.162.0.0/16"
   cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
+  s3_kms_key_alias                   = "alias/${local.default_tags.application}_s3_encryption"
   sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_2.name
   providers = {
     aws.region     = aws.eu_west_2

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -2,8 +2,8 @@ module "eu_west_1" {
   source                             = "./region"
   count                              = contains(local.account.regions, "eu-west-1") ? 1 : 0
   network_cidr_block                 = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
-  s3_kms_key_alias                   = "alias/${local.default_tags.application}_s3_encryption"
+  cloudwatch_log_group_kms_key_alias = aws_kms_alias.cloudwatch_alias_eu_west_1.name
+  s3_kms_key_alias                   = aws_kms_alias.s3_alias_eu_west_1.name
   sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_1.name
   providers = {
     aws.region     = aws.eu_west_1
@@ -16,8 +16,8 @@ module "eu_west_2" {
   source                             = "./region"
   count                              = contains(local.account.regions, "eu-west-2") ? 1 : 0
   network_cidr_block                 = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias = "alias/${local.default_tags.application}_cloudwatch_application_logs_encryption"
-  s3_kms_key_alias                   = "alias/${local.default_tags.application}_s3_encryption"
+  cloudwatch_log_group_kms_key_alias = aws_kms_alias.cloudwatch_alias_eu_west_2.name
+  s3_kms_key_alias                   = aws_kms_alias.s3_alias_eu_west_2.name
   sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_2.name
   providers = {
     aws.region     = aws.eu_west_2

--- a/terraform/account/s3_kms.tf
+++ b/terraform/account/s3_kms.tf
@@ -1,0 +1,152 @@
+resource "aws_kms_key" "s3" {
+  description             = "${local.default_tags.application} S3 encryption key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.s3_kms_merged.json : data.aws_iam_policy_document.s3_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+}
+
+resource "aws_kms_replica_key" "s3_replica" {
+  description             = "${local.default_tags.application} S3 Multi-Region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.s3.arn
+  provider                = aws.eu_west_2
+}
+
+resource "aws_kms_alias" "s3_alias_eu_west_1" {
+  name          = "alias/${local.default_tags.application}_s3_encryption"
+  target_key_id = aws_kms_key.s3.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "s3_alias_eu_west_2" {
+  name          = "alias/${local.default_tags.application}_s3_encryption"
+  target_key_id = aws_kms_replica_key.s3_replica.key_id
+  provider      = aws.eu_west_2
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "s3_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.s3_kms.json,
+    data.aws_iam_policy_document.s3_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "s3_kms" {
+  provider = aws.global
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.eu_west_1.name}.amazonaws.com",
+        "logs.${data.aws_region.eu_west_2.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:List*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "s3_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid    = "Dev Account Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Purpose

Use customer managed encryption key for S3 buckets.

Fixes MLPAB-421

## Approach

- Create an encryption key for S3 and pass it into the region module

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html

## Checklist

* [x] I have performed a self-review of my own code