### PR TITLE
MLPAB-696 - Create healthcheck

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,23 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.54.0"
-  constraints = "4.54.0"
+  version     = "4.57.1"
+  constraints = "4.57.1"
   hashes = [
-    "h1:5kHs3DzABjYybNL+rkl7oiRAPup1SnhFd0TC83qcDZ8=",
-    "h1:8F5YQIE6YgG9+THTQv/m9utVEch0GwI4+vi0bmKKmpA=",
-    "h1:BGib+JVRkTJBZcgSySan5645HD+OVRedZNgXozN7OPI=",
-    "h1:CvZ2TNI0ImPJN1xxCCZsrU5mEQXcyfPcEWM7u7tMfPs=",
-    "h1:DIFLuKBXhHyocPD33cgVeg1JrkB/WT0WLX0v+L8BD5U=",
-    "h1:HseI01em8j2/fhiydrCgsOHOjSfllDETLAmISXWCC4I=",
-    "h1:VyzlgzOAYcwGzrpWGoKmJUhOAnYj54edFu82uv4budw=",
-    "h1:ZruBKATjoiQ2Ee2j1zoDIKuTb1gz9SQXReWpzEi3md4=",
-    "h1:eiPVhVhAawhvnZIwtRRM4y7UpfWSJpYXFHwml1M2LB0=",
-    "h1:gr0Xlk9orKv2lMVbyGpiPHdBpyQzTblOqto3JF517DQ=",
-    "h1:j/L01+hlHVM2X2VrkQC2WtMZyu4ZLhDMw+HDJ7k0Y2Q=",
-    "h1:k4XBt5tpRagyiMgU8UjjbwfockiTIqQBnVohS1AmjAk=",
-    "h1:kprzRGcLNMqsf4643+PfmXiw5ax5tTqtqudBaR3LJzU=",
-    "h1:tQZshYGaphFASlCJMo+vWin4arIlvwOkE4IiIwxO5vQ=",
+    "h1:Qfq7Q9aCQqdl7w439mCMm89126n8DsDAmg6H8gXhnLI=",
+    "zh:44200c213ddb138df80d2a5ad86c2ebadbb5fd1d08cd7e4fc56ec6dca927659b",
+    "zh:469e6fe6a9e99e60cb168d32f05e2e9a83cf161f39160d075ff96f7674c510e1",
+    "zh:6110ba2c15a2268652ec9ea3797dd0216de84ece428055c49eaf9caa2be1ed62",
+    "zh:62ed7348acca44f64fc087e879e01cfa4e084c7600cc91e8bb7683f8065a9c79",
+    "zh:7a80e6fa9b35be178bb566093f7984dd6ffb7ad9d40b9dd5d5907f054f0c3e60",
+    "zh:8793043c8575a598c1a7cbefcb65ee1776b0061eba719098e552a3adc88f3090",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a777a0082114e273b7b3eb14095a3f6f6e703c1aff61ffb1f0846bb869e6dfc7",
+    "zh:b060c3b2973097f2087a98ac6aad7c9c89fe80f7cf3027019049feafc3f8305b",
+    "zh:e7035e74563f4486848ea1feb60852175353790bc374e0e97e241a88dc0908f7",
+    "zh:eaaa8e9eba09ada41e13116d53d4baece04fead8fcf3eab68cca3a67ed738e18",
+    "zh:ec52d8f95a84fad8fe1aae169c89d0c54d5401f75caae0869ad8182c6b6db65b",
+    "zh:f0e33174025b1b57ecfbdd09f2a59c2559ee94d7681e5ae09079e2822ec54ecf",
+    "zh:f69790a21380e5aab9303a252564737333e1e95b5d25567681630e49b17e3ec7",
+    "zh:ff6053942c40a99904bd407f3c082c1fa8f927ecce0374566eb7e8ee8145e582",
   ]
 }
 

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -23,20 +23,20 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.2.3"
+  version = "2.3.0"
   hashes = [
-    "h1:FvRIEgCmAezgZUqb2F+PZ9WnSSnR5zbEM2ZI+GLmbMk=",
-    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
-    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
-    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "h1:U+DbBqKnXSIqC2z7qIko2dy8w6wwuZd89orPvfeqHk0=",
+    "zh:1f1920b3f78c31c6b69cdfe1e016a959667c0e2d01934e1a084b94d5a02cd9d2",
+    "zh:550a3cdae0ddb350942624e7b2e8b31d28bc15c20511553432413b1f38f4b214",
+    "zh:68d1d9ccbfce2ce56b28a23b22833a5369d4c719d6d75d50e101a8a8dbe33b9b",
+    "zh:6ae3ad6d865a906920c313ec2f413d080efe32c230aca711fd106b4cb9022ced",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
-    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
-    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
-    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
-    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
-    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
-    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
-    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+    "zh:a0f413d50f54124057ae3dcd9353a797b84e91dc34bcf85c34a06f8aef1f9b12",
+    "zh:a2ac6d4088ceddcd73d88505e18b8226a6e008bff967b9e2d04254ef71b4ac6b",
+    "zh:a851010672e5218bdd4c4ea1822706c9025ef813a03da716d647dd6f8e2cffb0",
+    "zh:aa797561755041ef2fad99ee9ffc12b5e724e246bb019b21d7409afc2ece3232",
+    "zh:c6afa960a20d776f54bb1fc260cd13ead17280ebd87f05b9abcaa841ed29d289",
+    "zh:df0975e86b30bb89717b8c8d6d4690b21db66de06e79e6d6cfda769f3304afe6",
+    "zh:f0d3cc3da72135efdbe8f4cfbfb0f2f7174827887990a5545e6db1981f0d3a7c",
   ]
 }

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -26,6 +26,6 @@ resource "aws_route53_health_check" "service_root" {
   request_interval  = 30
   resource_path     = "/health-check"
   measure_latency   = true
-  regions           = ["us-east-1", "eu-west-1"]
+  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
   provider          = aws.global
 }

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -28,4 +28,7 @@ resource "aws_route53_health_check" "health_check" {
   measure_latency   = true
   regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
   provider          = aws.global
+  tags = {
+    Name = "${local.environment_name}-health-check"
+  }
 }

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -24,6 +24,7 @@ resource "aws_route53_health_check" "service_root" {
   type              = "HTTPS"
   failure_threshold = 1
   request_interval  = 30
+  resource_path     = "/health-check"
   measure_latency   = true
   regions           = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
   provider          = aws.global

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -1,0 +1,30 @@
+resource "aws_cloudwatch_metric_alarm" "service_root" {
+  alarm_description   = "${local.environment_name} service root health check"
+  alarm_name          = "${local.environment_name}-service-root-healthcheck-alarm"
+  actions_enabled     = false
+  comparison_operator = "LessThanThreshold"
+  datapoints_to_alarm = 1
+  evaluation_periods  = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.service_root.id
+  }
+
+  provider = aws.global
+}
+
+resource "aws_route53_health_check" "service_root" {
+  fqdn              = aws_route53_record.app.fqdn
+  reference_name    = "${substr(local.environment_name, 0, 20)}-service-root"
+  port              = 443
+  type              = "HTTPS"
+  failure_threshold = 1
+  request_interval  = 30
+  measure_latency   = true
+  regions           = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
+  provider          = aws.global
+}

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -1,3 +1,19 @@
+resource "aws_route53_health_check" "health_check" {
+  fqdn              = aws_route53_record.app.fqdn
+  reference_name    = "${substr(local.environment_name, 0, 20)}-health-check"
+  port              = 443
+  type              = "HTTPS"
+  failure_threshold = 1
+  request_interval  = 30
+  resource_path     = "/health-check"
+  measure_latency   = true
+  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
+  provider          = aws.global
+  tags = {
+    Name = "${local.environment_name}-health-check"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "health_check" {
   alarm_description   = "${local.environment_name} health check"
   alarm_name          = "${local.environment_name}-healthcheck-alarm"
@@ -15,20 +31,4 @@ resource "aws_cloudwatch_metric_alarm" "health_check" {
   }
 
   provider = aws.global
-}
-
-resource "aws_route53_health_check" "health_check" {
-  fqdn              = aws_route53_record.app.fqdn
-  reference_name    = "${substr(local.environment_name, 0, 20)}-health-check"
-  port              = 443
-  type              = "HTTPS"
-  failure_threshold = 1
-  request_interval  = 30
-  resource_path     = "/health-check"
-  measure_latency   = true
-  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
-  provider          = aws.global
-  tags = {
-    Name = "${local.environment_name}-health-check"
-  }
 }

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -26,6 +26,6 @@ resource "aws_route53_health_check" "service_root" {
   request_interval  = 30
   resource_path     = "/health-check"
   measure_latency   = true
-  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1", "sa-east-1"]
+  regions           = ["us-east-1", "eu-west-1"]
   provider          = aws.global
 }

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -1,6 +1,6 @@
-resource "aws_cloudwatch_metric_alarm" "service_root" {
-  alarm_description   = "${local.environment_name} service root health check"
-  alarm_name          = "${local.environment_name}-service-root-healthcheck-alarm"
+resource "aws_cloudwatch_metric_alarm" "health_check" {
+  alarm_description   = "${local.environment_name} health check"
+  alarm_name          = "${local.environment_name}-healthcheck-alarm"
   actions_enabled     = false
   comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = 1
@@ -11,15 +11,15 @@ resource "aws_cloudwatch_metric_alarm" "service_root" {
   statistic           = "Minimum"
   threshold           = 1
   dimensions = {
-    HealthCheckId = aws_route53_health_check.service_root.id
+    HealthCheckId = aws_route53_health_check.health_check.id
   }
 
   provider = aws.global
 }
 
-resource "aws_route53_health_check" "service_root" {
+resource "aws_route53_health_check" "health_check" {
   fqdn              = aws_route53_record.app.fqdn
-  reference_name    = "${substr(local.environment_name, 0, 20)}-service-root"
+  reference_name    = "${substr(local.environment_name, 0, 20)}-health-check"
   port              = 443
   type              = "HTTPS"
   failure_threshold = 1

--- a/terraform/environment/healthcheck.tf
+++ b/terraform/environment/healthcheck.tf
@@ -26,6 +26,6 @@ resource "aws_route53_health_check" "service_root" {
   request_interval  = 30
   resource_path     = "/health-check"
   measure_latency   = true
-  regions           = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
+  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1", "sa-east-1"]
   provider          = aws.global
 }

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "app_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["us-east-1", "eu-west-1"]
+  regions  = ["us-east-1", "eu-west-1", "ap-southeast-1"]
   provider = aws.region
 }
 

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -140,13 +140,6 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
-resource "aws_security_group" "loadbalancer_route53" {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-loadbalancer-route53"
-  description = "Allow Route53 healthchecks"
-  vpc_id      = var.network.vpc_id
-  provider    = aws.region
-}
-
 resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
   description       = "Loadbalancer ingresss from Route53 healthchecks"
   type              = "ingress"
@@ -154,6 +147,6 @@ resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
   from_port         = "443"
   to_port           = "443"
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
-  security_group_id = aws_security_group.loadbalancer_route53.id
+  security_group_id = aws_security_group.app_loadbalancer.id
   provider          = aws.region
 }

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "app_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
+  regions  = ["us-east-1", "eu-west-1"]
   provider = aws.region
 }
 

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "app_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["GLOBAL"]
+  regions  = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
   provider = aws.region
 }
 

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -133,3 +133,24 @@ resource "aws_security_group_rule" "app_loadbalancer_egress" {
   security_group_id = aws_security_group.app_loadbalancer.id
   provider          = aws.region
 }
+
+data "aws_ip_ranges" "route53_healthchecks" {
+  services = ["route53_healthchecks"]
+  regions  = ["GLOBAL"]
+}
+
+resource "aws_security_group" "loadbalancer_route53" {
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-loadbalancer-route53"
+  description = "Allow Route53 healthchecks"
+  vpc_id      = var.network.vpc_id
+}
+
+resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
+  description       = "Loadbalancer ingresss from Route53 healthchecks"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "443"
+  to_port           = "443"
+  cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+  security_group_id = aws_security_group.loadbalancer_route53.id
+}

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -137,12 +137,14 @@ resource "aws_security_group_rule" "app_loadbalancer_egress" {
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
   regions  = ["GLOBAL"]
+  provider = aws.region
 }
 
 resource "aws_security_group" "loadbalancer_route53" {
   name_prefix = "${data.aws_default_tags.current.tags.environment-name}-loadbalancer-route53"
   description = "Allow Route53 healthchecks"
   vpc_id      = var.network.vpc_id
+  provider    = aws.region
 }
 
 resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
@@ -153,4 +155,5 @@ resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
   to_port           = "443"
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
   security_group_id = aws_security_group.loadbalancer_route53.id
+  provider          = aws.region
 }

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -100,13 +100,19 @@ resource "aws_security_group_rule" "app_loadbalancer_port_80_redirect_ingress" {
   provider          = aws.region
 }
 
+data "aws_ip_ranges" "route53_healthchecks" {
+  services = ["route53_healthchecks"]
+  regions  = ["GLOBAL"]
+  provider = aws.region
+}
+
 resource "aws_security_group_rule" "app_loadbalancer_ingress" {
   description       = "Port 443 ingress from the allow list to the application load balancer"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  cidr_blocks       = concat(var.ingress_allow_list_cidr, data.aws_ip_ranges.route53_healthchecks.cidr_blocks) #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.app_loadbalancer.id
   provider          = aws.region
 }
@@ -134,19 +140,14 @@ resource "aws_security_group_rule" "app_loadbalancer_egress" {
   provider          = aws.region
 }
 
-data "aws_ip_ranges" "route53_healthchecks" {
-  services = ["route53_healthchecks"]
-  regions  = ["GLOBAL"]
-  provider = aws.region
-}
 
-resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
-  description       = "Loadbalancer ingresss from Route53 healthchecks"
-  type              = "ingress"
-  protocol          = "tcp"
-  from_port         = "443"
-  to_port           = "443"
-  cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
-  security_group_id = aws_security_group.app_loadbalancer.id
-  provider          = aws.region
-}
+# resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
+#   description       = "Loadbalancer ingresss from Route53 healthchecks"
+#   type              = "ingress"
+#   protocol          = "tcp"
+#   from_port         = "443"
+#   to_port           = "443"
+#   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+#   security_group_id = aws_security_group.app_loadbalancer.id
+#   provider          = aws.region
+# }

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -301,7 +301,7 @@ locals {
           value = var.app_env_vars.yoti_scenario_id
         },
         {
-          name = "YOTI_CERTIFICATE_PROVIDER_SCENARIO_ID",
+          name  = "YOTI_CERTIFICATE_PROVIDER_SCENARIO_ID",
           value = var.app_env_vars.yoti_certificate_provider_scenario_id,
         },
         {

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.54.0"
+      version = "4.57.1"
     }
   }
   required_version = ">= 1.2.2"

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -21,13 +21,13 @@ variable "environments" {
       app = object({
         public_access_enabled = bool
         env = object({
-          app_public_url         = string
-          auth_redirect_base_url = string
-          notify_is_production   = string
-          yoti_client_sdk_id     = string
-          yoti_scenario_id       = string
+          app_public_url                        = string
+          auth_redirect_base_url                = string
+          notify_is_production                  = string
+          yoti_client_sdk_id                    = string
+          yoti_scenario_id                      = string
           yoti_certificate_provider_scenario_id = string
-          yoti_sandbox           = string
+          yoti_sandbox                          = string
         })
       })
       backups = object({


### PR DESCRIPTION
# Purpose

Monitor service uptime

Uptime percentage is reported to the us-east-1 region (because that's where the health-checks exist, even though the test from other regions)

Fixes MLPAB-696

## Approach

- Create a route53 endpoint check
- Allow ingress for route53 health checks

## Learning

- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-types.html

## Checklist

* [x] I have performed a self-review of my own code