### PR TITLE
MLPAB-550 Rate limit entry of the witness code

### DIFF
--- a/app/internal/page/data.go
+++ b/app/internal/page/data.go
@@ -88,6 +88,7 @@ type Lpa struct {
 	WantToSignLpa                               bool
 	Submitted                                   time.Time
 	CPWitnessCodeValidated                      bool
+	WitnessCodeLimiter                          *Limiter
 
 	CertificateProviderIdentityOption   identity.Option
 	CertificateProviderYotiUserData     identity.UserData

--- a/app/internal/page/donor/witnessing_as_certificate_provider.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider.go
@@ -34,20 +34,32 @@ func WitnessingAsCertificateProvider(tmpl template.Template, lpaStore LpaStore, 
 			data.Form = readWitnessingAsCertificateProviderForm(r)
 			data.Errors = data.Form.Validate()
 
-			code, found := lpa.WitnessCodes.Find(data.Form.Code)
-			if !found {
-				data.Errors.Add("witness-code", validation.CustomError{Label: "witnessCodeDoesNotMatch"})
-			} else if code.HasExpired() {
-				data.Errors.Add("witness-code", validation.CustomError{Label: "witnessCodeExpired"})
+			if lpa.WitnessCodeLimiter == nil {
+				lpa.WitnessCodeLimiter = page.NewLimiter(time.Minute, 5, 10)
+			}
+
+			if !lpa.WitnessCodeLimiter.Allow(now()) {
+				data.Errors.Add("witness-code", validation.CustomError{Label: "tooManyWitnessCodeAttempts"})
+			} else {
+				code, found := lpa.WitnessCodes.Find(data.Form.Code)
+				if !found {
+					data.Errors.Add("witness-code", validation.CustomError{Label: "witnessCodeDoesNotMatch"})
+				} else if code.HasExpired() {
+					data.Errors.Add("witness-code", validation.CustomError{Label: "witnessCodeExpired"})
+				}
 			}
 
 			if data.Errors.None() {
+				lpa.WitnessCodeLimiter = nil
 				lpa.CPWitnessCodeValidated = true
 				lpa.Submitted = now()
-				if err := lpaStore.Put(r.Context(), lpa); err != nil {
-					return err
-				}
+			}
 
+			if err := lpaStore.Put(r.Context(), lpa); err != nil {
+				return err
+			}
+
+			if data.Errors.None() {
 				if lpa.CertificateProviderOneLoginUserData.OK {
 					if err := shareCodeSender.Send(r.Context(), notify.CertificateProviderReturnEmail, appData, false, lpa); err != nil {
 						return err

--- a/app/internal/page/limiter.go
+++ b/app/internal/page/limiter.go
@@ -1,0 +1,45 @@
+package page
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter is a basic rate limiter that can be serialised.
+type Limiter struct {
+	TokenPer  time.Duration
+	MaxTokens float64
+
+	mu       sync.Mutex
+	Tokens   float64
+	TokensAt time.Time
+}
+
+func NewLimiter(tokenPer time.Duration, initialTokens, maxTokens float64) *Limiter {
+	return &Limiter{
+		TokenPer:  tokenPer,
+		MaxTokens: maxTokens,
+		Tokens:    initialTokens,
+		TokensAt:  time.Now(),
+	}
+}
+
+func (l *Limiter) Allow(now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	elapsed := now.Sub(l.TokensAt)
+	l.Tokens += elapsed.Seconds() / l.TokenPer.Seconds()
+	l.TokensAt = now
+
+	if l.Tokens > l.MaxTokens {
+		l.Tokens = l.MaxTokens
+	}
+
+	if l.Tokens >= 1 {
+		l.Tokens--
+		return true
+	}
+
+	return false
+}

--- a/app/internal/page/limiter_test.go
+++ b/app/internal/page/limiter_test.go
@@ -1,0 +1,92 @@
+package page
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLimiter(t *testing.T) {
+	limiter := NewLimiter(time.Minute, 5, 10)
+
+	assert.Equal(t, time.Minute, limiter.TokenPer)
+	assert.Equal(t, float64(5), limiter.Tokens)
+	assert.Equal(t, float64(10), limiter.MaxTokens)
+	assert.WithinDuration(t, time.Now(), limiter.TokensAt, time.Millisecond)
+}
+
+func TestLimiter(t *testing.T) {
+	now := time.Now()
+
+	testcases := map[string]struct {
+		limiter *Limiter
+		allowed bool
+	}{
+		"has a token": {
+			limiter: &Limiter{
+				TokenPer:  time.Minute,
+				Tokens:    1,
+				MaxTokens: 1,
+				TokensAt:  time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC),
+			},
+			allowed: true,
+		},
+		"has no tokens": {
+			limiter: &Limiter{
+				TokenPer:  time.Minute,
+				Tokens:    0,
+				MaxTokens: 1,
+				TokensAt:  now,
+			},
+			allowed: false,
+		},
+		"gets a token on refresh": {
+			limiter: &Limiter{
+				TokenPer:  time.Minute,
+				Tokens:    0,
+				MaxTokens: 1,
+				TokensAt:  now.Add(-time.Minute),
+			},
+			allowed: true,
+		},
+		"gets a partial token on refresh": {
+			limiter: &Limiter{
+				TokenPer:  time.Minute,
+				Tokens:    0.5,
+				MaxTokens: 1,
+				TokensAt:  now.Add(-time.Second * 30),
+			},
+			allowed: true,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.allowed, tc.limiter.Allow(now))
+		})
+	}
+}
+
+func TestLimiterBurst(t *testing.T) {
+	now := time.Now()
+	limiter := &Limiter{TokenPer: time.Second, Tokens: 3, MaxTokens: 5, TokensAt: now.Add(-time.Second)}
+
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.False(t, limiter.Allow(now))
+}
+
+func TestLimiterMax(t *testing.T) {
+	now := time.Now()
+	limiter := &Limiter{TokenPer: time.Second, Tokens: 0, MaxTokens: 5, TokensAt: now.Add(-10 * time.Second)}
+
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.True(t, limiter.Allow(now))
+	assert.False(t, limiter.Allow(now))
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -546,5 +546,7 @@
     "requestANewWitnessCode": "Request a new witness code",
     "textMessagesSometimesTakeAFewMinutes": "Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.",
     "requestANewCode": "Request a new code",
-    "pleaseWaitOneMinute": "Please wait at least one minute for the previous text message to arrive before requesting a new code"
+    "pleaseWaitOneMinute": "Please wait at least one minute for the previous text message to arrive before requesting a new code",
+
+    "tooManyWitnessCodeAttempts": "Wait a bit before attempting to enter the witness code again"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -371,7 +371,7 @@
     "enterUniqueCodeHint": "{{ .CpFirstName }}, please type in the code we have sent you, to prove that you are with {{ .DonorFullName }} and have witnessed them sign their LPA.",
     "cpNotReceivedCodeLink": "{{ .CpFirstName }} has not received a text message with the code",
     "witnessCodeDoesNotMatch": "The code you entered is incorrect, please check it and try again",
-    "witnessCodeExpired": "The code has expired. New code sent.",
+    "witnessCodeExpired": "The code has expired",
     "theCodeWeSentCertificateProvider": "The code we sent to the certificate provider",
 
     "submittedYourLpa": "You’ve submitted your LPA",


### PR DESCRIPTION
I felt that embedding the rate limiter state in the Lpa was going to be nicer than having a global map of limiters (that would then require cleaning up, and wouldn't scale if we had more than 1 container).

Also missed that I'd changed some content in my previous PR copy and pasting from the GDS pattern, but not reverted it.