### PR TITLE
MLAPB-538 - Tag path to live images with latest and main

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -61,6 +61,6 @@ jobs:
           if github.ref == 'refs/heads/main'
           then
             docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
-            docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:main
+            docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:main-${{ inputs.tag }}
           fi
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -58,4 +58,9 @@ jobs:
           ECR_REPOSITORY: modernising-lpa/app
         run: |
           docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.tag }}
+          if github.ref == 'refs/heads/main'
+          then
+            docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
+            docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:main
+          fi
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY


### PR DESCRIPTION
# Purpose

ECR lifecycle rules were not persisting images we wanted to keep as the image tags didn't contain matching patterns.

ECR lifecycle is

```
keep image tagged latest forever
keep last 10 images with main in tag
keep last 10 images with master in tag
keep untagged images for 1 day
keep all other tags for 14 days
```

Images were not being tagged with latest, main* or master* so were only being persisted for 14 days

Fixes MLPAB-538

## Approach

- add condition that if github.ref == 'refs/heads/main' add latest and main tags to the image

This should result in the path to live creating an image with `latest`, `main` and `v0.0.0` tags

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy
- https://github.com/ministryofjustice/opg-org-infra/blob/main/services/modernising-lpa/ecr.tf

## Checklist

* [x] I have performed a self-review of my own code