### PR TITLE
MLPAB-522 - Use docker compose pull instead of docker compose build for Cypress tests

### DIFF
--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v4
-        with:
-          record: true
+        # with:
+        #   record: true
         env:
           CYPRESS_baseUrl: ${{ inputs.base_url }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -52,7 +52,7 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml pull
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml build
+          # docker compose -f docker-compose.yml -f docker-compose.ci.yml build
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
       - name: Manage Ingress/Configure AWS Credentials

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -51,6 +51,7 @@ jobs:
           ECR_REPOSITORY: modernising-lpa/app
           TAG: ${{ inputs.tag }}
         run: |
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml pull
           docker compose -f docker-compose.yml -f docker-compose.ci.yml build
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -52,7 +52,6 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml pull
-          # docker compose -f docker-compose.yml -f docker-compose.ci.yml build
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
       - name: Manage Ingress/Configure AWS Credentials

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -81,8 +81,6 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v4
-        # with:
-        #   record: true
         env:
           CYPRESS_baseUrl: ${{ inputs.base_url }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
# Purpose

Optimise Cypress test workflow by using the previously built image instead of rebuilding it

Fixes MLPAB-522

## Approach

- Use docker compose pull
- Remove docker compose build

## Checklist

* [x] I have performed a self-review of my own code