### PR TITLE
MLPAB-518 - Use a path in SSM parameter name to enable wildcards

### DIFF
--- a/terraform/environment/container_version_parameter.tf
+++ b/terraform/environment/container_version_parameter.tf
@@ -1,5 +1,5 @@
 resource "aws_ssm_parameter" "container_version" {
-  name     = "modernising-lpa/container-version/${local.environment_name}"
+  name     = "/modernising-lpa/container-version/${local.environment_name}"
   type     = "String"
   value    = var.container_version
   provider = aws.management_global

--- a/terraform/environment/container_version_parameter.tf
+++ b/terraform/environment/container_version_parameter.tf
@@ -1,5 +1,5 @@
 resource "aws_ssm_parameter" "container_version" {
-  name     = "modernising-lpa-${local.environment_name}-container-version"
+  name     = "modernising-lpa/container-version/${local.environment_name}"
   type     = "String"
   value    = var.container_version
   provider = aws.management_global


### PR DESCRIPTION
# Purpose

Use paths in parameter store names so that OIDC roles can safely use IAM policy document wildcards for retrieving container versions

Fixes MLPAB-518

## Approach

- use modernising-lpa/container-version/${env-name} path format

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter#name

## Checklist

* [x] I have performed a self-review of my own code