### PR TITLE
MLPAB-428 - Enable bucket keys encryption with CMK

### DIFF
--- a/terraform/account/region/data_sources.tf
+++ b/terraform/account/region/data_sources.tf
@@ -3,7 +3,7 @@ data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
   provider = aws.region
 }
 
-# data "aws_kms_alias" "s3_encryption" {
-#   name     = var.s3_kms_key_alias
-#   provider = aws.region
-# }
+data "aws_kms_alias" "s3_encryption" {
+  name     = var.s3_kms_key_alias
+  provider = aws.region
+}

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -56,6 +56,24 @@ data "aws_elb_service_account" "main" {
 data "aws_iam_policy_document" "access_log" {
   provider = aws.region
   statement {
+    sid = "DenyUnEncryptedObjectUploads"
+    resources = [
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+    effect  = "Deny"
+    actions = ["s3:PutObject"]
+    principals {
+      identifiers = [data.aws_elb_service_account.main.id]
+      type        = "AWS"
+    }
+    condition {
+      test     = "StringNotEquals"
+      values   = ["aws:kms"]
+      variable = "s3:x-amz-server-side-encryption"
+    }
+  }
+
+  statement {
     sid = "accessLogBucketAccess"
     resources = [
       aws_s3_bucket.access_log.arn,

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -14,8 +14,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
   bucket   = aws_s3_bucket.access_log.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      kms_master_key_id = data.aws_kms_alias.s3_encryption.target_key_arn
+      sse_algorithm     = "aws:kms"
     }
+    bucket_key_enabled = true
   }
 }
 


### PR DESCRIPTION
# Purpose

Use an AWS KMS customer managed key (CMK) when encrypting S3 buckets, and use bucket keys to reduce AWS KMS usage.

Fixes MLPAB-428

## Approach

- Retrieve key ARN using data source
- Use CMK to encrypt bucket
- Enable Bucket Keys
- Require server side encryption when putting objects

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#require-sse-kms
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html

## Checklist

* [x] I have performed a self-review of my own code