### PR TITLE
Actually fix jwks timeout test

### DIFF
--- a/cypress/e2e/certificate-provider/enter-reference-number.cy.js
+++ b/cypress/e2e/certificate-provider/enter-reference-number.cy.js
@@ -1,5 +1,5 @@
 describe('Enter reference number', () => {
-    it('can enter a valid reference number', { defaultCommandTimeout: 6000 }, () => {
+    it('can enter a valid reference number', { pageLoadTimeout: 6000 }, () => {
         cy.visit('/testing-start?completeLpa=1&startCpFlowDonorHasPaid=1&useTestShareCode=1');
 
         cy.contains('a', 'Start').click()

--- a/cypress/e2e/certificate-provider/enter-reference-number.cy.js
+++ b/cypress/e2e/certificate-provider/enter-reference-number.cy.js
@@ -1,5 +1,5 @@
 describe('Enter reference number', () => {
-    it('can enter a valid reference number', () => {
+    it('can enter a valid reference number', { defaultCommandTimeout: 6000 }, () => {
         cy.visit('/testing-start?completeLpa=1&startCpFlowDonorHasPaid=1&useTestShareCode=1');
 
         cy.contains('a', 'Start').click()
@@ -14,7 +14,7 @@ describe('Enter reference number', () => {
             cy.url().should('contain', '/certificate-provider-check-your-name')
         } else {
             cy.origin('https://signin.integration.account.gov.uk', () => {
-                cy.url({ timeout: 6000 }).should('contain', '/')
+                cy.url().should('contain', '/')
             })
         }
     });


### PR DESCRIPTION
# Purpose

We're still getting flaky failures for the test that lands on one login /.jwks despite seemingly bumping the timeout. Turns out the timeout wasn't boosted for the right event in cypress, it should have been pageLoad. Its a little confusing where to add this on a specific command in the test so I've boosted it for the whole spec instead.