### PR TITLE
MLPAB-669 Use a single code in link to certificate provider

### DIFF
--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -50,6 +50,7 @@ func App(
 		sessionStore,
 		lpaStore,
 		oneLoginClient,
+		dataStore,
 	)
 
 	donor.Register(
@@ -65,6 +66,7 @@ func App(
 		yotiClient,
 		yotiScenarioID,
 		notifyClient,
+		dataStore,
 	)
 
 	return withAppData(page.ValidateCsrf(rootMux, sessionStore, random.String), localizer, lang, rumConfig, staticHash)

--- a/app/internal/page/certificateprovider/login_callback.go
+++ b/app/internal/page/certificateprovider/login_callback.go
@@ -64,13 +64,6 @@ func LoginCallback(tmpl template.Template, oneLoginClient page.OneLoginClient, s
 
 		data := &loginCallbackData{App: appData}
 
-		if lpa.CertificateProviderUserData.OK {
-			data.FullName = lpa.CertificateProviderUserData.FullName
-			data.ConfirmedAt = lpa.CertificateProviderUserData.RetrievedAt
-
-			return tmpl(w, data)
-		}
-
 		if r.FormValue("error") == "access_denied" {
 			data.CouldNotConfirm = true
 
@@ -87,32 +80,37 @@ func LoginCallback(tmpl template.Template, oneLoginClient page.OneLoginClient, s
 			return err
 		}
 
-		userData, err := oneLoginClient.ParseIdentityClaim(ctx, userInfo)
-		if err != nil {
+		userData := lpa.CertificateProviderUserData
+		if !userData.OK {
+			userData, err = oneLoginClient.ParseIdentityClaim(ctx, userInfo)
+			if err != nil {
+				return err
+			}
+
+			if !userData.OK {
+				data.CouldNotConfirm = true
+
+				return tmpl(w, data)
+			} else {
+				lpa.CertificateProviderUserData = userData
+
+				if err := lpaStore.Put(ctx, lpa); err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := sesh.SetCertificateProvider(sessionStore, r, w, &sesh.CertificateProviderSession{
+			Sub:            userInfo.Sub,
+			Email:          userInfo.Email,
+			LpaID:          oneLoginSession.LpaID,
+			DonorSessionID: oneLoginSession.SessionID,
+		}); err != nil {
 			return err
 		}
 
-		if !userData.OK {
-			data.CouldNotConfirm = true
-		} else {
-			lpa.CertificateProviderUserData = userData
-
-			if err := lpaStore.Put(ctx, lpa); err != nil {
-				return err
-			}
-
-			if err := sesh.SetCertificateProvider(sessionStore, r, w, &sesh.CertificateProviderSession{
-				Sub:            userInfo.Sub,
-				Email:          userInfo.Email,
-				LpaID:          oneLoginSession.LpaID,
-				DonorSessionID: oneLoginSession.SessionID,
-			}); err != nil {
-				return err
-			}
-
-			data.FullName = userData.FullName
-			data.ConfirmedAt = userData.RetrievedAt
-		}
+		data.FullName = lpa.CertificateProviderUserData.FullName
+		data.ConfirmedAt = lpa.CertificateProviderUserData.RetrievedAt
 
 		return tmpl(w, data)
 	}

--- a/app/internal/page/certificateprovider/register.go
+++ b/app/internal/page/certificateprovider/register.go
@@ -17,11 +17,12 @@ func Register(
 	sessionStore sesh.Store,
 	lpaStore page.LpaStore,
 	oneLoginClient page.OneLoginClient,
+	dataStore page.DataStore,
 ) {
 	handleRoot := makeHandle(rootMux, logger, sessionStore, None)
 
 	handleRoot(page.Paths.CertificateProviderStart, None,
-		Start(tmpls.Get("certificate_provider_start.gohtml"), lpaStore))
+		Start(tmpls.Get("certificate_provider_start.gohtml"), lpaStore, dataStore))
 	handleRoot(page.Paths.CertificateProviderLogin, None,
 		Login(logger, oneLoginClient, sessionStore, random.String))
 	handleRoot(page.Paths.CertificateProviderLoginCallback, None,

--- a/app/internal/page/data.go
+++ b/app/internal/page/data.go
@@ -233,3 +233,8 @@ func (l *Lpa) Progress() Progress {
 
 	return p
 }
+
+type ShareCodeData struct {
+	SessionID string
+	LpaID     string
+}

--- a/app/internal/page/donor/mock_test.go
+++ b/app/internal/page/donor/mock_test.go
@@ -2,6 +2,7 @@ package donor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -171,4 +172,25 @@ func (m *mockNotifyClient) Email(ctx context.Context, email notify.Email) (strin
 func (m *mockNotifyClient) Sms(ctx context.Context, sms notify.Sms) (string, error) {
 	args := m.Called(ctx, sms)
 	return args.String(0), args.Error(1)
+}
+
+type mockDataStore struct {
+	data interface{}
+	mock.Mock
+}
+
+func (m *mockDataStore) GetAll(ctx context.Context, pk string, v interface{}) error {
+	data, _ := json.Marshal(m.data)
+	json.Unmarshal(data, v)
+	return m.Called(ctx, pk).Error(0)
+}
+
+func (m *mockDataStore) Get(ctx context.Context, pk, sk string, v interface{}) error {
+	data, _ := json.Marshal(m.data)
+	json.Unmarshal(data, v)
+	return m.Called(ctx, pk, sk).Error(0)
+}
+
+func (m *mockDataStore) Put(ctx context.Context, pk, sk string, v interface{}) error {
+	return m.Called(ctx, pk, sk, v).Error(0)
 }

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -28,6 +28,7 @@ func Register(
 	yotiClient page.YotiClient,
 	yotiScenarioID string,
 	notifyClient page.NotifyClient,
+	dataStore page.DataStore,
 ) {
 	handleRoot := makeHandle(rootMux, logger, sessionStore, None)
 
@@ -112,7 +113,7 @@ func Register(
 	handleLpa(page.Paths.AboutPayment, CanGoBack,
 		AboutPayment(logger, tmpls.Get("about_payment.gohtml"), sessionStore, payClient, appPublicUrl, random.String, lpaStore))
 	handleLpa(page.Paths.PaymentConfirmation, CanGoBack,
-		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, notifyClient, lpaStore, sessionStore, appPublicUrl))
+		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, notifyClient, lpaStore, sessionStore, appPublicUrl, dataStore, random.String))
 
 	handleLpa(page.Paths.HowToConfirmYourIdentityAndSign, CanGoBack,
 		page.Guidance(tmpls.Get("how_to_confirm_your_identity_and_sign.gohtml"), page.Paths.WhatYoullNeedToConfirmYourIdentity, lpaStore))

--- a/app/internal/page/paths.go
+++ b/app/internal/page/paths.go
@@ -149,5 +149,5 @@ func IsLpaPath(url string) bool {
 
 	return path != Paths.Auth && path != Paths.AuthRedirect &&
 		path != Paths.Dashboard && path != Paths.Start &&
-		path != Paths.CertificateProviderLogin && path != Paths.CertificateProviderLoginCallback && path != Paths.CertificateProviderYourDetails
+		path != Paths.CertificateProviderStart && path != Paths.CertificateProviderLogin && path != Paths.CertificateProviderLoginCallback && path != Paths.CertificateProviderYourDetails
 }

--- a/app/web/template/layout/page.gohtml
+++ b/app/web/template/layout/page.gohtml
@@ -42,7 +42,7 @@
             </div>
 
             <form novalidate action="/cookies-consent" method="post">
-              <input type="hidden" name="cookies-redirect" value="{{ link .App .App.Page }}" />
+              <input type="hidden" name="cookies-redirect" value="{{ link .App .App.Page }}{{ .App.Query }}" />
               <div class="govuk-button-group">
                 <button value="accept" type="submit" name="cookies" class="govuk-button" data-module="govuk-button">
                   {{ tr .App "acceptCookies" }}


### PR DESCRIPTION
I took the key design from https://amazon-dynamodb-labs.workshop.aws/game-player-data/core-usage/step1.html, which seemed sensible enough. I was going to expire the code and add a different record to tie the certificate provider to the LPA but realised if you had multiple LPAs we'd then need a dashboard type thing to pick from, so I've gone the simple route of requiring the code each time on sign in. This can obviously be changed later.