### PR TITLE
MLPAB-466: Group paths under a struct and use in app

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -238,10 +238,10 @@
         "filename": "app/main.go",
         "hashed_secret": "dc9c2ac186b77d3f4f84400225d460ddcc5940db",
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 201,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-12-01T11:43:16Z"
+  "generated_at": "2022-12-05T15:02:29Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -238,10 +238,10 @@
         "filename": "app/main.go",
         "hashed_secret": "dc9c2ac186b77d3f4f84400225d460ddcc5940db",
         "is_verified": false,
-        "line_number": 258,
+        "line_number": 147,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-10-13T16:46:56Z"
+  "generated_at": "2022-12-01T11:43:16Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,11 @@ COPY --from=build-env /go/bin/mlpab mlpab
 COPY --from=asset-env /app/web/static web/static
 COPY app/web/template web/template
 COPY app/lang lang
+COPY app/web/robots.txt web/robots.txt
 
 RUN addgroup -S app && \
   adduser -S -g app app && \
-  chown -R app:app mlpab web/template web/static
+  chown -R app:app mlpab web/template web/static web/robots.txt
 USER app
 
 ENTRYPOINT ["./mlpab"]

--- a/app/internal/page/about_payment.go
+++ b/app/internal/page/about_payment.go
@@ -27,7 +27,7 @@ func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.S
 				Amount:      CostOfLpaPence,
 				Reference:   randomString(12),
 				Description: "Property and Finance LPA",
-				ReturnUrl:   appPublicUrl + appData.Lang.BuildUrl(paymentConfirmationPath),
+				ReturnUrl:   appPublicUrl + appData.Lang.BuildUrl(appData.Paths.PaymentConfirmation),
 				Email:       "a@b.com",
 				Language:    appData.Lang.String(),
 			}

--- a/app/internal/page/app.go
+++ b/app/internal/page/app.go
@@ -103,6 +103,7 @@ type AppData struct {
 	SessionID        string
 	RumConfig        RumConfig
 	StaticHash       string
+	Paths            AppPaths
 }
 
 type Handler func(data AppData, w http.ResponseWriter, r *http.Request) error
@@ -122,111 +123,112 @@ func App(
 	addressClient AddressClient,
 	rumConfig RumConfig,
 	staticHash string,
+	paths AppPaths,
 ) http.Handler {
 	mux := http.NewServeMux()
 
 	lpaStore := &lpaStore{dataStore: dataStore, randomInt: rand.Intn}
 
-	handle := makeHandle(mux, logger, sessionStore, localizer, lang, rumConfig, staticHash)
+	handle := makeHandle(mux, logger, sessionStore, localizer, lang, rumConfig, staticHash, paths)
 
-	mux.Handle("/testing-start", testingStart(sessionStore, lpaStore))
-	mux.Handle("/", Root())
+	mux.Handle(paths.TestingStart, testingStart(sessionStore, lpaStore))
+	mux.Handle(paths.Root, Root(paths))
 
-	handle(startPath, None,
-		Guidance(tmpls.Get("start.gohtml"), AuthPath, nil))
-	handle(lpaTypePath, RequireSession,
+	handle(paths.Start, None,
+		Guidance(tmpls.Get("start.gohtml"), paths.Auth, nil))
+	handle(paths.LpaType, RequireSession,
 		LpaType(tmpls.Get("lpa_type.gohtml"), lpaStore))
-	handle(whoIsTheLpaForPath, RequireSession,
+	handle(paths.WhoIsTheLpaFor, RequireSession,
 		WhoIsTheLpaFor(tmpls.Get("who_is_the_lpa_for.gohtml"), lpaStore))
 
-	handle(yourDetailsPath, RequireSession,
+	handle(paths.YourDetails, RequireSession,
 		YourDetails(tmpls.Get("your_details.gohtml"), lpaStore, sessionStore))
-	handle(yourAddressPath, RequireSession,
+	handle(paths.YourAddress, RequireSession,
 		YourAddress(logger, tmpls.Get("your_address.gohtml"), addressClient, lpaStore))
-	handle(howWouldYouLikeToBeContactedPath, RequireSession,
+	handle(paths.HowWouldYouLikeToBeContacted, RequireSession,
 		HowWouldYouLikeToBeContacted(tmpls.Get("how_would_you_like_to_be_contacted.gohtml"), lpaStore))
 
-	handle(taskListPath, RequireSession,
+	handle(paths.TaskList, RequireSession,
 		TaskList(tmpls.Get("task_list.gohtml"), lpaStore))
 
-	handle(chooseAttorneysPath, RequireSession|CanGoBack,
+	handle(paths.ChooseAttorneys, RequireSession|CanGoBack,
 		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), lpaStore, random.String))
-	handle(chooseAttorneysAddressPath, RequireSession|CanGoBack,
+	handle(paths.ChooseAttorneysAddress, RequireSession|CanGoBack,
 		ChooseAttorneysAddress(logger, tmpls.Get("choose_attorneys_address.gohtml"), addressClient, lpaStore))
-	handle(chooseAttorneysSummaryPath, RequireSession|CanGoBack,
+	handle(paths.ChooseAttorneysSummary, RequireSession|CanGoBack,
 		ChooseAttorneysSummary(logger, tmpls.Get("choose_attorneys_summary.gohtml"), lpaStore))
-	handle(removeAttorneyPath, RequireSession|CanGoBack,
+	handle(paths.RemoveAttorney, RequireSession|CanGoBack,
 		RemoveAttorney(logger, tmpls.Get("remove_attorney.gohtml"), lpaStore))
-	handle(howShouldAttorneysMakeDecisionsPath, RequireSession|CanGoBack,
+	handle(paths.HowShouldAttorneysMakeDecisions, RequireSession|CanGoBack,
 		HowShouldAttorneysMakeDecisions(tmpls.Get("how_should_attorneys_make_decisions.gohtml"), lpaStore))
 
-	handle(wantReplacementAttorneysPath, RequireSession|CanGoBack,
+	handle(paths.WantReplacementAttorneys, RequireSession|CanGoBack,
 		WantReplacementAttorneys(tmpls.Get("want_replacement_attorneys.gohtml"), lpaStore))
-	handle(chooseReplacementAttorneysPath, RequireSession|CanGoBack,
+	handle(paths.ChooseReplacementAttorneys, RequireSession|CanGoBack,
 		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), lpaStore, random.String))
-	handle(chooseReplacementAttorneysAddressPath, RequireSession|CanGoBack,
+	handle(paths.ChooseReplacementAttorneysAddress, RequireSession|CanGoBack,
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_replacement_attorneys_address.gohtml"), addressClient, lpaStore))
-	handle(chooseReplacementAttorneysSummaryPath, RequireSession|CanGoBack,
+	handle(paths.ChooseReplacementAttorneysSummary, RequireSession|CanGoBack,
 		ChooseReplacementAttorneysSummary(logger, tmpls.Get("choose_replacement_attorneys_summary.gohtml"), lpaStore))
-	handle(removeReplacementAttorneyPath, RequireSession|CanGoBack,
+	handle(paths.RemoveReplacementAttorney, RequireSession|CanGoBack,
 		RemoveReplacementAttorney(logger, tmpls.Get("remove_replacement_attorney.gohtml"), lpaStore))
-	handle(howShouldReplacementAttorneysStepInPath, RequireSession|CanGoBack,
+	handle(paths.HowShouldReplacementAttorneysStepIn, RequireSession|CanGoBack,
 		HowShouldReplacementAttorneysStepIn(tmpls.Get("how_should_replacement_attorneys_step_in.gohtml"), lpaStore))
-	handle(howShouldReplacementAttorneysMakeDecisionsPath, RequireSession|CanGoBack,
+	handle(paths.HowShouldReplacementAttorneysMakeDecisions, RequireSession|CanGoBack,
 		HowShouldReplacementAttorneysMakeDecisions(tmpls.Get("how_should_replacement_attorneys_make_decisions.gohtml"), lpaStore))
 
-	handle(whenCanTheLpaBeUsedPath, RequireSession|CanGoBack,
+	handle(paths.WhenCanTheLpaBeUsed, RequireSession|CanGoBack,
 		WhenCanTheLpaBeUsed(tmpls.Get("when_can_the_lpa_be_used.gohtml"), lpaStore))
-	handle(restrictionsPath, RequireSession|CanGoBack,
+	handle(paths.Restrictions, RequireSession|CanGoBack,
 		Restrictions(tmpls.Get("restrictions.gohtml"), lpaStore))
-	handle(whoDoYouWantToBeCertificateProviderGuidancePath, RequireSession|CanGoBack,
+	handle(paths.WhoDoYouWantToBeCertificateProviderGuidance, RequireSession|CanGoBack,
 		WhoDoYouWantToBeCertificateProviderGuidance(tmpls.Get("who_do_you_want_to_be_certificate_provider_guidance.gohtml"), lpaStore))
-	handle(certificateProviderDetailsPath, RequireSession|CanGoBack,
+	handle(paths.CertificateProviderDetails, RequireSession|CanGoBack,
 		CertificateProviderDetails(tmpls.Get("certificate_provider_details.gohtml"), lpaStore))
-	handle(howDoYouKnowYourCertificateProviderPath, RequireSession|CanGoBack,
+	handle(paths.HowDoYouKnowYourCertificateProvider, RequireSession|CanGoBack,
 		HowDoYouKnowYourCertificateProvider(tmpls.Get("how_do_you_know_your_certificate_provider.gohtml"), lpaStore))
-	handle(howLongHaveYouKnownCertificateProviderPath, RequireSession|CanGoBack,
+	handle(paths.HowLongHaveYouKnownCertificateProvider, RequireSession|CanGoBack,
 		HowLongHaveYouKnownCertificateProvider(tmpls.Get("how_long_have_you_known_certificate_provider.gohtml"), lpaStore))
 
-	handle(aboutPaymentPath, RequireSession|CanGoBack,
+	handle(paths.AboutPayment, RequireSession|CanGoBack,
 		AboutPayment(logger, tmpls.Get("about_payment.gohtml"), sessionStore, payClient, appPublicUrl, random.String))
-	handle(paymentConfirmationPath, RequireSession|CanGoBack,
+	handle(paths.PaymentConfirmation, RequireSession|CanGoBack,
 		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, lpaStore, sessionStore))
 
-	handle(checkYourLpaPath, RequireSession|CanGoBack,
+	handle(paths.CheckYourLpa, RequireSession|CanGoBack,
 		CheckYourLpa(tmpls.Get("check_your_lpa.gohtml"), lpaStore))
 
-	handle(selectYourIdentityOptionsPath, RequireSession|CanGoBack,
+	handle(paths.SelectYourIdentityOptions, RequireSession|CanGoBack,
 		SelectYourIdentityOptions(tmpls.Get("select_your_identity_options.gohtml"), lpaStore))
-	handle(yourChosenIdentityOptionsPath, RequireSession|CanGoBack,
+	handle(paths.YourChosenIdentityOptions, RequireSession|CanGoBack,
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml"), lpaStore))
-	handle(identityWithYotiPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithYoti, RequireSession|CanGoBack,
 		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), lpaStore, yotiClient, yotiScenarioID))
-	handle(identityWithYotiCallbackPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithYotiCallback, RequireSession|CanGoBack,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, lpaStore))
-	handle(identityWithPassportPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithPassport, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, Passport))
-	handle(identityWithDrivingLicencePath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithDrivingLicence, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, DrivingLicence))
-	handle(identityWithGovernmentGatewayAccountPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithGovernmentGatewayAccount, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, GovernmentGatewayAccount))
-	handle(identityWithDwpAccountPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithDwpAccount, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, DwpAccount))
-	handle(identityWithOnlineBankAccountPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithOnlineBankAccount, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, OnlineBankAccount))
-	handle(identityWithUtilityBillPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithUtilityBill, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, UtilityBill))
-	handle(identityWithCouncilTaxBillPath, RequireSession|CanGoBack,
+	handle(paths.IdentityWithCouncilTaxBill, RequireSession|CanGoBack,
 		IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, CouncilTaxBill))
-	handle(whatHappensWhenSigningPath, RequireSession|CanGoBack,
-		Guidance(tmpls.Get("what_happens_when_signing.gohtml"), howToSignPath, lpaStore))
-	handle(howToSignPath, RequireSession|CanGoBack,
+	handle(paths.WhatHappensWhenSigning, RequireSession|CanGoBack,
+		Guidance(tmpls.Get("what_happens_when_signing.gohtml"), paths.HowToSign, lpaStore))
+	handle(paths.HowToSign, RequireSession|CanGoBack,
 		HowToSign(tmpls.Get("how_to_sign.gohtml"), lpaStore, notifyClient, random.Code))
-	handle(readYourLpaPath, RequireSession|CanGoBack,
+	handle(paths.ReadYourLpa, RequireSession|CanGoBack,
 		ReadYourLpa(tmpls.Get("read_your_lpa.gohtml"), lpaStore))
-	handle(signingConfirmationPath, RequireSession|CanGoBack,
-		Guidance(tmpls.Get("signing_confirmation.gohtml"), taskListPath, lpaStore))
-	handle(dashboardPath, RequireSession|CanGoBack,
+	handle(paths.SigningConfirmation, RequireSession|CanGoBack,
+		Guidance(tmpls.Get("signing_confirmation.gohtml"), paths.TaskList, lpaStore))
+	handle(paths.Dashboard, RequireSession|CanGoBack,
 		Guidance(tmpls.Get("dashboard.gohtml"), "", lpaStore))
 
 	return mux
@@ -326,7 +328,7 @@ const (
 	CanGoBack
 )
 
-func makeHandle(mux *http.ServeMux, logger Logger, store sessions.Store, localizer localize.Localizer, lang Lang, rumConfig RumConfig, staticHash string) func(string, handleOpt, Handler) {
+func makeHandle(mux *http.ServeMux, logger Logger, store sessions.Store, localizer localize.Localizer, lang Lang, rumConfig RumConfig, staticHash string, paths AppPaths) func(string, handleOpt, Handler) {
 	return func(path string, opt handleOpt, h Handler) {
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			sessionID := ""
@@ -335,14 +337,14 @@ func makeHandle(mux *http.ServeMux, logger Logger, store sessions.Store, localiz
 				session, err := store.Get(r, "session")
 				if err != nil {
 					logger.Print(err)
-					http.Redirect(w, r, startPath, http.StatusFound)
+					http.Redirect(w, r, paths.Start, http.StatusFound)
 					return
 				}
 
 				sub, ok := session.Values["sub"].(string)
 				if !ok {
 					logger.Print("sub missing from session")
-					http.Redirect(w, r, startPath, http.StatusFound)
+					http.Redirect(w, r, paths.Start, http.StatusFound)
 					return
 				}
 
@@ -361,6 +363,7 @@ func makeHandle(mux *http.ServeMux, logger Logger, store sessions.Store, localiz
 				CanGoBack:        opt&CanGoBack != 0,
 				RumConfig:        rumConfig,
 				StaticHash:       staticHash,
+				Paths:            paths,
 			}, w, r); err != nil {
 				str := fmt.Sprintf("Error rendering page for path '%s': %s", path, err.Error())
 

--- a/app/internal/page/auth_redirect.go
+++ b/app/internal/page/auth_redirect.go
@@ -13,7 +13,7 @@ type authRedirectClient interface {
 	UserInfo(string) (signin.UserInfo, error)
 }
 
-func AuthRedirect(logger Logger, c authRedirectClient, store sessions.Store, secure bool) http.HandlerFunc {
+func AuthRedirect(logger Logger, c authRedirectClient, store sessions.Store, secure bool, paths AppPaths) http.HandlerFunc {
 	cookieOptions := &sessions.Options{
 		Path:     "/",
 		MaxAge:   24 * 60 * 60,
@@ -63,6 +63,6 @@ func AuthRedirect(logger Logger, c authRedirectClient, store sessions.Store, sec
 			return
 		}
 
-		http.Redirect(w, r, yourDetailsPath, http.StatusFound)
+		http.Redirect(w, r, paths.YourDetails, http.StatusFound)
 	}
 }

--- a/app/internal/page/auth_redirect_test.go
+++ b/app/internal/page/auth_redirect_test.go
@@ -57,11 +57,11 @@ func TestAuthRedirect(t *testing.T) {
 		On("Save", r, w, session).
 		Return(nil)
 
-	AuthRedirect(nil, client, sessionsStore, true)(w, r)
+	AuthRedirect(nil, client, sessionsStore, true, appData.Paths)(w, r)
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, yourDetailsPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.YourDetails, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, client, sessionsStore)
 }
 
@@ -109,7 +109,7 @@ func TestAuthRedirectSessionMissing(t *testing.T) {
 				On("Get", r, "params").
 				Return(tc.session, tc.getErr)
 
-			AuthRedirect(logger, nil, sessionsStore, true)(w, r)
+			AuthRedirect(logger, nil, sessionsStore, true, appData.Paths)(w, r)
 			resp := w.Result()
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -131,7 +131,7 @@ func TestAuthRedirectStateIncorrect(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{Values: map[interface{}]interface{}{"state": "my-state"}}, nil)
 
-	AuthRedirect(logger, nil, sessionsStore, true)(w, r)
+	AuthRedirect(logger, nil, sessionsStore, true, appData.Paths)(w, r)
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -156,7 +156,7 @@ func TestAuthRedirectWhenExchangeErrors(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{Values: map[interface{}]interface{}{"state": "my-state", "nonce": "my-nonce"}}, nil)
 
-	AuthRedirect(logger, client, sessionsStore, true)(w, r)
+	AuthRedirect(logger, client, sessionsStore, true, appData.Paths)(w, r)
 
 	mock.AssertExpectationsForObjects(t, client, logger)
 }
@@ -182,7 +182,7 @@ func TestAuthRedirectWhenUserInfoError(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{Values: map[interface{}]interface{}{"state": "my-state", "nonce": "my-nonce"}}, nil)
 
-	AuthRedirect(logger, client, sessionsStore, true)(w, r)
+	AuthRedirect(logger, client, sessionsStore, true, appData.Paths)(w, r)
 
 	mock.AssertExpectationsForObjects(t, client, logger)
 }

--- a/app/internal/page/certificate_provider_details.go
+++ b/app/internal/page/certificate_provider_details.go
@@ -46,7 +46,7 @@ func CertificateProviderDetails(tmpl template.Template, lpaStore LpaStore) Handl
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, howDoYouKnowYourCertificateProviderPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.HowDoYouKnowYourCertificateProvider, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/certificate_provider_details_test.go
+++ b/app/internal/page/certificate_provider_details_test.go
@@ -153,7 +153,7 @@ func TestPostCertificateProviderDetails(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, howDoYouKnowYourCertificateProviderPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.HowDoYouKnowYourCertificateProvider, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/check_your_lpa.go
+++ b/app/internal/page/check_your_lpa.go
@@ -7,22 +7,11 @@ import (
 )
 
 type checkYourLpaData struct {
-	App                            AppData
-	Errors                         map[string]string
-	Lpa                            *Lpa
-	Form                           *checkYourLpaForm
-	Completed                      bool
-	HowAttorneysMakeDecisionsPath  string
-	ChooseAttorneysPath            string
-	WhenCanLpaBeUsedPath           string
-	RestrictionsPath               string
-	CertificatesProviderPath       string
-	AttorneyDetailsPath            string
-	AttorneyAddressPath            string
-	RemoveAttorneyPath             string
-	ReplacementAttorneyDetailsPath string
-	ReplacementAttorneyAddressPath string
-	RemoveReplacementAttorneyPath  string
+	App       AppData
+	Errors    map[string]string
+	Lpa       *Lpa
+	Form      *checkYourLpaForm
+	Completed bool
 }
 
 func CheckYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
@@ -39,18 +28,7 @@ func CheckYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
 				Checked: lpa.Checked,
 				Happy:   lpa.HappyToShare,
 			},
-			Completed:                      lpa.Tasks.CheckYourLpa == TaskCompleted,
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
+			Completed: lpa.Tasks.CheckYourLpa == TaskCompleted,
 		}
 
 		if r.Method == http.MethodPost {
@@ -66,7 +44,7 @@ func CheckYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
 					return err
 				}
 
-				appData.Lang.Redirect(w, r, taskListPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.TaskList, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/check_your_lpa_test.go
+++ b/app/internal/page/check_your_lpa_test.go
@@ -22,20 +22,9 @@ func TestGetCheckYourLpa(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", w, &checkYourLpaData{
-			App:                            appData,
-			Form:                           &checkYourLpaForm{},
-			Lpa:                            &Lpa{},
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
+			App:  appData,
+			Form: &checkYourLpaForm{},
+			Lpa:  &Lpa{},
 		}).
 		Return(nil)
 
@@ -88,17 +77,6 @@ func TestGetCheckYourLpaFromStore(t *testing.T) {
 				Checked: true,
 				Happy:   true,
 			},
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
 		}).
 		Return(nil)
 
@@ -145,7 +123,7 @@ func TestPostCheckYourLpa(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/choose_attorneys.go
+++ b/app/internal/page/choose_attorneys.go
@@ -38,7 +38,7 @@ func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, randomString fun
 		attorney, attorneyFound := lpa.GetAttorney(r.URL.Query().Get("id"))
 
 		if r.Method == http.MethodGet && len(lpa.Attorneys) > 0 && attorneyFound == false && addAnother == false {
-			appData.Lang.Redirect(w, r, chooseAttorneysSummaryPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneysSummary, http.StatusFound)
 			return nil
 		}
 
@@ -92,7 +92,7 @@ func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, randomString fun
 				from := r.FormValue("from")
 
 				if from == "" {
-					from = fmt.Sprintf("%s?id=%s", chooseAttorneysAddressPath, attorney.ID)
+					from = fmt.Sprintf("%s?id=%s", appData.Paths.ChooseAttorneysAddress, attorney.ID)
 				}
 
 				appData.Lang.Redirect(w, r, from, http.StatusFound)

--- a/app/internal/page/choose_attorneys_address.go
+++ b/app/internal/page/choose_attorneys_address.go
@@ -33,7 +33,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 		attorney, found := lpa.GetAttorney(attorneyId)
 
 		if found == false {
-			appData.Lang.Redirect(w, r, chooseAttorneysPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneys, http.StatusFound)
 			return nil
 		}
 
@@ -63,7 +63,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 				from := r.FormValue("from")
 
 				if from == "" {
-					from = chooseAttorneysSummaryPath
+					from = appData.Paths.ChooseAttorneysSummary
 				}
 
 				appData.Lang.Redirect(w, r, from, http.StatusFound)

--- a/app/internal/page/choose_attorneys_summary.go
+++ b/app/internal/page/choose_attorneys_summary.go
@@ -32,9 +32,9 @@ func ChooseAttorneysSummary(logger Logger, tmpl template.Template, lpaStore LpaS
 		data := &chooseAttorneysSummaryData{
 			App:                 appData,
 			Lpa:                 lpa,
-			AttorneyDetailsPath: chooseAttorneysPath,
-			AttorneyAddressPath: chooseAttorneysAddressPath,
-			RemoveAttorneyPath:  removeAttorneyPath,
+			AttorneyDetailsPath: appData.Paths.ChooseAttorneys,
+			AttorneyAddressPath: appData.Paths.ChooseAttorneysAddress,
+			RemoveAttorneyPath:  appData.Paths.RemoveAttorney,
 			Form:                chooseAttorneysSummaryForm{},
 		}
 
@@ -46,10 +46,10 @@ func ChooseAttorneysSummary(logger Logger, tmpl template.Template, lpaStore LpaS
 			data.Errors = data.Form.Validate()
 
 			if len(data.Errors) == 0 {
-				redirectUrl := wantReplacementAttorneysPath
+				redirectUrl := appData.Paths.WantReplacementAttorneys
 
 				if len(lpa.Attorneys) > 1 {
-					redirectUrl = howShouldAttorneysMakeDecisionsPath
+					redirectUrl = appData.Paths.HowShouldAttorneysMakeDecisions
 				}
 
 				if data.Form.AddAttorney == "yes" {

--- a/app/internal/page/choose_attorneys_summary.go
+++ b/app/internal/page/choose_attorneys_summary.go
@@ -8,13 +8,10 @@ import (
 )
 
 type chooseAttorneysSummaryData struct {
-	App                 AppData
-	AttorneyAddressPath string
-	AttorneyDetailsPath string
-	Errors              map[string]string
-	Form                chooseAttorneysSummaryForm
-	Lpa                 *Lpa
-	RemoveAttorneyPath  string
+	App    AppData
+	Errors map[string]string
+	Form   chooseAttorneysSummaryForm
+	Lpa    *Lpa
 }
 
 type chooseAttorneysSummaryForm struct {
@@ -30,12 +27,9 @@ func ChooseAttorneysSummary(logger Logger, tmpl template.Template, lpaStore LpaS
 		}
 
 		data := &chooseAttorneysSummaryData{
-			App:                 appData,
-			Lpa:                 lpa,
-			AttorneyDetailsPath: appData.Paths.ChooseAttorneys,
-			AttorneyAddressPath: appData.Paths.ChooseAttorneysAddress,
-			RemoveAttorneyPath:  appData.Paths.RemoveAttorney,
-			Form:                chooseAttorneysSummaryForm{},
+			App:  appData,
+			Lpa:  lpa,
+			Form: chooseAttorneysSummaryForm{},
 		}
 
 		if r.Method == http.MethodPost {
@@ -53,7 +47,7 @@ func ChooseAttorneysSummary(logger Logger, tmpl template.Template, lpaStore LpaS
 				}
 
 				if data.Form.AddAttorney == "yes" {
-					redirectUrl = fmt.Sprintf("%s?addAnother=1", data.AttorneyDetailsPath)
+					redirectUrl = fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys)
 				}
 
 				appData.Lang.Redirect(w, r, redirectUrl, http.StatusFound)

--- a/app/internal/page/choose_attorneys_summary_test.go
+++ b/app/internal/page/choose_attorneys_summary_test.go
@@ -22,11 +22,8 @@ func TestGetChooseAttorneysSummary(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", w, &chooseAttorneysSummaryData{
-			App:                 appData,
-			Lpa:                 &Lpa{},
-			AttorneyAddressPath: appData.Paths.ChooseAttorneysAddress,
-			AttorneyDetailsPath: appData.Paths.ChooseAttorneys,
-			RemoveAttorneyPath:  appData.Paths.RemoveAttorney,
+			App: appData,
+			Lpa: &Lpa{},
 		}).
 		Return(nil)
 

--- a/app/internal/page/choose_attorneys_summary_test.go
+++ b/app/internal/page/choose_attorneys_summary_test.go
@@ -24,9 +24,9 @@ func TestGetChooseAttorneysSummary(t *testing.T) {
 		On("Func", w, &chooseAttorneysSummaryData{
 			App:                 appData,
 			Lpa:                 &Lpa{},
-			AttorneyAddressPath: chooseAttorneysAddressPath,
-			AttorneyDetailsPath: chooseAttorneysPath,
-			RemoveAttorneyPath:  removeAttorneyPath,
+			AttorneyAddressPath: appData.Paths.ChooseAttorneysAddress,
+			AttorneyDetailsPath: appData.Paths.ChooseAttorneys,
+			RemoveAttorneyPath:  appData.Paths.RemoveAttorney,
 		}).
 		Return(nil)
 

--- a/app/internal/page/choose_replacement_attorneys.go
+++ b/app/internal/page/choose_replacement_attorneys.go
@@ -25,7 +25,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, rando
 		ra, attorneyFound := lpa.GetReplacementAttorney(r.URL.Query().Get("id"))
 
 		if r.Method == http.MethodGet && len(lpa.ReplacementAttorneys) > 0 && attorneyFound == false && addAnother == false {
-			appData.Lang.Redirect(w, r, chooseReplacementAttorneysSummaryPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseReplacementAttorneysSummary, http.StatusFound)
 			return nil
 		}
 
@@ -78,7 +78,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, rando
 				from := r.FormValue("from")
 
 				if from == "" {
-					from = fmt.Sprintf("%s?id=%s", chooseReplacementAttorneysAddressPath, ra.ID)
+					from = fmt.Sprintf("%s?id=%s", appData.Paths.ChooseReplacementAttorneysAddress, ra.ID)
 				}
 
 				appData.Lang.Redirect(w, r, from, http.StatusFound)

--- a/app/internal/page/choose_replacement_attorneys_address.go
+++ b/app/internal/page/choose_replacement_attorneys_address.go
@@ -51,7 +51,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 				from := r.FormValue("from")
 
 				if from == "" {
-					from = chooseReplacementAttorneysSummaryPath
+					from = appData.Paths.ChooseReplacementAttorneysSummary
 				}
 
 				appData.Lang.Redirect(w, r, from, http.StatusFound)

--- a/app/internal/page/choose_replacement_attorneys_summary.go
+++ b/app/internal/page/choose_replacement_attorneys_summary.go
@@ -8,13 +8,10 @@ import (
 )
 
 type chooseReplacementAttorneysSummaryData struct {
-	App                            AppData
-	ReplacementAttorneyAddressPath string
-	ReplacementAttorneyDetailsPath string
-	Errors                         map[string]string
-	Form                           chooseAttorneysSummaryForm
-	Lpa                            *Lpa
-	RemoveReplacementAttorneyPath  string
+	App    AppData
+	Errors map[string]string
+	Form   chooseAttorneysSummaryForm
+	Lpa    *Lpa
 }
 
 func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, lpaStore LpaStore) Handler {
@@ -26,12 +23,9 @@ func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, lp
 		}
 
 		data := &chooseReplacementAttorneysSummaryData{
-			App:                            appData,
-			Lpa:                            lpa,
-			ReplacementAttorneyDetailsPath: appData.Paths.ChooseReplacementAttorneys,
-			ReplacementAttorneyAddressPath: appData.Paths.ChooseReplacementAttorneysAddress,
-			Form:                           chooseAttorneysSummaryForm{},
-			RemoveReplacementAttorneyPath:  appData.Paths.RemoveReplacementAttorney,
+			App:  appData,
+			Lpa:  lpa,
+			Form: chooseAttorneysSummaryForm{},
 		}
 
 		if r.Method == http.MethodPost {
@@ -53,7 +47,7 @@ func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, lp
 				}
 
 				if data.Form.AddAttorney == "yes" {
-					redirectUrl = fmt.Sprintf("%s?addAnother=1", data.ReplacementAttorneyDetailsPath)
+					redirectUrl = fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseReplacementAttorneys)
 				}
 
 				appData.Lang.Redirect(w, r, redirectUrl, http.StatusFound)

--- a/app/internal/page/choose_replacement_attorneys_summary.go
+++ b/app/internal/page/choose_replacement_attorneys_summary.go
@@ -28,10 +28,10 @@ func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, lp
 		data := &chooseReplacementAttorneysSummaryData{
 			App:                            appData,
 			Lpa:                            lpa,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
+			ReplacementAttorneyDetailsPath: appData.Paths.ChooseReplacementAttorneys,
+			ReplacementAttorneyAddressPath: appData.Paths.ChooseReplacementAttorneysAddress,
 			Form:                           chooseAttorneysSummaryForm{},
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
+			RemoveReplacementAttorneyPath:  appData.Paths.RemoveReplacementAttorney,
 		}
 
 		if r.Method == http.MethodPost {
@@ -45,11 +45,11 @@ func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, lp
 				var redirectUrl string
 
 				if len(lpa.ReplacementAttorneys) > 1 && len(lpa.Attorneys) > 1 && lpa.HowAttorneysMakeDecisions == Jointly {
-					redirectUrl = howShouldReplacementAttorneysMakeDecisionsPath
+					redirectUrl = appData.Paths.HowShouldReplacementAttorneysMakeDecisions
 				} else if len(lpa.Attorneys) > 1 && lpa.HowAttorneysMakeDecisions == JointlyAndSeverally {
-					redirectUrl = howShouldReplacementAttorneysStepInPath
+					redirectUrl = appData.Paths.HowShouldReplacementAttorneysStepIn
 				} else {
-					redirectUrl = whenCanTheLpaBeUsedPath
+					redirectUrl = appData.Paths.WhenCanTheLpaBeUsed
 				}
 
 				if data.Form.AddAttorney == "yes" {

--- a/app/internal/page/choose_replacement_attorneys_summary_test.go
+++ b/app/internal/page/choose_replacement_attorneys_summary_test.go
@@ -24,9 +24,9 @@ func TestGetChooseReplacementAttorneysSummary(t *testing.T) {
 		On("Func", w, &chooseReplacementAttorneysSummaryData{
 			App:                            appData,
 			Lpa:                            &Lpa{},
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
+			ReplacementAttorneyAddressPath: appData.Paths.ChooseReplacementAttorneysAddress,
+			ReplacementAttorneyDetailsPath: appData.Paths.ChooseReplacementAttorneys,
+			RemoveReplacementAttorneyPath:  appData.Paths.RemoveReplacementAttorney,
 		}).
 		Return(nil)
 

--- a/app/internal/page/choose_replacement_attorneys_summary_test.go
+++ b/app/internal/page/choose_replacement_attorneys_summary_test.go
@@ -22,11 +22,8 @@ func TestGetChooseReplacementAttorneysSummary(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", w, &chooseReplacementAttorneysSummaryData{
-			App:                            appData,
-			Lpa:                            &Lpa{},
-			ReplacementAttorneyAddressPath: appData.Paths.ChooseReplacementAttorneysAddress,
-			ReplacementAttorneyDetailsPath: appData.Paths.ChooseReplacementAttorneys,
-			RemoveReplacementAttorneyPath:  appData.Paths.RemoveReplacementAttorney,
+			App: appData,
+			Lpa: &Lpa{},
 		}).
 		Return(nil)
 

--- a/app/internal/page/cookie_consent.go
+++ b/app/internal/page/cookie_consent.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-func CookieConsent() http.HandlerFunc {
+func CookieConsent(paths AppPaths) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		consent := "reject"
 		if r.PostFormValue("cookies") == "accept" {
@@ -20,7 +20,7 @@ func CookieConsent() http.HandlerFunc {
 
 		redirectURL := r.PostFormValue("cookies-redirect")
 		if len(redirectURL) <= 1 || redirectURL[0] != '/' || redirectURL[1] == '/' || redirectURL[1] == '\\' {
-			redirectURL = startPath
+			redirectURL = paths.Start
 		}
 
 		http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/app/internal/page/cookie_consent_test.go
+++ b/app/internal/page/cookie_consent_test.go
@@ -16,11 +16,11 @@ func TestCookieConsent(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("cookies="+consent))
 			r.Header.Add("Content-Type", formUrlEncoded)
 
-			CookieConsent()(w, r)
+			CookieConsent(appData.Paths)(w, r)
 			resp := w.Result()
 
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, startPath, resp.Header.Get("Location"))
+			assert.Equal(t, appData.Paths.Start, resp.Header.Get("Location"))
 
 			cookies := resp.Cookies()
 			if assert.Len(t, cookies, 1) {
@@ -40,7 +40,7 @@ func TestCookieConsentRedirect(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("cookies-redirect=/here&cookies=accept"))
 	r.Header.Add("Content-Type", formUrlEncoded)
 
-	CookieConsent()(w, r)
+	CookieConsent(appData.Paths)(w, r)
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
@@ -62,11 +62,11 @@ func TestCookieConsentBadRedirect(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("cookies-redirect=http://google&cookies=accept"))
 	r.Header.Add("Content-Type", formUrlEncoded)
 
-	CookieConsent()(w, r)
+	CookieConsent(appData.Paths)(w, r)
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, startPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.Start, resp.Header.Get("Location"))
 
 	cookies := resp.Cookies()
 	if assert.Len(t, cookies, 1) {

--- a/app/internal/page/how_do_you_know_your_certificate_provider.go
+++ b/app/internal/page/how_do_you_know_your_certificate_provider.go
@@ -55,9 +55,9 @@ func HowDoYouKnowYourCertificateProvider(tmpl template.Template, lpaStore LpaSto
 				}
 
 				if requireLength {
-					appData.Lang.Redirect(w, r, howLongHaveYouKnownCertificateProviderPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.HowLongHaveYouKnownCertificateProvider, http.StatusFound)
 				} else {
-					appData.Lang.Redirect(w, r, checkYourLpaPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.CheckYourLpa, http.StatusFound)
 				}
 				return nil
 			}

--- a/app/internal/page/how_do_you_know_your_certificate_provider_test.go
+++ b/app/internal/page/how_do_you_know_your_certificate_provider_test.go
@@ -122,7 +122,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				Relationship: "legal-professional",
 			},
 			taskState: TaskCompleted,
-			redirect:  checkYourLpaPath,
+			redirect:  appData.Paths.CheckYourLpa,
 		},
 		"health-professional": {
 			form: url.Values{"how": {"health-professional"}},
@@ -131,7 +131,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				Relationship: "health-professional",
 			},
 			taskState: TaskCompleted,
-			redirect:  checkYourLpaPath,
+			redirect:  appData.Paths.CheckYourLpa,
 		},
 		"other": {
 			form: url.Values{"how": {"other"}, "description": {"This"}},
@@ -142,7 +142,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength:      "gte-2-years",
 			},
 			taskState: TaskInProgress,
-			redirect:  howLongHaveYouKnownCertificateProviderPath,
+			redirect:  appData.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - friend": {
 			form: url.Values{"how": {"friend"}},
@@ -152,7 +152,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: TaskInProgress,
-			redirect:  howLongHaveYouKnownCertificateProviderPath,
+			redirect:  appData.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - neighbour": {
 			form: url.Values{"how": {"neighbour"}},
@@ -162,7 +162,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: TaskInProgress,
-			redirect:  howLongHaveYouKnownCertificateProviderPath,
+			redirect:  appData.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - colleague": {
 			form: url.Values{"how": {"colleague"}},
@@ -172,7 +172,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: TaskInProgress,
-			redirect:  howLongHaveYouKnownCertificateProviderPath,
+			redirect:  appData.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 	}
 

--- a/app/internal/page/how_long_have_you_known_certificate_provider.go
+++ b/app/internal/page/how_long_have_you_known_certificate_provider.go
@@ -36,7 +36,7 @@ func HowLongHaveYouKnownCertificateProvider(tmpl template.Template, lpaStore Lpa
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, checkYourLpaPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.CheckYourLpa, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/how_long_have_you_known_certificate_provider_test.go
+++ b/app/internal/page/how_long_have_you_known_certificate_provider_test.go
@@ -134,7 +134,7 @@ func TestPostHowLongHaveYouKnownCertificateProvider(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, checkYourLpaPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.CheckYourLpa, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/how_should_attorneys_make_decisions.go
+++ b/app/internal/page/how_should_attorneys_make_decisions.go
@@ -48,7 +48,7 @@ func HowShouldAttorneysMakeDecisions(tmpl template.Template, lpaStore LpaStore) 
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, wantReplacementAttorneysPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.WantReplacementAttorneys, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/how_should_attorneys_make_decisions_test.go
+++ b/app/internal/page/how_should_attorneys_make_decisions_test.go
@@ -139,7 +139,7 @@ func TestPostHowShouldAttorneysMakeDecisions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, wantReplacementAttorneysPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.WantReplacementAttorneys, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -197,7 +197,7 @@ func TestPostHowShouldAttorneysMakeDecisionsFromStore(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, wantReplacementAttorneysPath, resp.Header.Get("Location"))
+			assert.Equal(t, appData.Paths.WantReplacementAttorneys, resp.Header.Get("Location"))
 			mock.AssertExpectationsForObjects(t, lpaStore)
 		})
 	}

--- a/app/internal/page/how_should_replacement_attorneys_make_decisions.go
+++ b/app/internal/page/how_should_replacement_attorneys_make_decisions.go
@@ -43,7 +43,7 @@ func HowShouldReplacementAttorneysMakeDecisions(tmpl template.Template, lpaStore
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, taskListPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.TaskList, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/how_should_replacement_attorneys_make_decisions_test.go
+++ b/app/internal/page/how_should_replacement_attorneys_make_decisions_test.go
@@ -139,7 +139,7 @@ func TestPostHowShouldReplacementAttorneysMakeDecisions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -197,7 +197,7 @@ func TestPostHowShouldReplacementAttorneysMakeDecisionsFromStore(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+			assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 			mock.AssertExpectationsForObjects(t, lpaStore)
 		})
 	}

--- a/app/internal/page/how_should_replacement_attorneys_step_in.go
+++ b/app/internal/page/how_should_replacement_attorneys_step_in.go
@@ -49,13 +49,13 @@ func HowShouldReplacementAttorneysStepIn(tmpl template.Template, lpaStore LpaSto
 					return err
 				}
 
-				redirectUrl := taskListPath
+				redirectUrl := appData.Paths.TaskList
 
 				if len(lpa.Attorneys) > 1 &&
 					lpa.HowAttorneysMakeDecisions == JointlyAndSeverally &&
 					lpa.HowShouldReplacementAttorneysStepIn == AllCanNoLongerAct &&
 					len(lpa.ReplacementAttorneys) > 1 {
-					redirectUrl = howShouldReplacementAttorneysMakeDecisionsPath
+					redirectUrl = appData.Paths.HowShouldReplacementAttorneysMakeDecisions
 
 				}
 

--- a/app/internal/page/how_should_replacement_attorneys_step_in_test.go
+++ b/app/internal/page/how_should_replacement_attorneys_step_in_test.go
@@ -120,7 +120,7 @@ func TestPostHowShouldReplacementAttorneysStepIn(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, template, lpaStore)
 }
 
@@ -138,7 +138,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			},
 			HowAttorneysMakeDecisions:           "doesnt matter",
 			HowShouldReplacementAttorneysStepIn: "doesnt matter",
-			ExpectedRedirectUrl:                 taskListPath,
+			ExpectedRedirectUrl:                 appData.Paths.TaskList,
 		},
 		"multiple attorneys acting jointly and severally replacements step in when none left": {
 			Attorneys: []Attorney{
@@ -151,7 +151,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			},
 			HowAttorneysMakeDecisions:           "jointly-and-severally",
 			HowShouldReplacementAttorneysStepIn: AllCanNoLongerAct,
-			ExpectedRedirectUrl:                 howShouldReplacementAttorneysMakeDecisionsPath,
+			ExpectedRedirectUrl:                 appData.Paths.HowShouldReplacementAttorneysMakeDecisions,
 		},
 		"multiple attorneys acting jointly and severally replacements step in when one loses capacity": {
 			Attorneys: []Attorney{
@@ -160,7 +160,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			},
 			HowAttorneysMakeDecisions:           "jointly-and-severally",
 			HowShouldReplacementAttorneysStepIn: OneCanNoLongerAct,
-			ExpectedRedirectUrl:                 taskListPath,
+			ExpectedRedirectUrl:                 appData.Paths.TaskList,
 		},
 		"multiple attorneys acting jointly": {
 			Attorneys: []Attorney{
@@ -169,7 +169,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			},
 			HowAttorneysMakeDecisions:           "jointly-and-severally",
 			HowShouldReplacementAttorneysStepIn: "doesnt matter",
-			ExpectedRedirectUrl:                 taskListPath,
+			ExpectedRedirectUrl:                 appData.Paths.TaskList,
 		},
 	}
 
@@ -272,7 +272,7 @@ func TestPostHowShouldReplacementAttorneysStepInFromStore(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+			assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 			mock.AssertExpectationsForObjects(t, template, lpaStore)
 		})
 	}

--- a/app/internal/page/how_to_sign.go
+++ b/app/internal/page/how_to_sign.go
@@ -40,7 +40,7 @@ func HowToSign(tmpl template.Template, lpaStore LpaStore, notifyClient NotifyCli
 				return err
 			}
 
-			appData.Lang.Redirect(w, r, readYourLpaPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ReadYourLpa, http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/how_to_sign_test.go
+++ b/app/internal/page/how_to_sign_test.go
@@ -121,7 +121,7 @@ func TestPostHowToSign(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, readYourLpaPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.ReadYourLpa, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore, notifyClient)
 }
 

--- a/app/internal/page/how_would_you_like_to_be_contacted.go
+++ b/app/internal/page/how_would_you_like_to_be_contacted.go
@@ -33,7 +33,7 @@ func HowWouldYouLikeToBeContacted(tmpl template.Template, lpaStore LpaStore) Han
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, taskListPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.TaskList, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/how_would_you_like_to_be_contacted_test.go
+++ b/app/internal/page/how_would_you_like_to_be_contacted_test.go
@@ -126,7 +126,7 @@ func TestPostHowWouldYouLikeToBeContacted(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/identity_options.go
+++ b/app/internal/page/identity_options.go
@@ -97,22 +97,23 @@ type IdentityOptions struct {
 	Selected []IdentityOption
 	First    IdentityOption
 	Second   IdentityOption
+	Paths    AppPaths
 }
 
 func (o IdentityOptions) NextPath(current IdentityOption) string {
 	identityOptionPaths := map[IdentityOption]string{
-		Yoti:                     identityWithYotiPath,
-		Passport:                 identityWithPassportPath,
-		DrivingLicence:           identityWithDrivingLicencePath,
-		GovernmentGatewayAccount: identityWithGovernmentGatewayAccountPath,
-		DwpAccount:               identityWithDwpAccountPath,
-		OnlineBankAccount:        identityWithOnlineBankAccountPath,
-		UtilityBill:              identityWithUtilityBillPath,
-		CouncilTaxBill:           identityWithCouncilTaxBillPath,
+		Yoti:                     o.Paths.IdentityWithYoti,
+		Passport:                 o.Paths.IdentityWithPassport,
+		DrivingLicence:           o.Paths.IdentityWithDrivingLicence,
+		GovernmentGatewayAccount: o.Paths.IdentityWithGovernmentGatewayAccount,
+		DwpAccount:               o.Paths.IdentityWithDwpAccount,
+		OnlineBankAccount:        o.Paths.IdentityWithOnlineBankAccount,
+		UtilityBill:              o.Paths.IdentityWithUtilityBill,
+		CouncilTaxBill:           o.Paths.IdentityWithCouncilTaxBill,
 	}
 
 	if current == o.Second {
-		return whatHappensWhenSigningPath
+		return o.Paths.WhatHappensWhenSigning
 	}
 
 	if current == o.First {

--- a/app/internal/page/identity_options.go
+++ b/app/internal/page/identity_options.go
@@ -97,23 +97,22 @@ type IdentityOptions struct {
 	Selected []IdentityOption
 	First    IdentityOption
 	Second   IdentityOption
-	Paths    AppPaths
 }
 
-func (o IdentityOptions) NextPath(current IdentityOption) string {
+func (o IdentityOptions) NextPath(current IdentityOption, paths AppPaths) string {
 	identityOptionPaths := map[IdentityOption]string{
-		Yoti:                     o.Paths.IdentityWithYoti,
-		Passport:                 o.Paths.IdentityWithPassport,
-		DrivingLicence:           o.Paths.IdentityWithDrivingLicence,
-		GovernmentGatewayAccount: o.Paths.IdentityWithGovernmentGatewayAccount,
-		DwpAccount:               o.Paths.IdentityWithDwpAccount,
-		OnlineBankAccount:        o.Paths.IdentityWithOnlineBankAccount,
-		UtilityBill:              o.Paths.IdentityWithUtilityBill,
-		CouncilTaxBill:           o.Paths.IdentityWithCouncilTaxBill,
+		Yoti:                     paths.IdentityWithYoti,
+		Passport:                 paths.IdentityWithPassport,
+		DrivingLicence:           paths.IdentityWithDrivingLicence,
+		GovernmentGatewayAccount: paths.IdentityWithGovernmentGatewayAccount,
+		DwpAccount:               paths.IdentityWithDwpAccount,
+		OnlineBankAccount:        paths.IdentityWithOnlineBankAccount,
+		UtilityBill:              paths.IdentityWithUtilityBill,
+		CouncilTaxBill:           paths.IdentityWithCouncilTaxBill,
 	}
 
 	if current == o.Second {
-		return o.Paths.WhatHappensWhenSigning
+		return paths.WhatHappensWhenSigning
 	}
 
 	if current == o.First {

--- a/app/internal/page/identity_options_test.go
+++ b/app/internal/page/identity_options_test.go
@@ -22,11 +22,11 @@ func TestIdentityOptionLabel(t *testing.T) {
 }
 
 func TestIdentityOptionNextPath(t *testing.T) {
-	options := IdentityOptions{First: Yoti, Second: GovernmentGatewayAccount, Paths: appData.Paths}
+	options := IdentityOptions{First: Yoti, Second: GovernmentGatewayAccount}
 
-	assert.Equal(t, options.Paths.IdentityWithYoti, options.NextPath(IdentityOptionUnknown))
-	assert.Equal(t, options.Paths.IdentityWithGovernmentGatewayAccount, options.NextPath(Yoti))
-	assert.Equal(t, options.Paths.WhatHappensWhenSigning, options.NextPath(GovernmentGatewayAccount))
+	assert.Equal(t, appData.Paths.IdentityWithYoti, options.NextPath(IdentityOptionUnknown, appData.Paths))
+	assert.Equal(t, appData.Paths.IdentityWithGovernmentGatewayAccount, options.NextPath(Yoti, appData.Paths))
+	assert.Equal(t, appData.Paths.WhatHappensWhenSigning, options.NextPath(GovernmentGatewayAccount, appData.Paths))
 }
 
 func TestIdentityOptionsRanked(t *testing.T) {

--- a/app/internal/page/identity_options_test.go
+++ b/app/internal/page/identity_options_test.go
@@ -22,11 +22,11 @@ func TestIdentityOptionLabel(t *testing.T) {
 }
 
 func TestIdentityOptionNextPath(t *testing.T) {
-	options := IdentityOptions{First: Yoti, Second: GovernmentGatewayAccount}
+	options := IdentityOptions{First: Yoti, Second: GovernmentGatewayAccount, Paths: appData.Paths}
 
-	assert.Equal(t, identityWithYotiPath, options.NextPath(IdentityOptionUnknown))
-	assert.Equal(t, identityWithGovernmentGatewayAccountPath, options.NextPath(Yoti))
-	assert.Equal(t, whatHappensWhenSigningPath, options.NextPath(GovernmentGatewayAccount))
+	assert.Equal(t, options.Paths.IdentityWithYoti, options.NextPath(IdentityOptionUnknown))
+	assert.Equal(t, options.Paths.IdentityWithGovernmentGatewayAccount, options.NextPath(Yoti))
+	assert.Equal(t, options.Paths.WhatHappensWhenSigning, options.NextPath(GovernmentGatewayAccount))
 }
 
 func TestIdentityOptionsRanked(t *testing.T) {

--- a/app/internal/page/identity_with_todo.go
+++ b/app/internal/page/identity_with_todo.go
@@ -20,7 +20,7 @@ func IdentityWithTodo(tmpl template.Template, lpaStore LpaStore, identityOption 
 				return err
 			}
 
-			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(identityOption), http.StatusFound)
+			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(identityOption, appData.Paths), http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/identity_with_todo_test.go
+++ b/app/internal/page/identity_with_todo_test.go
@@ -38,6 +38,7 @@ func TestPostIdentityWithTodo(t *testing.T) {
 		IdentityOptions: IdentityOptions{
 			First:  Passport,
 			Second: GovernmentGatewayAccount,
+			Paths:  appData.Paths,
 		},
 	}, nil)
 
@@ -48,7 +49,7 @@ func TestPostIdentityWithTodo(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, identityWithGovernmentGatewayAccountPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.IdentityWithGovernmentGatewayAccount, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/identity_with_todo_test.go
+++ b/app/internal/page/identity_with_todo_test.go
@@ -38,7 +38,6 @@ func TestPostIdentityWithTodo(t *testing.T) {
 		IdentityOptions: IdentityOptions{
 			First:  Passport,
 			Second: GovernmentGatewayAccount,
-			Paths:  appData.Paths,
 		},
 	}, nil)
 

--- a/app/internal/page/identity_with_yoti.go
+++ b/app/internal/page/identity_with_yoti.go
@@ -21,7 +21,7 @@ func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient Yoti
 		}
 
 		if lpa.YotiUserData.OK || yotiClient.IsTest() {
-			appData.Lang.Redirect(w, r, identityWithYotiCallbackPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.IdentityWithYotiCallback, http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/identity_with_yoti_callback.go
+++ b/app/internal/page/identity_with_yoti_callback.go
@@ -22,7 +22,7 @@ func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, lpa
 		}
 
 		if r.Method == http.MethodPost {
-			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(Yoti), http.StatusFound)
+			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(Yoti, appData.Paths), http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/identity_with_yoti_callback_test.go
+++ b/app/internal/page/identity_with_yoti_callback_test.go
@@ -128,7 +128,6 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 		IdentityOptions: IdentityOptions{
 			First:  Yoti,
 			Second: Passport,
-			Paths:  appData.Paths,
 		}}, nil)
 
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)

--- a/app/internal/page/identity_with_yoti_callback_test.go
+++ b/app/internal/page/identity_with_yoti_callback_test.go
@@ -124,7 +124,12 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	lpaStore := &mockLpaStore{}
-	lpaStore.On("Get", mock.Anything, "session-id").Return(&Lpa{IdentityOptions: IdentityOptions{First: Yoti, Second: Passport}}, nil)
+	lpaStore.On("Get", mock.Anything, "session-id").Return(&Lpa{
+		IdentityOptions: IdentityOptions{
+			First:  Yoti,
+			Second: Passport,
+			Paths:  appData.Paths,
+		}}, nil)
 
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
@@ -133,5 +138,5 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, identityWithPassportPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.IdentityWithPassport, resp.Header.Get("Location"))
 }

--- a/app/internal/page/identity_with_yoti_test.go
+++ b/app/internal/page/identity_with_yoti_test.go
@@ -70,7 +70,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, identityWithYotiCallbackPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.IdentityWithYotiCallback, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -90,7 +90,7 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, identityWithYotiCallbackPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.IdentityWithYotiCallback, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore, yotiClient)
 }
 

--- a/app/internal/page/lpa_type.go
+++ b/app/internal/page/lpa_type.go
@@ -33,7 +33,7 @@ func LpaType(tmpl template.Template, lpaStore LpaStore) Handler {
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, taskListPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.TaskList, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/lpa_type_test.go
+++ b/app/internal/page/lpa_type_test.go
@@ -128,7 +128,7 @@ func TestPostLpaType(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/paths.go
+++ b/app/internal/page/paths.go
@@ -1,52 +1,55 @@
 package page
 
-const (
-	AuthPath         = "/auth"
-	AuthRedirectPath = "/auth/redirect"
-
-	aboutPaymentPath                                = "/about-payment"
-	certificateProviderDetailsPath                  = "/certificate-provider-details"
-	checkYourLpaPath                                = "/check-your-lpa"
-	chooseAttorneysAddressPath                      = "/choose-attorneys-address"
-	chooseAttorneysPath                             = "/choose-attorneys"
-	chooseAttorneysSummaryPath                      = "/choose-attorneys-summary"
-	chooseReplacementAttorneysPath                  = "/choose-replacement-attorneys"
-	chooseReplacementAttorneysAddressPath           = "/choose-replacement-attorneys-address"
-	chooseReplacementAttorneysSummaryPath           = "/choose-replacement-attorneys-summary"
-	dashboardPath                                   = "/dashboard"
-	howDoYouKnowYourCertificateProviderPath         = "/how-do-you-know-your-certificate-provider"
-	howLongHaveYouKnownCertificateProviderPath      = "/how-long-have-you-known-certificate-provider"
-	howShouldReplacementAttorneysMakeDecisionsPath  = "/how-should-replacement-attorneys-make-decisions"
-	howShouldReplacementAttorneysStepInPath         = "/how-should-replacement-attorneys-step-in"
-	howShouldAttorneysMakeDecisionsPath             = "/how-should-attorneys-make-decisions"
-	howToSignPath                                   = "/how-to-sign"
-	howWouldYouLikeToBeContactedPath                = "/how-would-you-like-to-be-contacted"
-	identityConfirmedPath                           = "/identity-confirmed"
-	identityWithCouncilTaxBillPath                  = "/id/council-tax-bill"
-	identityWithDrivingLicencePath                  = "/id/driving-licence"
-	identityWithDwpAccountPath                      = "/id/dwp-account"
-	identityWithGovernmentGatewayAccountPath        = "/id/government-gateway-account"
-	identityWithOnlineBankAccountPath               = "/id/online-bank-account"
-	identityWithPassportPath                        = "/id/passport"
-	identityWithUtilityBillPath                     = "/id/utility-bill"
-	identityWithYotiCallbackPath                    = "/id/yoti/callback"
-	identityWithYotiPath                            = "/id/yoti"
-	lpaTypePath                                     = "/lpa-type"
-	paymentConfirmationPath                         = "/payment-confirmation"
-	readYourLpaPath                                 = "/read-your-lpa"
-	removeAttorneyPath                              = "/remove-attorney"
-	removeReplacementAttorneyPath                   = "/remove-replacement-attorney"
-	restrictionsPath                                = "/restrictions"
-	selectYourIdentityOptionsPath                   = "/select-your-identity-options"
-	signingConfirmationPath                         = "/signing-confirmation"
-	startPath                                       = "/start"
-	taskListPath                                    = "/task-list"
-	wantReplacementAttorneysPath                    = "/want-replacement-attorneys"
-	whatHappensWhenSigningPath                      = "/what-happens-when-signing"
-	whenCanTheLpaBeUsedPath                         = "/when-can-the-lpa-be-used"
-	whoDoYouWantToBeCertificateProviderGuidancePath = "/who-do-you-want-to-be-certificate-provider-guidance"
-	whoIsTheLpaForPath                              = "/who-is-the-lpa-for"
-	yourAddressPath                                 = "/your-address"
-	yourChosenIdentityOptionsPath                   = "/your-chosen-identity-options"
-	yourDetailsPath                                 = "/your-details"
-)
+type AppPaths struct {
+	Auth                                        string
+	AuthRedirect                                string
+	AboutPayment                                string
+	CertificateProviderDetails                  string
+	CheckYourLpa                                string
+	ChooseAttorneysAddress                      string
+	ChooseAttorneys                             string
+	ChooseAttorneysSummary                      string
+	ChooseReplacementAttorneys                  string
+	ChooseReplacementAttorneysAddress           string
+	ChooseReplacementAttorneysSummary           string
+	CookiesConsent                              string
+	Dashboard                                   string
+	HealthCheck                                 string
+	HowDoYouKnowYourCertificateProvider         string
+	HowLongHaveYouKnownCertificateProvider      string
+	HowShouldReplacementAttorneysMakeDecisions  string
+	HowShouldReplacementAttorneysStepIn         string
+	HowShouldAttorneysMakeDecisions             string
+	HowToSign                                   string
+	HowWouldYouLikeToBeContacted                string
+	IdentityConfirmed                           string
+	IdentityWithCouncilTaxBill                  string
+	IdentityWithDrivingLicence                  string
+	IdentityWithDwpAccount                      string
+	IdentityWithGovernmentGatewayAccount        string
+	IdentityWithOnlineBankAccount               string
+	IdentityWithPassport                        string
+	IdentityWithUtilityBill                     string
+	IdentityWithYotiCallback                    string
+	IdentityWithYoti                            string
+	LpaType                                     string
+	PaymentConfirmation                         string
+	ReadYourLpa                                 string
+	RemoveAttorney                              string
+	RemoveReplacementAttorney                   string
+	Restrictions                                string
+	Root                                        string
+	SelectYourIdentityOptions                   string
+	SigningConfirmation                         string
+	Start                                       string
+	TaskList                                    string
+	TestingStart                                string
+	WantReplacementAttorneys                    string
+	WhatHappensWhenSigning                      string
+	WhenCanTheLpaBeUsed                         string
+	WhoDoYouWantToBeCertificateProviderGuidance string
+	WhoIsTheLpaFor                              string
+	YourAddress                                 string
+	YourChosenIdentityOptions                   string
+	YourDetails                                 string
+}

--- a/app/internal/page/payment_confirmation.go
+++ b/app/internal/page/payment_confirmation.go
@@ -44,7 +44,7 @@ func PaymentConfirmation(logger Logger, tmpl template.Template, client PayClient
 		data := &paymentConfirmationData{
 			App:              appData,
 			PaymentReference: payment.Reference,
-			Continue:         taskListPath,
+			Continue:         appData.Paths.TaskList,
 		}
 
 		payCookie.Options.MaxAge = -1

--- a/app/internal/page/payment_confirmation_test.go
+++ b/app/internal/page/payment_confirmation_test.go
@@ -20,7 +20,7 @@ func TestGetPaymentConfirmation(t *testing.T) {
 
 	template := &mockTemplate{}
 	template.
-		On("Func", w, &paymentConfirmationData{App: appData, PaymentReference: "123456789012", Continue: taskListPath}).
+		On("Func", w, &paymentConfirmationData{App: appData, PaymentReference: "123456789012", Continue: appData.Paths.TaskList}).
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodGet, "/payment-confirmation", nil)

--- a/app/internal/page/read_your_lpa.go
+++ b/app/internal/page/read_your_lpa.go
@@ -8,22 +8,11 @@ import (
 )
 
 type readYourLpaData struct {
-	App                            AppData
-	Errors                         map[string]string
-	Lpa                            *Lpa
-	EnteredSignature               bool
-	Form                           *readYourLpaForm
-	HowAttorneysMakeDecisionsPath  string
-	ChooseAttorneysPath            string
-	WhenCanLpaBeUsedPath           string
-	RestrictionsPath               string
-	CertificatesProviderPath       string
-	AttorneyDetailsPath            string
-	AttorneyAddressPath            string
-	RemoveAttorneyPath             string
-	ReplacementAttorneyDetailsPath string
-	ReplacementAttorneyAddressPath string
-	RemoveReplacementAttorneyPath  string
+	App              AppData
+	Errors           map[string]string
+	Lpa              *Lpa
+	EnteredSignature bool
+	Form             *readYourLpaForm
 }
 
 func ReadYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
@@ -41,17 +30,6 @@ func ReadYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
 				Confirm:   lpa.ConfirmFreeWill,
 				Signature: lpa.EnteredSignatureCode,
 			},
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
 		}
 
 		if r.Method == http.MethodPost {
@@ -73,7 +51,7 @@ func ReadYourLpa(tmpl template.Template, lpaStore LpaStore) Handler {
 					return err
 				}
 
-				appData.Lang.Redirect(w, r, signingConfirmationPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.SigningConfirmation, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/read_your_lpa_test.go
+++ b/app/internal/page/read_your_lpa_test.go
@@ -22,20 +22,9 @@ func TestGetReadYourLpa(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", w, &readYourLpaData{
-			App:                            appData,
-			Form:                           &readYourLpaForm{},
-			Lpa:                            &Lpa{},
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
+			App:  appData,
+			Form: &readYourLpaForm{},
+			Lpa:  &Lpa{},
 		}).
 		Return(nil)
 
@@ -91,17 +80,6 @@ func TestGetReadYourLpaFromStore(t *testing.T) {
 				Confirm:   true,
 				Signature: "4567",
 			},
-			HowAttorneysMakeDecisionsPath:  howShouldAttorneysMakeDecisionsPath,
-			ChooseAttorneysPath:            chooseAttorneysPath,
-			WhenCanLpaBeUsedPath:           whenCanTheLpaBeUsedPath,
-			RestrictionsPath:               restrictionsPath,
-			CertificatesProviderPath:       certificateProviderDetailsPath,
-			AttorneyDetailsPath:            chooseAttorneysPath,
-			AttorneyAddressPath:            chooseAttorneysAddressPath,
-			RemoveAttorneyPath:             removeAttorneyPath,
-			ReplacementAttorneyDetailsPath: chooseReplacementAttorneysPath,
-			ReplacementAttorneyAddressPath: chooseReplacementAttorneysAddressPath,
-			RemoveReplacementAttorneyPath:  removeReplacementAttorneyPath,
 		}).
 		Return(nil)
 
@@ -148,7 +126,7 @@ func TestPostReadYourLpa(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, signingConfirmationPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.SigningConfirmation, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/remove_attorney.go
+++ b/app/internal/page/remove_attorney.go
@@ -30,7 +30,7 @@ func RemoveAttorney(logger Logger, tmpl template.Template, lpaStore LpaStore) Ha
 		attorney, found := lpa.GetAttorney(id)
 
 		if found == false {
-			appData.Lang.Redirect(w, r, chooseAttorneysSummaryPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneysSummary, http.StatusFound)
 			return nil
 		}
 
@@ -58,16 +58,16 @@ func RemoveAttorney(logger Logger, tmpl template.Template, lpaStore LpaStore) Ha
 				}
 
 				if len(lpa.Attorneys) == 0 {
-					appData.Lang.Redirect(w, r, chooseAttorneysPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneys, http.StatusFound)
 				} else {
-					appData.Lang.Redirect(w, r, chooseAttorneysSummaryPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneysSummary, http.StatusFound)
 				}
 
 				return nil
 			}
 
 			if data.Form.RemoveAttorney == "no" {
-				appData.Lang.Redirect(w, r, chooseAttorneysSummaryPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.ChooseAttorneysSummary, http.StatusFound)
 				return nil
 			}
 

--- a/app/internal/page/remove_replacement_attorney.go
+++ b/app/internal/page/remove_replacement_attorney.go
@@ -26,7 +26,7 @@ func RemoveReplacementAttorney(logger Logger, tmpl template.Template, lpaStore L
 		attorney, found := lpa.GetReplacementAttorney(id)
 
 		if found == false {
-			appData.Lang.Redirect(w, r, chooseReplacementAttorneysSummaryPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseReplacementAttorneysSummary, http.StatusFound)
 			return nil
 		}
 
@@ -54,16 +54,16 @@ func RemoveReplacementAttorney(logger Logger, tmpl template.Template, lpaStore L
 				}
 
 				if len(lpa.ReplacementAttorneys) == 0 {
-					appData.Lang.Redirect(w, r, wantReplacementAttorneysPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.WantReplacementAttorneys, http.StatusFound)
 				} else {
-					appData.Lang.Redirect(w, r, chooseReplacementAttorneysSummaryPath, http.StatusFound)
+					appData.Lang.Redirect(w, r, appData.Paths.ChooseReplacementAttorneysSummary, http.StatusFound)
 				}
 
 				return nil
 			}
 
 			if data.Form.RemoveAttorney == "no" {
-				appData.Lang.Redirect(w, r, chooseReplacementAttorneysSummaryPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.ChooseReplacementAttorneysSummary, http.StatusFound)
 				return nil
 			}
 

--- a/app/internal/page/restrictions.go
+++ b/app/internal/page/restrictions.go
@@ -41,7 +41,7 @@ func Restrictions(tmpl template.Template, lpaStore LpaStore) Handler {
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, whoDoYouWantToBeCertificateProviderGuidancePath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/restrictions_test.go
+++ b/app/internal/page/restrictions_test.go
@@ -129,7 +129,7 @@ func TestPostRestrictions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, whoDoYouWantToBeCertificateProviderGuidancePath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -157,7 +157,7 @@ func TestPostRestrictionsWhenAnswerLater(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, whoDoYouWantToBeCertificateProviderGuidancePath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/root.go
+++ b/app/internal/page/root.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 )
 
-func Root() http.HandlerFunc {
+func Root(paths AppPaths) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			http.Redirect(w, r, startPath, http.StatusFound)
+			http.Redirect(w, r, paths.Start, http.StatusFound)
 		} else {
 			http.NotFound(w, r)
 		}

--- a/app/internal/page/root_test.go
+++ b/app/internal/page/root_test.go
@@ -12,18 +12,18 @@ func TestRoot(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	Root()(w, r)
+	Root(appData.Paths)(w, r)
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, startPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.Start, resp.Header.Get("Location"))
 }
 
 func TestRootNotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/what", nil)
 
-	Root()(w, r)
+	Root(appData.Paths)(w, r)
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/app/internal/page/select_your_identity_options.go
+++ b/app/internal/page/select_your_identity_options.go
@@ -36,7 +36,6 @@ func SelectYourIdentityOptions(tmpl template.Template, lpaStore LpaStore) Handle
 					Selected: data.Form.Options,
 					First:    data.Form.First,
 					Second:   data.Form.Second,
-					Paths:    appData.Paths,
 				}
 				lpa.Tasks.ConfirmYourIdentityAndSign = TaskInProgress
 

--- a/app/internal/page/select_your_identity_options.go
+++ b/app/internal/page/select_your_identity_options.go
@@ -36,13 +36,14 @@ func SelectYourIdentityOptions(tmpl template.Template, lpaStore LpaStore) Handle
 					Selected: data.Form.Options,
 					First:    data.Form.First,
 					Second:   data.Form.Second,
+					Paths:    appData.Paths,
 				}
 				lpa.Tasks.ConfirmYourIdentityAndSign = TaskInProgress
 
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, yourChosenIdentityOptionsPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.YourChosenIdentityOptions, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/select_your_identity_options_test.go
+++ b/app/internal/page/select_your_identity_options_test.go
@@ -62,6 +62,7 @@ func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 		Return(&Lpa{
 			IdentityOptions: IdentityOptions{
 				Selected: []IdentityOption{Passport},
+				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -119,6 +120,7 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 				Selected: []IdentityOption{Passport, DwpAccount, UtilityBill},
 				First:    Passport,
 				Second:   DwpAccount,
+				Paths:    appData.Paths,
 			},
 			Tasks: Tasks{
 				ConfirmYourIdentityAndSign: TaskInProgress,
@@ -138,7 +140,7 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, yourChosenIdentityOptionsPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.YourChosenIdentityOptions, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/select_your_identity_options_test.go
+++ b/app/internal/page/select_your_identity_options_test.go
@@ -62,7 +62,6 @@ func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 		Return(&Lpa{
 			IdentityOptions: IdentityOptions{
 				Selected: []IdentityOption{Passport},
-				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -120,7 +119,6 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 				Selected: []IdentityOption{Passport, DwpAccount, UtilityBill},
 				First:    Passport,
 				Second:   DwpAccount,
-				Paths:    appData.Paths,
 			},
 			Tasks: Tasks{
 				ConfirmYourIdentityAndSign: TaskInProgress,

--- a/app/internal/page/task_list.go
+++ b/app/internal/page/task_list.go
@@ -6,6 +6,23 @@ import (
 	"github.com/ministryofjustice/opg-go-common/template"
 )
 
+const (
+	FillInLpaSection                      = "fillInTheLpa"
+	ProvideYourDetailsTask                = "provideYourDetails"
+	ChooseYourAttorneysTask               = "chooseYourAttorneys"
+	ChooseYourReplacementAttorneysTask    = "chooseYourReplacementAttorneys"
+	ChooseWhenTheLpaCanBeUsedTask         = "chooseWhenTheLpaCanBeUsed"
+	AddRestrictionsToLpaTask              = "addRestrictionsToTheLpa"
+	ChooseCertificateProviderTask         = "chooseYourCertificateProvider"
+	CheckAndSendToCertificateProviderTask = "checkAndSendToYourCertificateProvider"
+	PayForLpaSection                      = "payForTheLpa"
+	PayForTheLpaTask                      = "payForTheLpa"
+	ConfirmYourIdentityAndSignSection     = "confirmYourIdentityAndSign"
+	ConfirmYourIdentityAndSignTask        = "confirmYourIdentityAndSign"
+	RegisterTheLpaSection                 = "registerTheLpa"
+	RegisterTheLpaTask                    = "registerTheLpa"
+)
+
 type taskListData struct {
 	App      AppData
 	Errors   map[string]string
@@ -37,48 +54,48 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 			App: appData,
 			Sections: []taskListSection{
 				{
-					Heading: "fillInTheLpa",
+					Heading: FillInLpaSection,
 					Items: []taskListItem{
 						{
-							Name:       "provideYourDetails",
+							Name:       ProvideYourDetailsTask,
 							Path:       yourDetailsPath,
 							Completed:  lpa.You.Address.Line1 != "",
 							InProgress: lpa.You.FirstNames != "",
 						},
 						{
-							Name:       "chooseYourAttorneys",
+							Name:       ChooseYourAttorneysTask,
 							Path:       chooseAttorneysPath,
 							Completed:  lpa.AttorneysTaskComplete(),
 							InProgress: len(lpa.Attorneys) > 0 && !lpa.AttorneysTaskComplete(),
 							Count:      len(lpa.Attorneys),
 						},
 						{
-							Name:       "chooseYourReplacementAttorneys",
+							Name:       ChooseYourReplacementAttorneysTask,
 							Path:       wantReplacementAttorneysPath,
 							Completed:  lpa.ReplacementAttorneysTaskComplete(),
 							InProgress: len(lpa.ReplacementAttorneys) > 0 && !lpa.ReplacementAttorneysTaskComplete(),
 							Count:      len(lpa.ReplacementAttorneys),
 						},
 						{
-							Name:       "chooseWhenTheLpaCanBeUsed",
+							Name:       ChooseWhenTheLpaCanBeUsedTask,
 							Path:       whenCanTheLpaBeUsedPath,
 							Completed:  lpa.Tasks.WhenCanTheLpaBeUsed == TaskCompleted,
 							InProgress: lpa.Tasks.WhenCanTheLpaBeUsed == TaskInProgress,
 						},
 						{
-							Name:       "addRestrictionsToTheLpa",
+							Name:       AddRestrictionsToLpaTask,
 							Path:       restrictionsPath,
 							Completed:  lpa.Tasks.Restrictions == TaskCompleted,
 							InProgress: lpa.Tasks.Restrictions == TaskInProgress,
 						},
 						{
-							Name:       "chooseYourCertificateProvider",
+							Name:       ChooseCertificateProviderTask,
 							Path:       whoDoYouWantToBeCertificateProviderGuidancePath,
 							Completed:  lpa.Tasks.CertificateProvider == TaskCompleted,
 							InProgress: lpa.Tasks.CertificateProvider == TaskInProgress,
 						},
 						{
-							Name:       "checkAndSendToYourCertificateProvider",
+							Name:       CheckAndSendToCertificateProviderTask,
 							Path:       checkYourLpaPath,
 							Completed:  lpa.Tasks.CheckYourLpa == TaskCompleted,
 							InProgress: lpa.Tasks.CheckYourLpa == TaskInProgress,
@@ -86,10 +103,10 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					},
 				},
 				{
-					Heading: "payForTheLpa",
+					Heading: PayForLpaSection,
 					Items: []taskListItem{
 						{
-							Name:       "payForTheLpa",
+							Name:       PayForTheLpaTask,
 							Path:       aboutPaymentPath,
 							Completed:  lpa.Tasks.PayForLpa == TaskCompleted,
 							InProgress: lpa.Tasks.PayForLpa == TaskInProgress,
@@ -97,10 +114,10 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					},
 				},
 				{
-					Heading: "confirmYourIdentityAndSign",
+					Heading: ConfirmYourIdentityAndSignSection,
 					Items: []taskListItem{
 						{
-							Name:       "confirmYourIdentityAndSign",
+							Name:       ConfirmYourIdentityAndSignTask,
 							Path:       selectYourIdentityOptionsPath,
 							Completed:  lpa.Tasks.ConfirmYourIdentityAndSign == TaskCompleted,
 							InProgress: lpa.Tasks.ConfirmYourIdentityAndSign == TaskInProgress,
@@ -108,9 +125,9 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					},
 				},
 				{
-					Heading: "registerTheLpa",
+					Heading: RegisterTheLpaSection,
 					Items: []taskListItem{
-						{Name: "registerTheLpa", Disabled: true},
+						{Name: RegisterTheLpaTask, Disabled: true},
 					},
 				},
 			},

--- a/app/internal/page/task_list.go
+++ b/app/internal/page/task_list.go
@@ -58,45 +58,45 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					Items: []taskListItem{
 						{
 							Name:       ProvideYourDetailsTask,
-							Path:       yourDetailsPath,
+							Path:       appData.Paths.YourDetails,
 							Completed:  lpa.You.Address.Line1 != "",
 							InProgress: lpa.You.FirstNames != "",
 						},
 						{
 							Name:       ChooseYourAttorneysTask,
-							Path:       chooseAttorneysPath,
+							Path:       appData.Paths.ChooseAttorneys,
 							Completed:  lpa.AttorneysTaskComplete(),
 							InProgress: len(lpa.Attorneys) > 0 && !lpa.AttorneysTaskComplete(),
 							Count:      len(lpa.Attorneys),
 						},
 						{
 							Name:       ChooseYourReplacementAttorneysTask,
-							Path:       wantReplacementAttorneysPath,
+							Path:       appData.Paths.WantReplacementAttorneys,
 							Completed:  lpa.ReplacementAttorneysTaskComplete(),
 							InProgress: len(lpa.ReplacementAttorneys) > 0 && !lpa.ReplacementAttorneysTaskComplete(),
 							Count:      len(lpa.ReplacementAttorneys),
 						},
 						{
 							Name:       ChooseWhenTheLpaCanBeUsedTask,
-							Path:       whenCanTheLpaBeUsedPath,
+							Path:       appData.Paths.WhenCanTheLpaBeUsed,
 							Completed:  lpa.Tasks.WhenCanTheLpaBeUsed == TaskCompleted,
 							InProgress: lpa.Tasks.WhenCanTheLpaBeUsed == TaskInProgress,
 						},
 						{
 							Name:       AddRestrictionsToLpaTask,
-							Path:       restrictionsPath,
+							Path:       appData.Paths.Restrictions,
 							Completed:  lpa.Tasks.Restrictions == TaskCompleted,
 							InProgress: lpa.Tasks.Restrictions == TaskInProgress,
 						},
 						{
 							Name:       ChooseCertificateProviderTask,
-							Path:       whoDoYouWantToBeCertificateProviderGuidancePath,
+							Path:       appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance,
 							Completed:  lpa.Tasks.CertificateProvider == TaskCompleted,
 							InProgress: lpa.Tasks.CertificateProvider == TaskInProgress,
 						},
 						{
 							Name:       CheckAndSendToCertificateProviderTask,
-							Path:       checkYourLpaPath,
+							Path:       appData.Paths.CheckYourLpa,
 							Completed:  lpa.Tasks.CheckYourLpa == TaskCompleted,
 							InProgress: lpa.Tasks.CheckYourLpa == TaskInProgress,
 						},
@@ -107,7 +107,7 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					Items: []taskListItem{
 						{
 							Name:       PayForTheLpaTask,
-							Path:       aboutPaymentPath,
+							Path:       appData.Paths.AboutPayment,
 							Completed:  lpa.Tasks.PayForLpa == TaskCompleted,
 							InProgress: lpa.Tasks.PayForLpa == TaskInProgress,
 						},
@@ -118,7 +118,7 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) Handler {
 					Items: []taskListItem{
 						{
 							Name:       ConfirmYourIdentityAndSignTask,
-							Path:       selectYourIdentityOptionsPath,
+							Path:       appData.Paths.SelectYourIdentityOptions,
 							Completed:  lpa.Tasks.ConfirmYourIdentityAndSign == TaskCompleted,
 							InProgress: lpa.Tasks.ConfirmYourIdentityAndSign == TaskInProgress,
 						},

--- a/app/internal/page/task_list_test.go
+++ b/app/internal/page/task_list_test.go
@@ -44,21 +44,21 @@ func TestGetTaskList(t *testing.T) {
 			},
 			expected: func(sections []taskListSection) []taskListSection {
 				sections[0].Items = []taskListItem{
-					{Name: "provideYourDetails", Path: yourDetailsPath, InProgress: true},
-					{Name: "chooseYourAttorneys", Path: chooseAttorneysPath, InProgress: true, Count: 1},
-					{Name: "chooseYourReplacementAttorneys", Path: wantReplacementAttorneysPath, InProgress: true, Count: 1},
-					{Name: "chooseWhenTheLpaCanBeUsed", Path: whenCanTheLpaBeUsedPath, InProgress: true},
-					{Name: "addRestrictionsToTheLpa", Path: restrictionsPath, InProgress: true},
-					{Name: "chooseYourCertificateProvider", Path: whoDoYouWantToBeCertificateProviderGuidancePath, InProgress: true},
-					{Name: "checkAndSendToYourCertificateProvider", Path: checkYourLpaPath, InProgress: true},
+					{Name: ProvideYourDetailsTask, Path: appData.Paths.YourDetails, InProgress: true},
+					{Name: ChooseYourAttorneysTask, Path: appData.Paths.ChooseAttorneys, InProgress: true, Count: 1},
+					{Name: ChooseYourReplacementAttorneysTask, Path: appData.Paths.WantReplacementAttorneys, InProgress: true, Count: 1},
+					{Name: ChooseWhenTheLpaCanBeUsedTask, Path: appData.Paths.WhenCanTheLpaBeUsed, InProgress: true},
+					{Name: AddRestrictionsToLpaTask, Path: appData.Paths.Restrictions, InProgress: true},
+					{Name: ChooseCertificateProviderTask, Path: appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance, InProgress: true},
+					{Name: CheckAndSendToCertificateProviderTask, Path: appData.Paths.CheckYourLpa, InProgress: true},
 				}
 
 				sections[1].Items = []taskListItem{
-					{Name: "payForTheLpa", Path: aboutPaymentPath, InProgress: true},
+					{Name: PayForTheLpaTask, Path: appData.Paths.AboutPayment, InProgress: true},
 				}
 
 				sections[2].Items = []taskListItem{
-					{Name: "confirmYourIdentityAndSign", Path: selectYourIdentityOptionsPath, InProgress: true},
+					{Name: ConfirmYourIdentityAndSignTask, Path: appData.Paths.SelectYourIdentityOptions, InProgress: true},
 				}
 
 				return sections
@@ -96,21 +96,21 @@ func TestGetTaskList(t *testing.T) {
 			},
 			expected: func(sections []taskListSection) []taskListSection {
 				sections[0].Items = []taskListItem{
-					{Name: "provideYourDetails", Path: yourDetailsPath, Completed: true},
-					{Name: "chooseYourAttorneys", Path: chooseAttorneysPath, Completed: true, Count: 2},
-					{Name: "chooseYourReplacementAttorneys", Path: wantReplacementAttorneysPath, Completed: true, Count: 1},
-					{Name: "chooseWhenTheLpaCanBeUsed", Path: whenCanTheLpaBeUsedPath, Completed: true},
-					{Name: "addRestrictionsToTheLpa", Path: restrictionsPath, Completed: true},
-					{Name: "chooseYourCertificateProvider", Path: whoDoYouWantToBeCertificateProviderGuidancePath, Completed: true},
-					{Name: "checkAndSendToYourCertificateProvider", Path: checkYourLpaPath, Completed: true},
+					{Name: ProvideYourDetailsTask, Path: appData.Paths.YourDetails, Completed: true},
+					{Name: ChooseYourAttorneysTask, Path: appData.Paths.ChooseAttorneys, Completed: true, Count: 2},
+					{Name: ChooseYourReplacementAttorneysTask, Path: appData.Paths.WantReplacementAttorneys, Completed: true, Count: 1},
+					{Name: ChooseWhenTheLpaCanBeUsedTask, Path: appData.Paths.WhenCanTheLpaBeUsed, Completed: true},
+					{Name: AddRestrictionsToLpaTask, Path: appData.Paths.Restrictions, Completed: true},
+					{Name: ChooseCertificateProviderTask, Path: appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance, Completed: true},
+					{Name: CheckAndSendToCertificateProviderTask, Path: appData.Paths.CheckYourLpa, Completed: true},
 				}
 
 				sections[1].Items = []taskListItem{
-					{Name: "payForTheLpa", Path: aboutPaymentPath, Completed: true},
+					{Name: PayForTheLpaTask, Path: appData.Paths.AboutPayment, Completed: true},
 				}
 
 				sections[2].Items = []taskListItem{
-					{Name: "confirmYourIdentityAndSign", Path: selectYourIdentityOptionsPath, Completed: true},
+					{Name: ConfirmYourIdentityAndSignTask, Path: appData.Paths.SelectYourIdentityOptions, Completed: true},
 				}
 
 				return sections
@@ -133,39 +133,35 @@ func TestGetTaskList(t *testing.T) {
 					App: appData,
 					Sections: tc.expected([]taskListSection{
 						{
-							Heading: "fillInTheLpa",
+							Heading: FillInLpaSection,
 							Items: []taskListItem{
-								{Name: "provideYourDetails", Path: yourDetailsPath},
-								{Name: "chooseYourAttorneys", Path: chooseAttorneysPath},
-								{Name: "chooseYourReplacementAttorneys", Path: wantReplacementAttorneysPath},
-								{Name: "chooseWhenTheLpaCanBeUsed", Path: whenCanTheLpaBeUsedPath},
-								{Name: "addRestrictionsToTheLpa", Path: restrictionsPath},
-								{Name: "chooseYourCertificateProvider", Path: whoDoYouWantToBeCertificateProviderGuidancePath},
-								{Name: "checkAndSendToYourCertificateProvider", Path: checkYourLpaPath},
+								{Name: ProvideYourDetailsTask, Path: appData.Paths.YourDetails},
+								{Name: ChooseYourAttorneysTask, Path: appData.Paths.ChooseAttorneys},
+								{Name: ChooseYourReplacementAttorneysTask, Path: appData.Paths.WantReplacementAttorneys},
+								{Name: ChooseWhenTheLpaCanBeUsedTask, Path: appData.Paths.WhenCanTheLpaBeUsed},
+								{Name: AddRestrictionsToLpaTask, Path: appData.Paths.Restrictions},
+								{Name: ChooseCertificateProviderTask, Path: appData.Paths.WhoDoYouWantToBeCertificateProviderGuidance},
+								{Name: CheckAndSendToCertificateProviderTask, Path: appData.Paths.CheckYourLpa},
 							},
 						},
 						{
-							Heading: "payForTheLpa",
+							Heading: PayForLpaSection,
+							Items: []taskListItem{
+								{Name: PayForTheLpaTask, Path: appData.Paths.AboutPayment},
+							},
+						},
+						{
+							Heading: ConfirmYourIdentityAndSignSection,
 							Items: []taskListItem{
 								{
-									Name: "payForTheLpa",
-									Path: aboutPaymentPath,
+									Name: ConfirmYourIdentityAndSignTask, Path: appData.Paths.SelectYourIdentityOptions,
 								},
 							},
 						},
 						{
-							Heading: "confirmYourIdentityAndSign",
+							Heading: RegisterTheLpaSection,
 							Items: []taskListItem{
-								{
-									Name: "confirmYourIdentityAndSign",
-									Path: selectYourIdentityOptionsPath,
-								},
-							},
-						},
-						{
-							Heading: "registerTheLpa",
-							Items: []taskListItem{
-								{Name: "registerTheLpa", Disabled: true},
+								{Name: RegisterTheLpaTask, Disabled: true},
 							},
 						},
 					}),

--- a/app/internal/page/want_replacement_attorneys.go
+++ b/app/internal/page/want_replacement_attorneys.go
@@ -36,9 +36,9 @@ func WantReplacementAttorneys(tmpl template.Template, lpaStore LpaStore) Handler
 
 				if form.Want == "no" {
 					lpa.ReplacementAttorneys = []Attorney{}
-					redirectUrl = taskListPath
+					redirectUrl = appData.Paths.TaskList
 				} else {
-					redirectUrl = chooseReplacementAttorneysPath
+					redirectUrl = appData.Paths.ChooseReplacementAttorneys
 				}
 
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
@@ -51,7 +51,7 @@ func WantReplacementAttorneys(tmpl template.Template, lpaStore LpaStore) Handler
 		}
 
 		if len(lpa.ReplacementAttorneys) > 0 {
-			appData.Lang.Redirect(w, r, chooseReplacementAttorneysSummaryPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.ChooseReplacementAttorneysSummary, http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/want_replacement_attorneys_test.go
+++ b/app/internal/page/want_replacement_attorneys_test.go
@@ -58,7 +58,7 @@ func TestGetWantReplacementAttorneysWithExistingReplacementAttorneys(t *testing.
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, chooseReplacementAttorneysSummaryPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
 
 	mock.AssertExpectationsForObjects(t, template, lpaStore)
 }
@@ -143,13 +143,13 @@ func TestPostWantReplacementAttorneys(t *testing.T) {
 	}{
 		{
 			Want:                         "yes",
-			ExpectedRedirect:             chooseReplacementAttorneysPath,
+			ExpectedRedirect:             appData.Paths.ChooseReplacementAttorneys,
 			ExistingReplacementAttorneys: []Attorney{{ID: "123"}},
 			ExpectedReplacementAttorneys: []Attorney{{ID: "123"}},
 		},
 		{
 			Want:             "no",
-			ExpectedRedirect: taskListPath,
+			ExpectedRedirect: appData.Paths.TaskList,
 			ExistingReplacementAttorneys: []Attorney{
 				{ID: "123"},
 				{ID: "345"},

--- a/app/internal/page/when_can_the_lpa_be_used.go
+++ b/app/internal/page/when_can_the_lpa_be_used.go
@@ -42,7 +42,7 @@ func WhenCanTheLpaBeUsed(tmpl template.Template, lpaStore LpaStore) Handler {
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, restrictionsPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.Restrictions, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/when_can_the_lpa_be_used_test.go
+++ b/app/internal/page/when_can_the_lpa_be_used_test.go
@@ -131,7 +131,7 @@ func TestPostWhenCanTheLpaBeUsed(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, restrictionsPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.Restrictions, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -159,7 +159,7 @@ func TestPostWhenCanTheLpaBeUsedWhenAnswerLater(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, restrictionsPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.Restrictions, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/who_do_you_want_to_be_certificate_provider_guidance.go
+++ b/app/internal/page/who_do_you_want_to_be_certificate_provider_guidance.go
@@ -28,7 +28,7 @@ func WhoDoYouWantToBeCertificateProviderGuidance(tmpl template.Template, lpaStor
 
 		if r.Method == http.MethodPost {
 			if postFormString(r, "will-do-this-later") == "1" {
-				appData.Lang.Redirect(w, r, taskListPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.TaskList, http.StatusFound)
 				return nil
 			}
 
@@ -38,7 +38,7 @@ func WhoDoYouWantToBeCertificateProviderGuidance(tmpl template.Template, lpaStor
 			if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 				return err
 			}
-			appData.Lang.Redirect(w, r, certificateProviderDetailsPath, http.StatusFound)
+			appData.Lang.Redirect(w, r, appData.Paths.CertificateProviderDetails, http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/who_do_you_want_to_be_certificate_provider_guidance_test.go
+++ b/app/internal/page/who_do_you_want_to_be_certificate_provider_guidance_test.go
@@ -120,7 +120,7 @@ func TestPostWhoDoYouWantToBeCertificateProviderGuidance(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, certificateProviderDetailsPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.CertificateProviderDetails, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -142,7 +142,7 @@ func TestPostWhoDoYouWantToBeCertificateProviderGuidanceWhenWillDoLater(t *testi
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, taskListPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.TaskList, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/who_is_the_lpa_for.go
+++ b/app/internal/page/who_is_the_lpa_for.go
@@ -33,7 +33,7 @@ func WhoIsTheLpaFor(tmpl template.Template, lpaStore LpaStore) Handler {
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, lpaTypePath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.LpaType, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/who_is_the_lpa_for_test.go
+++ b/app/internal/page/who_is_the_lpa_for_test.go
@@ -128,7 +128,7 @@ func TestPostWhoIsTheLpaFor(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, lpaTypePath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.LpaType, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/your_address.go
+++ b/app/internal/page/your_address.go
@@ -40,7 +40,7 @@ func YourAddress(logger Logger, tmpl template.Template, addressClient AddressCli
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, whoIsTheLpaForPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.WhoIsTheLpaFor, http.StatusFound)
 				return nil
 			}
 

--- a/app/internal/page/your_address_test.go
+++ b/app/internal/page/your_address_test.go
@@ -194,7 +194,7 @@ func TestPostYourAddressManual(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, whoIsTheLpaForPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.WhoIsTheLpaFor, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 
@@ -283,7 +283,7 @@ func TestPostYourAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, whoIsTheLpaForPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.WhoIsTheLpaFor, resp.Header.Get("Location"))
 	mock.AssertExpectationsForObjects(t, lpaStore)
 }
 

--- a/app/internal/page/your_chosen_identity_options.go
+++ b/app/internal/page/your_chosen_identity_options.go
@@ -23,7 +23,7 @@ func YourChosenIdentityOptions(tmpl template.Template, lpaStore LpaStore) Handle
 		}
 
 		if r.Method == http.MethodPost {
-			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(IdentityOptionUnknown), http.StatusFound)
+			appData.Lang.Redirect(w, r, lpa.IdentityOptions.NextPath(IdentityOptionUnknown, appData.Paths), http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/your_chosen_identity_options_test.go
+++ b/app/internal/page/your_chosen_identity_options_test.go
@@ -22,6 +22,7 @@ func TestGetYourChosenIdentityOptions(t *testing.T) {
 				Selected: selected,
 				First:    Passport,
 				Second:   DwpAccount,
+				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -70,6 +71,7 @@ func TestGetYourChosenIdentityOptionsWhenTemplateErrors(t *testing.T) {
 		Return(&Lpa{
 			IdentityOptions: IdentityOptions{
 				Selected: []IdentityOption{Passport, DwpAccount, UtilityBill},
+				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -98,6 +100,7 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 			IdentityOptions: IdentityOptions{
 				First:  Passport,
 				Second: DwpAccount,
+				Paths:  appData.Paths,
 			},
 		}, nil)
 
@@ -108,5 +111,5 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, identityWithPassportPath, resp.Header.Get("Location"))
+	assert.Equal(t, appData.Paths.IdentityWithPassport, resp.Header.Get("Location"))
 }

--- a/app/internal/page/your_chosen_identity_options_test.go
+++ b/app/internal/page/your_chosen_identity_options_test.go
@@ -22,7 +22,6 @@ func TestGetYourChosenIdentityOptions(t *testing.T) {
 				Selected: selected,
 				First:    Passport,
 				Second:   DwpAccount,
-				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -71,7 +70,6 @@ func TestGetYourChosenIdentityOptionsWhenTemplateErrors(t *testing.T) {
 		Return(&Lpa{
 			IdentityOptions: IdentityOptions{
 				Selected: []IdentityOption{Passport, DwpAccount, UtilityBill},
-				Paths:    appData.Paths,
 			},
 		}, nil)
 
@@ -100,7 +98,6 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 			IdentityOptions: IdentityOptions{
 				First:  Passport,
 				Second: DwpAccount,
-				Paths:  appData.Paths,
 			},
 		}, nil)
 

--- a/app/internal/page/your_details.go
+++ b/app/internal/page/your_details.go
@@ -65,7 +65,7 @@ func YourDetails(tmpl template.Template, lpaStore LpaStore, sessionStore session
 				if err := lpaStore.Put(r.Context(), appData.SessionID, lpa); err != nil {
 					return err
 				}
-				appData.Lang.Redirect(w, r, yourAddressPath, http.StatusFound)
+				appData.Lang.Redirect(w, r, appData.Paths.YourAddress, http.StatusFound)
 				return nil
 			}
 		}

--- a/app/internal/page/your_details_test.go
+++ b/app/internal/page/your_details_test.go
@@ -189,7 +189,7 @@ func TestPostYourDetails(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, yourAddressPath, resp.Header.Get("Location"))
+			assert.Equal(t, appData.Paths.YourAddress, resp.Header.Get("Location"))
 			mock.AssertExpectationsForObjects(t, lpaStore, sessionStore)
 		})
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -184,6 +184,9 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
+	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, webDir+"/robots.txt")
+	})
 	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlHeaders(http.FileServer(http.Dir(webDir+"/static/"))))))
 	mux.Handle(page.AuthRedirectPath, page.AuthRedirect(logger, signInClient, sessionStore, secureCookies))
 	mux.Handle(page.AuthPath, page.Login(logger, signInClient, sessionStore, secureCookies, random.String))

--- a/app/web/robots.txt
+++ b/app/web/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/app/web/template/choose_attorneys_summary.gohtml
+++ b/app/web/template/choose_attorneys_summary.gohtml
@@ -5,7 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">{{ trCount .App "attorneysAdded" (len .Lpa.Attorneys) }}</h1>
 
-        {{ template "attorney-summary" (listAttorneys .Lpa.Attorneys .App .AttorneyDetailsPath .AttorneyAddressPath .RemoveAttorneyPath) }}
+        {{ template "attorney-summary" (listAttorneys .Lpa.Attorneys .App .App.Paths.ChooseAttorneys .App.Paths.ChooseAttorneysAddress .App.Paths.RemoveAttorney) }}
 
         <form novalidate method="post">
             <div class="govuk-form-group">

--- a/app/web/template/choose_replacement_attorneys_summary.gohtml
+++ b/app/web/template/choose_replacement_attorneys_summary.gohtml
@@ -5,7 +5,7 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">{{ trCount .App "replacementAttorneysAdded" (len .Lpa.ReplacementAttorneys) }}</h1>
 
-            {{ template "attorney-summary" (listAttorneys .Lpa.ReplacementAttorneys .App .ReplacementAttorneyDetailsPath .ReplacementAttorneyAddressPath .RemoveReplacementAttorneyPath) }}
+            {{ template "attorney-summary" (listAttorneys .Lpa.ReplacementAttorneys .App .App.Paths.ChooseReplacementAttorneys .App.Paths.ChooseReplacementAttorneysAddress .App.Paths.RemoveReplacementAttorney) }}
 
             <form novalidate method="post">
                 <div class="govuk-form-group">

--- a/app/web/template/layout/attorney-details.gohtml
+++ b/app/web/template/layout/attorney-details.gohtml
@@ -3,8 +3,8 @@
     {{ range .Attorneys }}
         <dl class="govuk-summary-list">
 
-            {{ $detailsLink := printf "/choose-attorneys?from=%s&id=%s" $.App.Page .ID }}
-            {{ $addressLink := printf "/choose-attorneys-address?from=%s&id=%s" $.App.Page .ID }}
+            {{ $detailsLink := printf "%s?from=%s&id=%s" $.App.Paths.ChooseAttorneys $.App.Page .ID }}
+            {{ $addressLink := printf "%s?from=%s&id=%s" $.App.Paths.ChooseAttorneysAddress $.App.Page .ID }}
 
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">

--- a/app/web/template/layout/certificate-provider-details.gohtml
+++ b/app/web/template/layout/certificate-provider-details.gohtml
@@ -8,7 +8,7 @@
                 {{ .Lpa.CertificateProvider.FirstNames }} {{ .Lpa.CertificateProvider.LastName }}
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .CertificatesProviderPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ lowerFirst (tr .App "certificateProvider") }}</span>
                 </a>
             </dd>
@@ -22,7 +22,7 @@
                 {{ .Lpa.CertificateProvider.Email }}
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .CertificatesProviderPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "certificateProviderEmail" }}</span>
                 </a>
             </dd>

--- a/app/web/template/layout/lpa-decisions.gohtml
+++ b/app/web/template/layout/lpa-decisions.gohtml
@@ -17,7 +17,7 @@
                 {{ tr .App .Lpa.WhenCanTheLpaBeUsed }}
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .WhenCanLpaBeUsedPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.WhenCanTheLpaBeUsed }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden">  {{ tr .App "whenTheLpaCanBeUsed" }}</span>
                 </a>
             </dd>
@@ -31,7 +31,7 @@
                 {{ .Lpa.AttorneysFullNames }}
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .ChooseAttorneysPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.ChooseAttorneys }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden">  {{ tr .App "yourAttorneys" }}</span>
                 </a>
             </dd>
@@ -46,7 +46,7 @@
                     {{ tr .App .Lpa.HowAttorneysMakeDecisions }}
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="{{ link .App .HowAttorneysMakeDecisionsPath }}">
+                    <a class="govuk-link" href="{{ link .App .App.Paths.HowShouldAttorneysMakeDecisions }}">
                         {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ .Lpa.HowAttorneysMakeDecisionsDetails }}</span>
                     </a>
                 </dd>
@@ -65,7 +65,7 @@
                 {{ end }}
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .ReplacementAttorneyDetailsPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.ChooseReplacementAttorneys }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ tr .App "yourReplacementAttorneys" }}</span>
                 </a>
             </dd>
@@ -79,7 +79,7 @@
                 <p style="white-space: pre-line;">{{ .Lpa.Restrictions }}</p>
             </dd>
             <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ link .App .RestrictionsPath }}">
+                <a class="govuk-link" href="{{ link .App .App.Paths.Restrictions }}">
                     {{ tr .App "change" }}<span class="govuk-visually-hidden">  {{ tr .App "yourRestrictions" }}</span>
                 </a>
             </dd>

--- a/app/web/template/layout/people-named-on-lpa.gohtml
+++ b/app/web/template/layout/people-named-on-lpa.gohtml
@@ -15,11 +15,11 @@
         {{ tr .App "attorneys" }}
     </h3>
 
-    {{ template "attorney-details" (listAttorneys .Lpa.Attorneys .App .AttorneyDetailsPath .AttorneyAddressPath .RemoveAttorneyPath) }}
+    {{ template "attorney-details" (listAttorneys .Lpa.Attorneys .App .App.Paths.ChooseAttorneys .App.Paths.ChooseAttorneysAddress .App.Paths.RemoveAttorney) }}
 
     <h3 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-2">
         {{ tr .App "replacementAttorneys" }}
     </h3>
 
-    {{ template "attorney-details" (listAttorneys .Lpa.ReplacementAttorneys .App .ReplacementAttorneyDetailsPath .ReplacementAttorneyAddressPath .RemoveReplacementAttorneyPath) }}
+    {{ template "attorney-details" (listAttorneys .Lpa.ReplacementAttorneys .App .App.Paths.ChooseReplacementAttorneys .App.Paths.ChooseReplacementAttorneysAddress .App.Paths.RemoveReplacementAttorney) }}
 {{ end }}

--- a/terraform/environment/region/modules/app/waf.tf
+++ b/terraform/environment/region/modules/app/waf.tf
@@ -1,4 +1,4 @@
-data "" "main" {
+data "aws_wafv2_web_acl" "main" {
   provider = aws.region
   name     = "${data.aws_default_tags.current.tags.account-name}-web-acl"
   scope    = "REGIONAL"

--- a/terraform/environment/region/modules/app/waf.tf
+++ b/terraform/environment/region/modules/app/waf.tf
@@ -1,4 +1,4 @@
-data "aws_wafv2_web_acl" "main" {
+data "" "main" {
   provider = aws.region
   name     = "${data.aws_default_tags.current.tags.account-name}-web-acl"
   scope    = "REGIONAL"

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -119,7 +119,7 @@
         "eu-west-1"
       ],
       "app": {
-        "public_access_enabled": false,
+        "public_access_enabled": true,
         "env": {
           "app_public_url": "https://app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://app.modernising.opg.service.justice.gov.uk",


### PR DESCRIPTION
# Purpose

Moves our app paths from consts to a struct and passes this around the app where required.

Fixes MLPAB-466

## Approach

The only real change to how anything works is injecting the Paths into the `identityOptions` struct and paths into `App()`. I've left a comment about my feelings on the approach for `identityOptions`.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
