### PR TITLE
Mlpab 478 fe perf

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
 	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9
+	golang.org/x/mod v0.6.0
 	golang.org/x/text v0.4.0
 	google.golang.org/grpc v1.51.0
 )

--- a/app/go.mod
+++ b/app/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -311,6 +311,8 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/app/go.sum
+++ b/app/go.sum
@@ -117,6 +117,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/getyoti/yoti-go-sdk/v3 v3.6.0 h1:2JaL8JmblIH0E7SPb9Z2anrn7q6mDEhJhCqZqDPPMeI=
@@ -188,6 +189,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=

--- a/app/internal/page/app.go
+++ b/app/internal/page/app.go
@@ -30,6 +30,13 @@ type RumConfig struct {
 
 type Lang int
 
+func CacheControlWrapper(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=2592000") // 30 days
+		h.ServeHTTP(w, r)
+	})
+}
+
 func (l Lang) Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 	http.Redirect(w, r, l.BuildUrl(url), code)
 }

--- a/app/internal/page/app.go
+++ b/app/internal/page/app.go
@@ -30,7 +30,7 @@ type RumConfig struct {
 
 type Lang int
 
-func CacheControlWrapper(h http.Handler) http.Handler {
+func CacheControlHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=2592000")
 		h.ServeHTTP(w, r)

--- a/app/internal/page/app.go
+++ b/app/internal/page/app.go
@@ -32,7 +32,7 @@ type Lang int
 
 func CacheControlWrapper(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "max-age=2592000") // 30 days
+		w.Header().Set("Cache-Control", "max-age=2592000")
 		h.ServeHTTP(w, r)
 	})
 }

--- a/app/internal/page/app_test.go
+++ b/app/internal/page/app_test.go
@@ -59,7 +59,7 @@ func (m *mockLogger) Print(v ...interface{}) {
 }
 
 func TestApp(t *testing.T) {
-	app := App(&mockLogger{}, localize.Localizer{}, En, template.Templates{}, nil, nil, "http://public.url", &pay.Client{}, &identity.YotiClient{}, "yoti-scenario-id", &notify.Client{}, &place.Client{}, RumConfig{})
+	app := App(&mockLogger{}, localize.Localizer{}, En, template.Templates{}, nil, nil, "http://public.url", &pay.Client{}, &identity.YotiClient{}, "yoti-scenario-id", &notify.Client{}, &place.Client{}, RumConfig{}, "?%3fNEI0t9MN")
 
 	assert.Implements(t, (*http.Handler)(nil), app)
 }
@@ -105,7 +105,7 @@ func TestMakeHandle(t *testing.T) {
 		Return(&sessions.Session{Values: map[interface{}]interface{}{"sub": "random"}}, nil)
 
 	mux := http.NewServeMux()
-	handle := makeHandle(mux, nil, sessionsStore, localizer, En, RumConfig{ApplicationID: "xyz"})
+	handle := makeHandle(mux, nil, sessionsStore, localizer, En, RumConfig{ApplicationID: "xyz"}, "?%3fNEI0t9MN")
 	handle("/path", RequireSession|CanGoBack, func(appData AppData, hw http.ResponseWriter, hr *http.Request) error {
 		assert.Equal(t, AppData{
 			Page:             "/path",
@@ -116,6 +116,7 @@ func TestMakeHandle(t *testing.T) {
 			CookieConsentSet: false,
 			CanGoBack:        true,
 			RumConfig:        RumConfig{ApplicationID: "xyz"},
+			StaticHash:       "?%3fNEI0t9MN",
 		}, appData)
 		assert.Equal(t, w, hw)
 		assert.Equal(t, r, hr)
@@ -145,7 +146,7 @@ func TestMakeHandleErrors(t *testing.T) {
 		Return(&sessions.Session{Values: map[interface{}]interface{}{"sub": "random"}}, nil)
 
 	mux := http.NewServeMux()
-	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{})
+	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{}, "?%3fNEI0t9MN")
 	handle("/path", RequireSession, func(appData AppData, hw http.ResponseWriter, hr *http.Request) error {
 		return expectedError
 	})
@@ -172,7 +173,7 @@ func TestMakeHandleSessionError(t *testing.T) {
 		Return(&sessions.Session{}, expectedError)
 
 	mux := http.NewServeMux()
-	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{})
+	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{}, "?%3fNEI0t9MN")
 	handle("/path", RequireSession, func(appData AppData, hw http.ResponseWriter, hr *http.Request) error { return nil })
 
 	mux.ServeHTTP(w, r)
@@ -198,7 +199,7 @@ func TestMakeHandleSessionMissing(t *testing.T) {
 		Return(&sessions.Session{Values: map[interface{}]interface{}{}}, nil)
 
 	mux := http.NewServeMux()
-	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{})
+	handle := makeHandle(mux, logger, sessionsStore, localizer, En, RumConfig{}, "?%3fNEI0t9MN")
 	handle("/path", RequireSession, func(appData AppData, hw http.ResponseWriter, hr *http.Request) error { return nil })
 
 	mux.ServeHTTP(w, r)
@@ -215,13 +216,14 @@ func TestMakeHandleNoSessionRequired(t *testing.T) {
 	localizer := localize.Localizer{}
 
 	mux := http.NewServeMux()
-	handle := makeHandle(mux, nil, nil, localizer, En, RumConfig{})
+	handle := makeHandle(mux, nil, nil, localizer, En, RumConfig{}, "?%3fNEI0t9MN")
 	handle("/path", None, func(appData AppData, hw http.ResponseWriter, hr *http.Request) error {
 		assert.Equal(t, AppData{
 			Page:             "/path",
 			Localizer:        localizer,
 			Lang:             En,
 			CookieConsentSet: false,
+			StaticHash:       "?%3fNEI0t9MN",
 		}, appData)
 		assert.Equal(t, w, hw)
 		assert.Equal(t, r, hr)

--- a/app/internal/page/app_test.go
+++ b/app/internal/page/app_test.go
@@ -64,6 +64,16 @@ func TestApp(t *testing.T) {
 	assert.Implements(t, (*http.Handler)(nil), app)
 }
 
+func TestCacheControlHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/path", nil)
+
+	CacheControlHeaders(http.NotFoundHandler()).ServeHTTP(w, r)
+
+	resp := w.Result()
+	assert.Equal(t, "max-age=2592000", resp.Header.Get("Cache-Control"))
+}
+
 func TestLangRedirect(t *testing.T) {
 	testCases := map[Lang]string{
 		En: "/somewhere",

--- a/app/main.go
+++ b/app/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/sessions"
 	"github.com/ministryofjustice/opg-go-common/env"
 	"github.com/ministryofjustice/opg-go-common/logging"
@@ -175,7 +176,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
-	mux.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir(webDir+"/static/"))))
+	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(http.FileServer(http.Dir(webDir+"/static/")))))
 	mux.Handle(page.AuthRedirectPath, page.AuthRedirect(logger, signInClient, sessionStore, secureCookies))
 	mux.Handle(page.AuthPath, page.Login(logger, signInClient, sessionStore, secureCookies, random.String))
 	mux.Handle("/cookies-consent", page.CookieConsent())

--- a/app/main.go
+++ b/app/main.go
@@ -176,7 +176,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
-	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlWrapper(http.FileServer(http.Dir(webDir+"/static/"))))))
+	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlHeaders(http.FileServer(http.Dir(webDir+"/static/"))))))
 	mux.Handle(page.AuthRedirectPath, page.AuthRedirect(logger, signInClient, sessionStore, secureCookies))
 	mux.Handle(page.AuthPath, page.Login(logger, signInClient, sessionStore, secureCookies, random.String))
 	mux.Handle("/cookies-consent", page.CookieConsent())

--- a/app/main.go
+++ b/app/main.go
@@ -70,7 +70,7 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	staticHash = "?" + url.QueryEscape(staticHash[3:11])
+	staticHash = url.QueryEscape(staticHash[3:11])
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 

--- a/app/main.go
+++ b/app/main.go
@@ -176,7 +176,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
-	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(http.FileServer(http.Dir(webDir+"/static/")))))
+	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlWrapper(http.FileServer(http.Dir(webDir+"/static/"))))))
 	mux.Handle(page.AuthRedirectPath, page.AuthRedirect(logger, signInClient, sessionStore, secureCookies))
 	mux.Handle(page.AuthPath, page.Login(logger, signInClient, sessionStore, secureCookies, random.String))
 	mux.Handle("/cookies-consent", page.CookieConsent())

--- a/app/web/template/layout/page.gohtml
+++ b/app/web/template/layout/page.gohtml
@@ -4,8 +4,8 @@
     <head>
       <meta charset="utf-8">
       <title>{{ if .Errors }}Error: {{ end }}{{ tr .App "serviceName" }}</title>
-      <link rel="preload" href="/static/stylesheets/all.css" as="style">
-      <link rel="preload" href="/static/javascript/main.js" as="script">
+      <link rel="preload" href="/static/stylesheets/all.css?{{ .App.StaticHash }}" as="style">
+      <link rel="preload" href="/static/javascript/main.js?{{ .App.StaticHash }}" as="script">
       <link rel="preconnect" href="//dataplane.rum.eu-west-1.amazonaws.com">
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <meta name="theme-color" content="blue">
@@ -16,8 +16,8 @@
       <link rel="apple-touch-icon" sizes="167x167" href="/static/assets/images/govuk-apple-touch-icon-167x167.png" >
       <link rel="apple-touch-icon" sizes="152x152" href="/static/assets/images/govuk-apple-touch-icon-152x152.png" >
       <link rel="apple-touch-icon" href="/static/assets/images/govuk-apple-touch-icon.png" >
-      <link href="/static/stylesheets/all.css" rel="stylesheet">
-      <script async src="/static/javascript/main.js"></script>
+      <link href="/static/stylesheets/all.css?{{ .App.StaticHash }}" rel="stylesheet">
+      <script async src="/static/javascript/main.js?{{ .App.StaticHash }}"></script>
       <meta name="rum-guest-role-arn" content="{{ .App.RumConfig.GuestRoleArn }}" />
       <meta name="rum-endpoint" content="{{ .App.RumConfig.Endpoint }}" />
       <meta name="rum-application-region" content="{{ .App.RumConfig.ApplicationRegion }}" />

--- a/app/web/template/layout/page.gohtml
+++ b/app/web/template/layout/page.gohtml
@@ -6,6 +6,7 @@
       <title>{{ if .Errors }}Error: {{ end }}{{ tr .App "serviceName" }}</title>
       <link rel="preload" href="/static/stylesheets/all.css" as="style">
       <link rel="preload" href="/static/javascript/main.js" as="script">
+      <link rel="preconnect" href="//dataplane.rum.eu-west-1.amazonaws.com">
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <meta name="theme-color" content="blue">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/web/template/layout/page.gohtml
+++ b/app/web/template/layout/page.gohtml
@@ -4,6 +4,8 @@
     <head>
       <meta charset="utf-8">
       <title>{{ if .Errors }}Error: {{ end }}{{ tr .App "serviceName" }}</title>
+      <link rel="preload" href="/static/stylesheets/all.css" as="style">
+      <link rel="preload" href="/static/javascript/main.js" as="script">
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <meta name="theme-color" content="blue">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -14,6 +16,7 @@
       <link rel="apple-touch-icon" sizes="152x152" href="/static/assets/images/govuk-apple-touch-icon-152x152.png" >
       <link rel="apple-touch-icon" href="/static/assets/images/govuk-apple-touch-icon.png" >
       <link href="/static/stylesheets/all.css" rel="stylesheet">
+      <script async src="/static/javascript/main.js"></script>
       <meta name="rum-guest-role-arn" content="{{ .App.RumConfig.GuestRoleArn }}" />
       <meta name="rum-endpoint" content="{{ .App.RumConfig.Endpoint }}" />
       <meta name="rum-application-region" content="{{ .App.RumConfig.ApplicationRegion }}" />
@@ -163,8 +166,6 @@
           </div>
         </div>
       </footer>
-
-      <script src="/static/javascript/main.js"></script>
     </body>
   </html>
 {{ end }}


### PR DESCRIPTION
* Add preconnect tag in for AWS RUM calls
* Move javascript to and add async tag to it. This will allow the browser to fetch it sooner in a non blocking
* Add preload tags in the for our CSS and Javascript
* Enable zip compression for static assets with a TTL of 30 days set.

Fixes [MLPAB-478](https://opgtransform.atlassian.net/browse/MPLAB-478)