### PR TITLE
MLPAB-609 - Deploy to ur environment from github user interface

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -7,7 +7,7 @@ on:
         type: string
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.sha }}
+        default: ${{ github.ref }}
         required: false
         type: string
 

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -7,7 +7,7 @@ on:
         type: string
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.ref }}
+        default: ${{ github.sha }}
         required: false
         type: string
 

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -5,6 +5,11 @@ on:
         description: 'Tag for docker image'
         required: true
         type: string
+      checkout_tag:
+        description: 'Ref or tag to checkout'
+        default: ${{ github.ref }}
+        required: false
+        type: string
 
 defaults:
   run:
@@ -21,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout_tag }}
       - name: Build Image
         id: build_image
         run: |

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -11,7 +11,7 @@ on:
         type: string
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.sha }}
+        default: ${{ github.ref }}
         required: false
         type: string
     outputs:

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -19,6 +19,11 @@ on:
       url:
         description: "URL for environment"
         value: ${{ jobs.terraform_environment_workflow.outputs.url }}
+      checkout_tag:
+        description: 'Ref or tag to checkout'
+        default: ${{ github.ref }}
+        required: false
+        type: string
 jobs:
   terraform_environment_workflow:
     runs-on: ubuntu-latest
@@ -29,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.checkout_tag }}
           fetch-depth: '0'
       - uses: unfor19/install-aws-cli-action@v1
       - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -9,6 +9,11 @@ on:
         description: 'The docker image tag to deploy in the environment'
         required: true
         type: string
+      checkout_tag:
+        description: 'Ref or tag to checkout'
+        default: ${{ github.ref }}
+        required: false
+        type: string
     outputs:
       terraform_workspace_name:
         description: "Name of Terraform workspace"
@@ -19,11 +24,7 @@ on:
       url:
         description: "URL for environment"
         value: ${{ jobs.terraform_environment_workflow.outputs.url }}
-      checkout_tag:
-        description: 'Ref or tag to checkout'
-        default: ${{ github.ref }}
-        required: false
-        type: string
+
 jobs:
   terraform_environment_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -11,7 +11,7 @@ on:
         type: string
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.ref }}
+        default: ${{ github.sha }}
         required: false
         type: string
     outputs:

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -22,7 +22,7 @@ on:
         default: cypress/e2e/**.cy.js
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.sha }}
+        default: ${{ github.ref }}
         required: false
         type: string
 

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: cypress/e2e/**.cy.js
+      checkout_tag:
+        description: 'Ref or tag to checkout'
+        default: ${{ github.ref }}
+        required: false
+        type: string
 
 defaults:
   run:
@@ -30,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout_tag }}
       - uses: unfor19/install-aws-cli-action@v1
         name: Run Against Image/aws-cli-action
         if: inputs.run_against_image

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -22,7 +22,7 @@ on:
         default: cypress/e2e/**.cy.js
       checkout_tag:
         description: 'Ref or tag to checkout'
-        default: ${{ github.ref }}
+        default: ${{ github.sha }}
         required: false
         type: string
 

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -81,6 +81,6 @@ jobs:
     steps:
       - name: End of UR Deployment Workflow
         run: |
-          echo "${{ needs.ur_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
+          echo "${{ needs.ur_deploy.outputs.terraform_workspace_name }} UR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.ur_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.ur_deploy.outputs.url }}"

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -45,10 +45,7 @@ jobs:
 
   ur_deploy:
       name: PR Environment Deploy
-      needs: [
-        docker_build_scan_push,
-        ui_tests_image
-      ]
+      needs: [ui_tests_image]
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
         workspace_name: ur
@@ -80,7 +77,7 @@ jobs:
     environment:
       name: "ur"
       url: "https://${{ needs.ur_deploy.outputs.url }}"
-    needs: [ur_deploy, ui_tests_pr_env]
+    needs: [ui_tests_pr_env]
     steps:
       - name: End of UR Deployment Workflow
         run: |

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -1,0 +1,115 @@
+name: "Deploy to UR Environment"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_to_deploy:
+        description: 'Tag to deploy to ur environment'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
+  pull-requests: read
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  docker_build_scan_push:
+    name: Docker Build, Scan and Push
+    if: |
+      always() &&
+      (needs.detect_changes.outputs.changes_detected == 'true') &&
+      (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped')
+    uses: ./.github/workflows/docker_job.yml
+    needs: [
+      go_unit_tests,
+      create_tags
+      ]
+    with:
+      tag: ${{ input.tag_to_deploy }}
+      checkout_tag : ${{ input.tag_to_deploy }}
+
+  ui_tests_image:
+    name: Run Cypress UI Tests On Images
+    if: |
+      needs.detect_changes.outputs.changes_detected == 'true' &&
+      needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped'
+    uses: ./.github/workflows/ui_test_job.yml
+    needs: [docker_build_scan_push, create_tags]
+    with:
+      run_against_image: true
+      tag: ${{ input.tag_to_deploy}}
+      checkout_tag: ${{ input.tag_to_deploy}}
+    secrets: inherit # pragma: allowlist secret
+
+  pr_deploy:
+      name: PR Environment Deploy
+      if: |
+        always() &&
+        (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped') &&
+        (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped') &&
+        (needs.ui_tests_image.result == 'success' || needs.ui_tests_image.result == 'skipped')
+      needs: [
+        create_tags,
+        go_unit_tests,
+        docker_build_scan_push,
+        ui_tests_image
+      ]
+      uses: ./.github/workflows/terraform_environment_job.yml
+      with:
+        workspace_name: ur
+        version_tag: ${{ input.tag_to_deploy}}
+        checkout_tag: ${{ input.tag_to_deploy}}
+      secrets: inherit # pragma: allowlist secret
+
+  ui_tests_pr_env:
+    name: Run Cypress UI Tests On PR Environment
+    if: |
+      always() &&
+      needs.pr_deploy.result == 'success'
+    uses: ./.github/workflows/ui_test_job.yml
+    needs: [pr_deploy, create_tags]
+    with:
+      run_against_image: false
+      base_url: "https://${{ needs.pr_deploy.outputs.url }}"
+      tag: ${{ input.tag_to_deploy}}
+      checkout_tag: ${{ input.tag_to_deploy}}
+    secrets: inherit # pragma: allowlist secret
+
+  always_remove_ingress:
+    name: Remove CI ingress from environment
+    if: always()
+    uses: ./.github/workflows/remove_ingress_job.yml
+    needs: [ui_tests_pr_env]
+    secrets: inherit # pragma: allowlist secret
+
+  end_of_ur_deployment_workflow:
+    name: End of UR Deployment Workflow
+    if: |
+      always() &&
+      needs.pr_deploy.result == 'success' &&
+      needs.create_tags.result == 'success' &&
+      needs.ui_tests_pr_env.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: "ur"
+      url: "https://${{ needs.pr_deploy.outputs.url }}"
+    needs: [pr_deploy, ui_tests_pr_env]
+    steps:
+      - name: End of UR Deployment Workflow
+        run: |
+          echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
+          echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
+          echo "URL: https://${{ needs.pr_deploy.outputs.url }}"

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -33,10 +33,6 @@ jobs:
       (needs.detect_changes.outputs.changes_detected == 'true') &&
       (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped')
     uses: ./.github/workflows/docker_job.yml
-    needs: [
-      go_unit_tests,
-      create_tags
-      ]
     with:
       tag: ${{ input.tag_to_deploy }}
       checkout_tag : ${{ input.tag_to_deploy }}
@@ -47,14 +43,14 @@ jobs:
       needs.detect_changes.outputs.changes_detected == 'true' &&
       needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped'
     uses: ./.github/workflows/ui_test_job.yml
-    needs: [docker_build_scan_push, create_tags]
+    needs: [docker_build_scan_push]
     with:
       run_against_image: true
       tag: ${{ input.tag_to_deploy}}
       checkout_tag: ${{ input.tag_to_deploy}}
     secrets: inherit # pragma: allowlist secret
 
-  pr_deploy:
+  ur_deploy:
       name: PR Environment Deploy
       if: |
         always() &&
@@ -62,8 +58,6 @@ jobs:
         (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped') &&
         (needs.ui_tests_image.result == 'success' || needs.ui_tests_image.result == 'skipped')
       needs: [
-        create_tags,
-        go_unit_tests,
         docker_build_scan_push,
         ui_tests_image
       ]
@@ -74,16 +68,16 @@ jobs:
         checkout_tag: ${{ input.tag_to_deploy}}
       secrets: inherit # pragma: allowlist secret
 
-  ui_tests_pr_env:
+  ui_tests_ur_env:
     name: Run Cypress UI Tests On PR Environment
     if: |
       always() &&
-      needs.pr_deploy.result == 'success'
+      needs.ur_deploy.result == 'success'
     uses: ./.github/workflows/ui_test_job.yml
-    needs: [pr_deploy, create_tags]
+    needs: [ur_deploy]
     with:
       run_against_image: false
-      base_url: "https://${{ needs.pr_deploy.outputs.url }}"
+      base_url: "https://${{ needs.ur_deploy.outputs.url }}"
       tag: ${{ input.tag_to_deploy}}
       checkout_tag: ${{ input.tag_to_deploy}}
     secrets: inherit # pragma: allowlist secret
@@ -99,17 +93,17 @@ jobs:
     name: End of UR Deployment Workflow
     if: |
       always() &&
-      needs.pr_deploy.result == 'success' &&
+      needs.ur_deploy.result == 'success' &&
       needs.create_tags.result == 'success' &&
       needs.ui_tests_pr_env.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: "ur"
-      url: "https://${{ needs.pr_deploy.outputs.url }}"
-    needs: [pr_deploy, ui_tests_pr_env]
+      url: "https://${{ needs.ur_deploy.outputs.url }}"
+    needs: [ur_deploy, ui_tests_pr_env]
     steps:
       - name: End of UR Deployment Workflow
         run: |
-          echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
-          echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
-          echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
+          echo "${{ needs.ur_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
+          echo "Tag Deployed: ${{ needs.ur_deploy.outputs.terraform_container_version }}"
+          echo "URL: https://${{ needs.ur_deploy.outputs.url }}"

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -28,10 +28,6 @@ defaults:
 jobs:
   docker_build_scan_push:
     name: Docker Build, Scan and Push
-    if: |
-      always() &&
-      (needs.detect_changes.outputs.changes_detected == 'true') &&
-      (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped')
     uses: ./.github/workflows/docker_job.yml
     with:
       tag: ${{ input.tag_to_deploy }}
@@ -39,9 +35,6 @@ jobs:
 
   ui_tests_image:
     name: Run Cypress UI Tests On Images
-    if: |
-      needs.detect_changes.outputs.changes_detected == 'true' &&
-      needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped'
     uses: ./.github/workflows/ui_test_job.yml
     needs: [docker_build_scan_push]
     with:
@@ -52,11 +45,6 @@ jobs:
 
   ur_deploy:
       name: PR Environment Deploy
-      if: |
-        always() &&
-        (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped') &&
-        (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped') &&
-        (needs.ui_tests_image.result == 'success' || needs.ui_tests_image.result == 'skipped')
       needs: [
         docker_build_scan_push,
         ui_tests_image
@@ -70,9 +58,6 @@ jobs:
 
   ui_tests_ur_env:
     name: Run Cypress UI Tests On PR Environment
-    if: |
-      always() &&
-      needs.ur_deploy.result == 'success'
     uses: ./.github/workflows/ui_test_job.yml
     needs: [ur_deploy]
     with:
@@ -91,11 +76,6 @@ jobs:
 
   end_of_ur_deployment_workflow:
     name: End of UR Deployment Workflow
-    if: |
-      always() &&
-      needs.ur_deploy.result == 'success' &&
-      needs.create_tags.result == 'success' &&
-      needs.ui_tests_pr_env.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: "ur"


### PR DESCRIPTION
# Purpose

Maintain a consistent environment for user research sessions by allowing team members to picka tag to build and deploy

Fixes MLPAB-609

## Approach

- Create a dispatch workflow that deploys to the ur environment
- add checkout tag to relevant jobs that defaults to the current ref

## Learning

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
- https://github.com/actions/checkout

## Checklist

* [x] I have performed a self-review of my own code