### PR TITLE
Use donor's email as default for payment

### DIFF
--- a/app/internal/page/donor/about_payment.go
+++ b/app/internal/page/donor/about_payment.go
@@ -38,7 +38,7 @@ func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.S
 				Reference:   randomString(12),
 				Description: "Property and Finance LPA",
 				ReturnUrl:   appPublicUrl + appData.BuildUrl(page.Paths.PaymentConfirmation),
-				Email:       "a@b.com",
+				Email:       lpa.You.Email,
 				Language:    appData.Lang.String(),
 			}
 

--- a/app/internal/page/donor/about_payment_test.go
+++ b/app/internal/page/donor/about_payment_test.go
@@ -106,7 +106,7 @@ func TestPostAboutPayment(t *testing.T) {
 				lpaStore := newMockLpaStore(t)
 				lpaStore.
 					On("Get", r.Context()).
-					Return(&page.Lpa{CertificateProvider: actor.CertificateProvider{}}, nil)
+					Return(&page.Lpa{You: actor.Person{Email: "a@b.com"}, CertificateProvider: actor.CertificateProvider{}}, nil)
 
 				template := newMockTemplate(t)
 				template.


### PR DESCRIPTION
After seeing this in the demo for the Nth time, I figured it should really be doing this