### PR TITLE
MLPAB-680 - Specify secrets for each job on all workflows

### DIFF
--- a/.github/workflows/remove_ingress_job.yml
+++ b/.github/workflows/remove_ingress_job.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    secrets:
+      aws_access_key_id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS Secret Access Key'
+        required: true
 
 defaults:
   run:
@@ -15,8 +22,8 @@ jobs:
       - name: Manage Ingress/Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-duration-seconds: 900
           role-session-name: OPGModernisingLPATerraformGithubAction

--- a/.github/workflows/terraform_account_job.yml
+++ b/.github/workflows/terraform_account_job.yml
@@ -5,6 +5,13 @@ on:
         description: 'The terraform workspace to target for account actions'
         required: true
         type: string
+    secrets:
+      aws_access_key_id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS Secret Access Key'
+        required: true
 jobs:
   terraform_account_workflow:
     runs-on: ubuntu-latest
@@ -21,8 +28,8 @@ jobs:
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-duration-seconds: 3600
           role-session-name: OPGModernisingLPATerraformGithubAction

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -24,6 +24,16 @@ on:
       url:
         description: "URL for environment"
         value: ${{ jobs.terraform_environment_workflow.outputs.url }}
+    secrets:
+      aws_access_key_id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS Secret Access Key'
+        required: true
+      ssh_deploy_key:
+        description: 'SSH Deploy Key'
+        required: true
 
 jobs:
   terraform_environment_workflow:
@@ -45,14 +55,14 @@ jobs:
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-duration-seconds: 3600
           role-session-name: OPGModernisingLPATerraformGithubAction
       - uses: webfactory/ssh-agent@v0.7.0
         with:
-          ssh-private-key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.ssh_deploy_key }}
 
       - name: Lint Terraform
         id: tf_lint

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -35,7 +35,7 @@ on:
       cypress_record_key:
         description: 'Cypress Record Key'
         required: true
-      github_token:
+      github_access_token:
         description: 'Github Token'
         required: true
 
@@ -109,7 +109,7 @@ jobs:
         env:
           CYPRESS_baseUrl: ${{ inputs.base_url }}
           CYPRESS_RECORD_KEY: ${{ secrets.cypress_record_key }}
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.github_access_token }}
         with:
           spec: ${{ inputs.spec }}
 

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -34,10 +34,10 @@ on:
         required: true
       cypress_record_key:
         description: 'Cypress Record Key'
-        required: false
+        required: true
       github_access_token:
         description: 'Github Token'
-        required: false
+        required: true
 
 defaults:
   run:

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -34,10 +34,10 @@ on:
         required: true
       cypress_record_key:
         description: 'Cypress Record Key'
-        required: true
+        required: false
       github_access_token:
         description: 'Github Token'
-        required: true
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -83,7 +83,7 @@ jobs:
         if: inputs.run_against_image != true
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ secrets.aws_secret_access_key }}
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-duration-seconds: 900

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -25,6 +25,19 @@ on:
         default: ${{ github.ref }}
         required: false
         type: string
+    secrets:
+      aws_access_key_id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS Secret Access Key'
+        required: true
+      cypress_record_key:
+        description: 'Cypress Record Key'
+        required: true
+      github_token:
+        description: 'Github Token'
+        required: true
 
 defaults:
   run:
@@ -44,8 +57,8 @@ jobs:
         if: inputs.run_against_image
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-ci
           role-duration-seconds: 900
@@ -70,8 +83,8 @@ jobs:
         if: inputs.run_against_image != true
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-access-key-id: ${{ secrets.aws_secret_access_key }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-west-1
           role-duration-seconds: 900
           role-session-name: OPGModernisingLPATerraformGithubAction
@@ -95,8 +108,8 @@ jobs:
         uses: cypress-io/github-action@v5
         env:
           CYPRESS_baseUrl: ${{ inputs.base_url }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.cypress_record_key }}
+          GITHUB_TOKEN: ${{ secrets.github_token }}
         with:
           spec: ${{ inputs.spec }}
 

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -39,14 +39,15 @@ jobs:
     needs: [go_unit_tests,create_tags]
     with:
       tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
 
   terraform_account_workflow_development:
     name: TF Apply Dev Account
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: development
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   terraform_account_workflow_preproduction:
     name: TF Apply Preprod Account
@@ -54,7 +55,9 @@ jobs:
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: preproduction
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   preproduction_deploy:
     name: Preproduction Deploy
@@ -63,7 +66,10 @@ jobs:
     with:
       workspace_name: preproduction
       version_tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
 
   ui_tests_preproduction_env:
     name: Run Cypress UI Tests On Preproduction Environment
@@ -73,7 +79,11 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.preproduction_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   preproduction_deploy_complete:
     name: Preproduction Deployment
@@ -99,7 +109,9 @@ jobs:
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: production
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   production_deploy:
     name: Production Deploy
@@ -108,7 +120,10 @@ jobs:
     with:
       workspace_name: production
       version_tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
 
   end_of_main_workflow:
     name: End of Main Workflow

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -102,7 +102,7 @@ jobs:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
       cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
 
   pr_deploy:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -60,7 +60,10 @@ jobs:
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: development
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   terraform_account_workflow_preproduction:
     name: TF Plan Preprod Account
@@ -68,7 +71,10 @@ jobs:
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: preproduction
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   terraform_account_workflow_production:
     name: TF Plan Prod Account
@@ -76,7 +82,10 @@ jobs:
     uses: ./.github/workflows/terraform_account_job.yml
     with:
       workspace_name: production
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   ui_tests_image:
     name: Run Cypress UI Tests On Images
@@ -88,7 +97,13 @@ jobs:
     with:
       run_against_image: true
       tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+
 
   pr_deploy:
       name: PR Environment Deploy
@@ -107,7 +122,11 @@ jobs:
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
         version_tag: ${{ needs.create_tags.outputs.version_tag }}
-      secrets: inherit # pragma: allowlist secret
+      # secrets: inherit # pragma: allowlist secret
+      secrets:
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+        ssh_deploy_key: ${{ secrets.OPG_WEBLATE_DEPLOY_KEY_PRIVATE_KEY }}
 
   ui_tests_pr_env:
     name: Run Cypress UI Tests On PR Environment
@@ -120,14 +139,20 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   always_remove_ingress:
     name: Remove CI ingress from environment
     if: always()
     uses: ./.github/workflows/remove_ingress_job.yml
     needs: [ui_tests_pr_env]
-    secrets: inherit # pragma: allowlist secret
+    # secrets: inherit # pragma: allowlist secret
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   end_of_pr_workflow:
     name: End of PR Workflow

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -126,7 +126,7 @@ jobs:
       secrets:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
-        ssh_deploy_key: ${{ secrets.OPG_WEBLATE_DEPLOY_KEY_PRIVATE_KEY }}
+        ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
 
   ui_tests_pr_env:
     name: Run Cypress UI Tests On PR Environment

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -143,6 +143,8 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   always_remove_ingress:
     name: Remove CI ingress from environment

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/workflow_path_to_live.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 104,
         "is_secret": false
       }
     ],
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-02T18:12:11Z"
+  "generated_at": "2023-02-17T12:39:37Z"
 }


### PR DESCRIPTION
# Purpose

Limit the secrets passed to each job so that only those needed are given

Fixes MLPAB-680

## Approach

- specify secrets for each job on pr workflow
- specify secrets for each job on path to live workflow

## Learning

- https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

## Checklist

* [x] I have performed a self-review of my own code