### PR TITLE
MLPAB-376 Make cache refresh secrets after a specified duration

### DIFF
--- a/app/internal/secrets/secrets.go
+++ b/app/internal/secrets/secrets.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -20,42 +21,72 @@ const (
 	YotiPrivateKey                 = "yoti-private-key"
 
 	cookieSessionKeys = "cookie-session-keys"
+
+	delay = time.Second
 )
 
 type secretsManager interface {
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
+type cacheItem struct {
+	untilNano  int64
+	errorCount int64
+	value      string
+}
+
+func (i *cacheItem) isFresh() bool {
+	return time.Now().UnixNano() < i.untilNano
+}
+
 type Client struct {
 	svc secretsManager
+	ttl int64
 
 	mu    sync.Mutex
-	cache map[string]string
+	cache map[string]*cacheItem
 }
 
-func NewClient(cfg aws.Config) (*Client, error) {
+func NewClient(cfg aws.Config, ttl time.Duration) (*Client, error) {
 	svc := secretsmanager.NewFromConfig(cfg)
 
-	return &Client{svc: svc, cache: map[string]string{}}, nil
+	return &Client{svc: svc, ttl: ttl.Nanoseconds(), cache: map[string]*cacheItem{}}, nil
 }
 
+// Secret retrieves the named secret from the cache. If not in the cache or the
+// item is stale then the secret is retrieved from Secrets Manager. On failure
+// the stale secret will be returned, and if that isn't possible an error.
 func (c *Client) Secret(ctx context.Context, name string) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	value, ok := c.cache[name]
-	if ok {
-		return value, nil
+	item, found := c.cache[name]
+	if found && item.isFresh() {
+		item.errorCount = 0
+		return item.value, nil
 	}
 
 	result, err := c.svc.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(name),
 	})
 	if err != nil {
+		if found {
+			item.errorCount++
+			item.untilNano += item.errorCount * delay.Nanoseconds()
+
+			return item.value, nil
+		}
+
 		return "", fmt.Errorf("error retrieving secret '%s': %w", name, err)
 	}
 
-	c.cache[name] = *result.SecretString
+	if found {
+		item.errorCount = 0
+		item.untilNano = time.Now().UnixNano() + c.ttl
+		item.value = *result.SecretString
+	} else {
+		c.cache[name] = &cacheItem{untilNano: time.Now().UnixNano() + c.ttl, value: *result.SecretString}
+	}
 
 	return *result.SecretString, nil
 }

--- a/app/main.go
+++ b/app/main.go
@@ -118,7 +118,7 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	secretsClient, err := secrets.NewClient(cfg)
+	secretsClient, err := secrets.NewClient(cfg, time.Hour)
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
This is potentially still over the top for what we have. I figured there was no point finding an LRU cache to match what we had before because the default size of 1024 was way over what we'd ever need. I've matched the 1 hour TTL but not gone as far as to implement exponential backoff (just doing a simple `errors * delay` instead).