### PR TITLE
MLPAB-442 / MLPAB-443 - Authorise app to send RUM data

### DIFF
--- a/terraform/account/rum_cognito_identity_pool.tf
+++ b/terraform/account/rum_cognito_identity_pool.tf
@@ -1,10 +1,12 @@
 resource "aws_cognito_identity_pool" "rum_monitor" {
+  count                            = local.account.rum_enabled ? 1 : 0
   identity_pool_name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
   allow_unauthenticated_identities = true
   provider                         = aws.eu_west_1
 }
 
 resource "aws_iam_role" "rum_monitor_unauthenticated" {
+  count              = local.account.rum_enabled ? 1 : 0
   name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
   assume_role_policy = data.aws_iam_policy_document.rum_monitor_unauthenticated_role_assume_policy.json
   provider           = aws.eu_west_1
@@ -25,7 +27,7 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" 
       variable = "cognito-identity.amazonaws.com:aud"
 
       values = [
-        aws_cognito_identity_pool.rum_monitor.id
+        aws_cognito_identity_pool.rum_monitor[0].id
       ]
     }
     condition {
@@ -34,6 +36,15 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" 
 
       values = ["unauthenticated"]
     }
+  }
+  provider = aws.eu_west_1
+}
+
+resource "aws_cognito_identity_pool_roles_attachment" "rum_monitor" {
+  count            = local.account.rum_enabled ? 1 : 0
+  identity_pool_id = aws_cognito_identity_pool.rum_monitor[0].id
+  roles = {
+    unauthenticated = aws_iam_role.rum_monitor_unauthenticated[0].arn
   }
   provider = aws.eu_west_1
 }

--- a/terraform/account/rum_cognito_identity_pool.tf
+++ b/terraform/account/rum_cognito_identity_pool.tf
@@ -8,12 +8,13 @@ resource "aws_cognito_identity_pool" "rum_monitor" {
 resource "aws_iam_role" "rum_monitor_unauthenticated" {
   count              = local.account.rum_enabled ? 1 : 0
   name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
-  assume_role_policy = data.aws_iam_policy_document.rum_monitor_unauthenticated_role_assume_policy.json
+  assume_role_policy = data.aws_iam_policy_document.rum_monitor_unauthenticated_role_assume_policy[0].json
   provider           = aws.eu_west_1
 }
 
 
 data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" {
+  count = local.account.rum_enabled ? 1 : 0
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -50,6 +51,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "rum_monitor" {
 }
 
 resource "aws_ssm_parameter" "rum_monitor_identity_pool_id" {
+  count    = local.account.rum_enabled ? 1 : 0
   name     = "rum_monitor_identity_pool_id"
   type     = "String"
   value    = aws_cognito_identity_pool.rum_monitor[0].id

--- a/terraform/account/rum_cognito_identity_pool.tf
+++ b/terraform/account/rum_cognito_identity_pool.tf
@@ -48,3 +48,10 @@ resource "aws_cognito_identity_pool_roles_attachment" "rum_monitor" {
   }
   provider = aws.eu_west_1
 }
+
+resource "aws_ssm_parameter" "rum_monitor_identity_pool_id" {
+  name     = "rum_monitor_identity_pool_id"
+  type     = "String"
+  value    = aws_cognito_identity_pool.rum_monitor[0].id
+  provider = aws.eu_west_1
+}

--- a/terraform/account/rum_cognito_identity_pool.tf
+++ b/terraform/account/rum_cognito_identity_pool.tf
@@ -1,0 +1,39 @@
+resource "aws_cognito_identity_pool" "rum_monitor" {
+  identity_pool_name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
+  allow_unauthenticated_identities = true
+  provider                         = aws.eu_west_1
+}
+
+resource "aws_iam_role" "rum_monitor_unauthenticated" {
+  name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
+  assume_role_policy = data.aws_iam_policy_document.rum_monitor_unauthenticated_role_assume_policy.json
+  provider           = aws.eu_west_1
+}
+
+
+data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      identifiers = ["cognito-identity.amazonaws.com"]
+      type        = "Federated"
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "cognito-identity.amazonaws.com:aud"
+
+      values = [
+        aws_cognito_identity_pool.rum_monitor.id
+      ]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "cognito-identity.amazonaws.com:amr"
+
+      values = ["unauthenticated"]
+    }
+  }
+  provider = aws.eu_west_1
+}

--- a/terraform/account/rum_cognito_identity_pool.tf
+++ b/terraform/account/rum_cognito_identity_pool.tf
@@ -7,11 +7,10 @@ resource "aws_cognito_identity_pool" "rum_monitor" {
 
 resource "aws_iam_role" "rum_monitor_unauthenticated" {
   count              = local.account.rum_enabled ? 1 : 0
-  name               = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
+  name               = "RUM-Monitor-Unauthenticated"
   assume_role_policy = data.aws_iam_policy_document.rum_monitor_unauthenticated_role_assume_policy[0].json
-  provider           = aws.eu_west_1
+  provider           = aws.global
 }
-
 
 data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" {
   count = local.account.rum_enabled ? 1 : 0
@@ -20,8 +19,8 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" 
     actions = ["sts:AssumeRoleWithWebIdentity"]
 
     principals {
-      identifiers = ["cognito-identity.amazonaws.com"]
       type        = "Federated"
+      identifiers = ["cognito-identity.amazonaws.com"]
     }
     condition {
       test     = "StringEquals"
@@ -34,11 +33,10 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated_role_assume_policy" 
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "cognito-identity.amazonaws.com:amr"
-
-      values = ["unauthenticated"]
+      values   = ["unauthenticated"]
     }
   }
-  provider = aws.eu_west_1
+  provider = aws.global
 }
 
 resource "aws_cognito_identity_pool_roles_attachment" "rum_monitor" {

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -4,6 +4,7 @@
       "account_id": "653761790766",
       "account_name": "development",
       "is_production": false,
+      "rum_enabled": true,
       "regions": [
         "eu-west-1"
       ]
@@ -12,6 +13,7 @@
       "account_id": "792093328875",
       "account_name": "preproduction",
       "is_production": false,
+      "rum_enabled": false,
       "regions": [
         "eu-west-1"
       ]
@@ -20,6 +22,7 @@
       "account_id": "313879017102",
       "account_name": "production",
       "is_production": true,
+      "rum_enabled": false,
       "regions": [
         "eu-west-1"
       ]

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -9,6 +9,7 @@ variable "accounts" {
       account_name  = string
       is_production = bool
       regions       = list(string)
+      rum_enabled   = bool
     })
   )
 }

--- a/terraform/environment/rum_monitoring.tf
+++ b/terraform/environment/rum_monitoring.tf
@@ -1,15 +1,15 @@
-data "aws_caller_identity" "eu_west_1" {
-  provider = aws.eu_west_1
+data "aws_caller_identity" "global" {
+  provider = aws.global
 }
 
-data "aws_region" "eu_west_1" {
-  provider = aws.eu_west_1
+data "aws_region" "global" {
+  provider = aws.global
 }
 
 data "aws_iam_role" "rum_monitor_unauthenticated" {
   count    = local.environment.app.rum_enabled ? 1 : 0
-  name     = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
-  provider = aws.eu_west_1
+  name     = "RUM-Monitor-Unauthenticated"
+  provider = aws.global
 }
 
 # create this policy and attachment for each environment
@@ -18,7 +18,7 @@ resource "aws_iam_role_policy" "rum_monitor_unauthenticated" {
   name     = "RUMPutBatchMetrics-${local.environment_name}"
   policy   = data.aws_iam_policy_document.rum_monitor_unauthenticated[0].json
   role     = data.aws_iam_role.rum_monitor_unauthenticated[0].id
-  provider = aws.eu_west_1
+  provider = aws.global
 }
 
 data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
@@ -26,13 +26,14 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
   statement {
     effect = "Allow"
     resources = [
-      "arn:aws:rum:${data.aws_region.eu_west_1.name}:${data.aws_caller_identity.eu_west_1.account_id}:appmonitor/${local.environment_name}"
+      "arn:aws:rum:eu-west-1:${data.aws_caller_identity.global.account_id}:appmonitor/${local.environment_name}",
+      "arn:aws:rum:eu-west-2:${data.aws_caller_identity.global.account_id}:appmonitor/${local.environment_name}"
     ]
     actions = [
       "rum:PutRumEvents",
     ]
   }
-  provider = aws.eu_west_1
+  provider = aws.global
 }
 
 data "aws_ssm_parameter" "rum_monitor_identity_pool_id" {

--- a/terraform/environment/rum_monitoring.tf
+++ b/terraform/environment/rum_monitoring.tf
@@ -7,7 +7,7 @@ data "aws_region" "eu_west_1" {
 }
 
 data "aws_iam_role" "rum_monitor_unauthenticated" {
-  name     = "RUM-Monitor-eu-west-1-653761790766-0155138158661-Unauth"
+  name     = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
   provider = aws.eu_west_1
 }
 

--- a/terraform/environment/rum_monitoring.tf
+++ b/terraform/environment/rum_monitoring.tf
@@ -7,6 +7,7 @@ data "aws_region" "eu_west_1" {
 }
 
 data "aws_iam_role" "rum_monitor_unauthenticated" {
+  count    = local.environment.app.rum_enabled ? 1 : 0
   name     = "RUM-Monitor-${data.aws_region.eu_west_1.name}"
   provider = aws.eu_west_1
 }
@@ -15,12 +16,13 @@ data "aws_iam_role" "rum_monitor_unauthenticated" {
 resource "aws_iam_role_policy" "rum_monitor_unauthenticated" {
   count    = local.environment.app.rum_enabled ? 1 : 0
   name     = "RUMPutBatchMetrics-${local.environment_name}"
-  policy   = data.aws_iam_policy_document.rum_monitor_unauthenticated.json
-  role     = data.aws_iam_role.rum_monitor_unauthenticated.id
+  policy   = data.aws_iam_policy_document.rum_monitor_unauthenticated[0].json
+  role     = data.aws_iam_role.rum_monitor_unauthenticated[0].id
   provider = aws.eu_west_1
 }
 
 data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
+  count = local.environment.app.rum_enabled ? 1 : 0
   statement {
     effect = "Allow"
     resources = [
@@ -34,18 +36,20 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
 }
 
 data "aws_ssm_parameter" "rum_monitor_identity_pool_id" {
+  count    = local.environment.app.rum_enabled ? 1 : 0
   name     = "rum_monitor_identity_pool_id"
   provider = aws.eu_west_1
 }
 
 resource "aws_rum_app_monitor" "main" {
+  count          = local.environment.app.rum_enabled ? 1 : 0
   name           = local.environment_name
   domain         = "*.${aws_route53_record.app.fqdn}"
   cw_log_enabled = true
   app_monitor_configuration {
     allow_cookies       = true
     enable_xray         = true
-    identity_pool_id    = data.aws_ssm_parameter.rum_monitor_identity_pool_id.value
+    identity_pool_id    = data.aws_ssm_parameter.rum_monitor_identity_pool_id[0].value
     session_sample_rate = 1.0
     telemetries = [
       "errors",

--- a/terraform/environment/rum_monitoring.tf
+++ b/terraform/environment/rum_monitoring.tf
@@ -32,3 +32,26 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
   }
   provider = aws.eu_west_1
 }
+
+data "aws_ssm_parameter" "rum_monitor_identity_pool_id" {
+  name     = "rum_monitor_identity_pool_id"
+  provider = aws.eu_west_1
+}
+
+resource "aws_rum_app_monitor" "main" {
+  name           = local.environment_name
+  domain         = "*.${aws_route53_record.app.fqdn}"
+  cw_log_enabled = true
+  app_monitor_configuration {
+    allow_cookies       = true
+    enable_xray         = true
+    identity_pool_id    = data.aws_ssm_parameter.rum_monitor_identity_pool_id.value
+    session_sample_rate = 1.0
+    telemetries = [
+      "errors",
+      "http",
+      "performance",
+    ]
+  }
+  provider = aws.eu_west_1
+}

--- a/terraform/environment/rum_monitoring_cognito_iam_role.tf
+++ b/terraform/environment/rum_monitoring_cognito_iam_role.tf
@@ -1,0 +1,34 @@
+data "aws_caller_identity" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_region" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_iam_role" "rum_monitor_unauthenticated" {
+  name     = "RUM-Monitor-eu-west-1-653761790766-0155138158661-Unauth"
+  provider = aws.eu_west_1
+}
+
+# create this policy and attachment for each environment
+resource "aws_iam_role_policy" "rum_monitor_unauthenticated" {
+  count    = local.environment.app.rum_enabled ? 1 : 0
+  name     = "RUMPutBatchMetrics-${local.environment_name}"
+  policy   = data.aws_iam_policy_document.rum_monitor_unauthenticated.json
+  role     = data.aws_iam_role.rum_monitor_unauthenticated.id
+  provider = aws.eu_west_1
+}
+
+data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
+  statement {
+    effect = "Allow"
+    resources = [
+      "arn:aws:rum:${data.aws_region.eu_west_1.name}:${data.aws_caller_identity.eu_west_1.account_id}:appmonitor/${local.environment_name}"
+    ]
+    actions = [
+      "rum:PutRumEvents",
+    ]
+  }
+  provider = aws.eu_west_1
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,7 +9,7 @@
       ],
       "app": {
         "public_access_enabled": false,
-        "rum_enabled": true,
+        "rum_enabled": false,
         "env": {
           "app_public_url": "",
           "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,6 +9,7 @@
       ],
       "app": {
         "public_access_enabled": false,
+        "rum_enabled": true,
         "env": {
           "app_public_url": "",
           "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",
@@ -46,6 +47,7 @@
       ],
       "app": {
         "public_access_enabled": true,
+        "rum_enabled": false,
         "env": {
           "app_public_url": "",
           "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",
@@ -83,6 +85,7 @@
       ],
       "app": {
         "public_access_enabled": false,
+        "rum_enabled": false,
         "env": {
           "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
@@ -120,6 +123,7 @@
       ],
       "app": {
         "public_access_enabled": false,
+        "rum_enabled": false,
         "env": {
           "app_public_url": "https://app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://app.modernising.opg.service.justice.gov.uk",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,7 +9,7 @@
       ],
       "app": {
         "public_access_enabled": false,
-        "rum_enabled": false,
+        "rum_enabled": true,
         "env": {
           "app_public_url": "",
           "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -20,6 +20,7 @@ variable "environments" {
       regions       = list(string)
       app = object({
         public_access_enabled = bool
+        rum_enabled           = bool
         env = object({
           app_public_url         = string
           auth_redirect_base_url = string


### PR DESCRIPTION
# Purpose

The App will use a cognito identity pool to send data to AWS

Fixes MLPAB-442 MLPAB-443

## Approach

- Create a Cognito identity pool (in global region?)
- Create a Cognito identity
- Create an IAM role for the Cognito identity with `PutRumEvents`
- Create an AWS RUM app monitor

## Learning

- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM-get-started-authorization.html
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM-get-started-create-app-monitor.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rum_app_monitor
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_pool
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_pool_roles_attachment

## Checklist

* [x] I have performed a self-review of my own code