### PR TITLE
MLPAB-528 - Configure auth redirect for gov.uk sign in on UR environment

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -47,8 +47,8 @@
       "app": {
         "public_access_enabled": true,
         "env": {
-          "app_public_url": "",
-          "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",
+          "app_public_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
+          "auth_redirect_base_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
           "notify_is_production": "",
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",


### PR DESCRIPTION
# Purpose

Finish configuration of UR environment

Fixes MLPAB-528

## Approach

- Configure auth redirect and public url for UR environment

This has been applied to the UR env with the current production tag deployed

## Checklist

* [x] I have performed a self-review of my own code