### PR TITLE
MLPAB-765 Match names retrieved from the identity checks

### DIFF
--- a/app/internal/identity/user_data.go
+++ b/app/internal/identity/user_data.go
@@ -1,0 +1,151 @@
+package identity
+
+import (
+	"strings"
+	"time"
+
+	"golang.org/x/exp/slices"
+)
+
+// https://www.icao.int/publications/Documents/9303_p3_cons_en.pdf
+var charmap = map[rune][]rune{
+	'\u00C0': {'A'},
+	'\u00C1': {'A'},
+	'\u00C2': {'A'},
+	'\u00C3': {'A'},
+	'\u00C4': {'A', 'E'}, // or "A"
+	'\u00C5': {'A', 'A'}, // or "A"
+	'\u00C6': {'A', 'E'},
+	'\u00C7': {'C'},
+	'\u00C8': {'E'},
+	'\u00C9': {'E'},
+	'\u00CA': {'E'},
+	'\u00CB': {'E'},
+	'\u00CC': {'I'},
+	'\u00CD': {'I'},
+	'\u00CE': {'I'},
+	'\u00CF': {'I'},
+	'\u00D0': {'D'},
+	'\u00D1': {'N'}, // or "NXX"
+	'\u00D2': {'O'},
+	'\u00D3': {'O'},
+	'\u00D4': {'O'},
+	'\u00D5': {'O'},
+	'\u00D6': {'O', 'E'}, // or "O"
+	'\u00D8': {'O', 'E'},
+	'\u00D9': {'U'},
+	'\u00DA': {'U'},
+	'\u00DB': {'U'},
+	'\u00DC': {'U', 'E'}, // or "UXX" or "U"
+	'\u00DD': {'Y'},
+	'\u00DE': {'T', 'H'},
+	// end page 1
+	'\u0100': {'A'},
+	'\u0102': {'A'},
+	'\u0104': {'A'},
+	'\u0106': {'C'},
+	'\u0108': {'C'},
+	'\u010A': {'C'},
+	'\u010C': {'C'},
+	'\u010E': {'D'},
+	'\u0110': {'D'},
+	'\u0112': {'E'},
+	'\u0114': {'E'},
+	'\u0116': {'E'},
+	'\u0118': {'E'},
+	'\u011A': {'E'},
+	'\u011C': {'G'},
+	'\u011E': {'G'},
+	'\u0120': {'G'},
+	'\u0122': {'G'},
+	'\u0124': {'H'},
+	'\u0126': {'H'},
+	'\u0128': {'I'},
+	'\u012A': {'I'},
+	'\u012C': {'I'},
+	'\u012E': {'I'},
+	'\u0130': {'I'},
+	'\u0131': {'I'},
+	'\u0132': {'I', 'J'},
+	'\u0134': {'J'},
+	'\u0136': {'K'},
+	'\u0139': {'L'},
+	'\u013B': {'L'},
+	'\u013D': {'L'},
+	'\u013F': {'L'},
+	'\u0141': {'L'},
+	'\u0143': {'N'},
+	'\u0145': {'N'},
+	'\u0147': {'N'},
+	// end page 2
+	'\u014A': {'N'},
+	'\u014C': {'O'},
+	'\u014E': {'O'},
+	'\u0150': {'O'},
+	'\u0152': {'O', 'E'},
+	'\u0154': {'R'},
+	'\u0156': {'R'},
+	'\u0158': {'R'},
+	'\u015A': {'S'},
+	'\u015C': {'S'},
+	'\u015E': {'S'},
+	'\u0160': {'S'},
+	'\u0162': {'T'},
+	'\u0164': {'T'},
+	'\u0166': {'T'},
+	'\u0168': {'U'},
+	'\u016A': {'U'},
+	'\u016C': {'U'},
+	'\u016E': {'U'},
+	'\u0170': {'U'},
+	'\u0172': {'U'},
+	'\u0174': {'W'},
+	'\u0176': {'Y'},
+	'\u0178': {'Y'},
+	'\u0179': {'Z'},
+	'\u017B': {'Z'},
+	'\u017D': {'Z'},
+	'\u1E9E': {'S', 'S'},
+	// end page 3
+}
+
+type UserData struct {
+	OK          bool
+	Provider    Option
+	FirstNames  string
+	LastName    string
+	RetrievedAt time.Time
+}
+
+func (u UserData) MatchName(firstNames, lastName string) bool {
+	expectedFirstNames := strings.ToUpper(u.FirstNames)
+	expectedLastName := strings.ToUpper(u.LastName)
+
+	firstNames = strings.ToUpper(firstNames)
+	lastName = strings.ToUpper(lastName)
+
+	if expectedFirstNames == firstNames && expectedLastName == lastName {
+		return true
+	}
+
+	expectedFirstNameParts := strings.Fields(expectedFirstNames)
+	firstNameParts := strings.Fields(transliterate(firstNames))
+
+	slices.Sort(expectedFirstNameParts)
+	slices.Sort(firstNameParts)
+
+	return slices.Equal(expectedFirstNameParts, firstNameParts) && expectedLastName == transliterate(lastName)
+}
+
+func transliterate(s string) string {
+	var runes []rune
+	for _, r := range s {
+		if c, ok := charmap[r]; ok {
+			runes = append(runes, c...)
+		} else {
+			runes = append(runes, r)
+		}
+	}
+
+	return string(runes)
+}

--- a/app/internal/identity/user_data_test.go
+++ b/app/internal/identity/user_data_test.go
@@ -1,0 +1,60 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserDataMatchName(t *testing.T) {
+	testcases := map[string]struct {
+		userData   UserData
+		firstNames string
+		lastName   string
+		expected   bool
+	}{
+		"match": {
+			userData: UserData{
+				FirstNames: "A BEE",
+				LastName:   "SEA",
+			},
+			firstNames: "A Bee",
+			lastName:   "Sea",
+			expected:   true,
+		},
+		"match on unordered firstnames": {
+			userData: UserData{
+				FirstNames: "BEE A",
+				LastName:   "SEA",
+			},
+			firstNames: "A Bee",
+			lastName:   "Sea",
+			expected:   true,
+		},
+		"match on accented characters": {
+			userData: UserData{
+				FirstNames: "A BEE",
+				LastName:   "SEA",
+			},
+			firstNames: "Ã Béë",
+			lastName:   "Sêâ",
+			expected:   true,
+		},
+		// TODO if we find out it is worth doing
+		// "match on alternate accented characters": {
+		//	userData: UserData{
+		//		FirstNames: "A BEE",
+		//		LastName:   "SEA",
+		//	},
+		//	firstNames: "Å Béë",
+		//	lastName:   "Sêå",
+		//	expected:   true,
+		// },
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.userData.MatchName(tc.firstNames, tc.lastName))
+		})
+	}
+}

--- a/app/internal/identity/yoti_client.go
+++ b/app/internal/identity/yoti_client.go
@@ -10,12 +10,6 @@ import (
 
 const yotiSandboxBaseURL = "https://api.yoti.com/sandbox/v1"
 
-type UserData struct {
-	OK          bool
-	FullName    string
-	RetrievedAt time.Time
-}
-
 type YotiClient struct {
 	yoti      *yoti.Client
 	isSandbox bool
@@ -65,11 +59,17 @@ func (c *YotiClient) IsTest() bool {
 
 func (c *YotiClient) User(token string) (UserData, error) {
 	if c.yoti == nil {
-		return UserData{OK: true, FullName: "Test Person", RetrievedAt: time.Now()}, nil
+		return UserData{OK: true, Provider: EasyID, FirstNames: "Test", LastName: "Person", RetrievedAt: time.Now()}, nil
 	}
 
 	if c.isSandbox {
-		return UserData{OK: true, FullName: c.details.UserProfile.FullName().Value(), RetrievedAt: time.Now()}, nil
+		return UserData{
+			OK:          true,
+			Provider:    EasyID,
+			FirstNames:  c.details.UserProfile.GivenNames().Value(),
+			LastName:    c.details.UserProfile.FamilyName().Value(),
+			RetrievedAt: time.Now(),
+		}, nil
 	}
 
 	details, err := c.yoti.GetActivityDetails(token)
@@ -77,5 +77,11 @@ func (c *YotiClient) User(token string) (UserData, error) {
 		return UserData{}, err
 	}
 
-	return UserData{OK: true, FullName: details.UserProfile.FullName().Value(), RetrievedAt: time.Now()}, nil
+	return UserData{
+		OK:          true,
+		Provider:    EasyID,
+		FirstNames:  details.UserProfile.GivenNames().Value(),
+		LastName:    details.UserProfile.FamilyName().Value(),
+		RetrievedAt: time.Now(),
+	}, nil
 }

--- a/app/internal/identity/yoti_client_test.go
+++ b/app/internal/identity/yoti_client_test.go
@@ -14,5 +14,7 @@ func TestMockClient(t *testing.T) {
 	user, err := client.User("xyz")
 	assert.Nil(t, err)
 	assert.True(t, user.OK)
-	assert.Equal(t, "Test Person", user.FullName)
+	assert.Equal(t, EasyID, user.Provider)
+	assert.Equal(t, "Test", user.FirstNames)
+	assert.Equal(t, "Person", user.LastName)
 }

--- a/app/internal/onelogin/user_info.go
+++ b/app/internal/onelogin/user_info.go
@@ -133,7 +133,7 @@ func (c *Client) ParseIdentityClaim(ctx context.Context, u UserInfo) (identity.U
 
 	currentName := claims.Vc.CredentialSubject.CurrentNameParts()
 	if len(currentName) == 0 || claims.IssuedAt == nil {
-		return identity.UserData{OK: false}, nil
+		return identity.UserData{OK: false, Provider: identity.OneLogin}, nil
 	}
 
 	var givenName, familyName []string
@@ -147,7 +147,9 @@ func (c *Client) ParseIdentityClaim(ctx context.Context, u UserInfo) (identity.U
 
 	return identity.UserData{
 		OK:          true,
-		FullName:    strings.Join(givenName, " ") + " " + strings.Join(familyName, " "),
+		Provider:    identity.OneLogin,
+		FirstNames:  strings.Join(givenName, " "),
+		LastName:    strings.Join(familyName, " "),
 		RetrievedAt: claims.IssuedAt.Time,
 	}, nil
 }

--- a/app/internal/onelogin/user_info_test.go
+++ b/app/internal/onelogin/user_info_test.go
@@ -147,7 +147,9 @@ func TestParseIdentityClaim(t *testing.T) {
 			}), privateKey),
 			userData: identity.UserData{
 				OK:          true,
-				FullName:    "Alice Jane Laura Doe",
+				Provider:    identity.OneLogin,
+				FirstNames:  "Alice Jane Laura",
+				LastName:    "Doe",
 				RetrievedAt: issuedAt,
 			},
 		},
@@ -158,13 +160,13 @@ func TestParseIdentityClaim(t *testing.T) {
 			token: mustSign(jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 				"iat": issuedAt.Unix(),
 			}), privateKey),
-			userData: identity.UserData{OK: false},
+			userData: identity.UserData{OK: false, Provider: identity.OneLogin},
 		},
 		"without iat": {
 			token: mustSign(jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 				"vc": vc,
 			}), privateKey),
-			userData: identity.UserData{OK: false},
+			userData: identity.UserData{OK: false, Provider: identity.OneLogin},
 		},
 		"with unexpected signing method": {
 			token: mustSign(jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{

--- a/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/sessions"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/onelogin"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
@@ -21,15 +22,18 @@ func TestGetIdentityWithOneLoginCallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/?code=a-code", nil)
 	now := time.Now()
 	userInfo := onelogin.UserInfo{CoreIdentityJWT: "an-identity-jwt"}
-	userData := identity.UserData{OK: true, FullName: "John Doe", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "John", LastName: "Doe", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.
 		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
+		Return(&page.Lpa{
+			CertificateProvider: actor.CertificateProvider{FirstNames: "John", LastName: "Doe"},
+		}, nil)
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
-			CertificateProviderOneLoginUserData: userData,
+			CertificateProvider:                 actor.CertificateProvider{FirstNames: "John", LastName: "Doe"},
+			CertificateProviderIdentityUserData: userData,
 		}).
 		Return(nil)
 
@@ -110,6 +114,24 @@ func TestGetIdentityWithOneLoginCallbackWhenIdentityNotConfirmed(t *testing.T) {
 		url            string
 		error          error
 	}{
+		"not a match": {
+			url: "/?code=a-code",
+			oneLoginClient: func(t *testing.T) *mockOneLoginClient {
+				oneLoginClient := newMockOneLoginClient(t)
+				oneLoginClient.
+					On("Exchange", mock.Anything, mock.Anything, mock.Anything).
+					Return("a-jwt", nil)
+				oneLoginClient.
+					On("UserInfo", mock.Anything, mock.Anything).
+					Return(userInfo, nil)
+				oneLoginClient.
+					On("ParseIdentityClaim", mock.Anything, mock.Anything).
+					Return(identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "x", LastName: "y"}, nil)
+				return oneLoginClient
+			},
+			sessionStore: sessionRetrieved,
+			template:     templateCalled,
+		},
 		"not ok": {
 			url: "/?code=a-code",
 			oneLoginClient: func(t *testing.T) *mockOneLoginClient {
@@ -252,7 +274,7 @@ func TestGetIdentityWithOneLoginCallbackWhenPutDataStoreError(t *testing.T) {
 		Return(userInfo, nil)
 	oneLoginClient.
 		On("ParseIdentityClaim", mock.Anything, mock.Anything).
-		Return(identity.UserData{OK: true}, nil)
+		Return(identity.UserData{OK: true, Provider: identity.OneLogin}, nil)
 
 	err := IdentityWithOneLoginCallback(nil, oneLoginClient, sessionStore, lpaStore)(testAppData, w, r)
 
@@ -263,16 +285,21 @@ func TestGetIdentityWithOneLoginCallbackWhenReturning(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?code=a-code", nil)
 	now := time.Date(2012, time.January, 1, 2, 3, 4, 5, time.UTC)
-	userData := identity.UserData{OK: true, FullName: "a-full-name", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "first-names", LastName: "last-name", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{CertificateProviderOneLoginUserData: userData}, nil)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			CertificateProvider:                 actor.CertificateProvider{FirstNames: "first-names", LastName: "last-name"},
+			CertificateProviderIdentityUserData: userData,
+		}, nil)
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &identityWithOneLoginCallbackData{
 			App:         testAppData,
-			FullName:    "a-full-name",
+			FullName:    "first-names last-name",
 			ConfirmedAt: now,
 		}).
 		Return(nil)
@@ -289,9 +316,11 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{
-		CertificateProviderOneLoginUserData: identity.UserData{OK: true},
-	}, nil)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
+		}, nil)
 
 	err := IdentityWithOneLoginCallback(nil, nil, nil, lpaStore)(testAppData, w, r)
 	resp := w.Result()

--- a/app/internal/page/certificateprovider/identity_with_todo.go
+++ b/app/internal/page/certificateprovider/identity_with_todo.go
@@ -2,6 +2,7 @@ package certificateprovider
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
@@ -15,10 +16,26 @@ type identityWithTodoData struct {
 	IdentityOption identity.Option
 }
 
-func IdentityWithTodo(tmpl template.Template, identityOption identity.Option) page.Handler {
+func IdentityWithTodo(tmpl template.Template, lpaStore LpaStore, now func() time.Time, identityOption identity.Option) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
+		lpa, err := lpaStore.Get(r.Context())
+		if err != nil {
+			return err
+		}
+
 		if r.Method == http.MethodPost {
 			return appData.Redirect(w, r, nil, page.Paths.CertificateProviderReadTheLpa)
+		}
+
+		lpa.CertificateProviderIdentityUserData = identity.UserData{
+			OK:          true,
+			Provider:    identityOption,
+			FirstNames:  lpa.CertificateProvider.FirstNames,
+			LastName:    lpa.CertificateProvider.LastName,
+			RetrievedAt: now(),
+		}
+		if err := lpaStore.Put(r.Context(), lpa); err != nil {
+			return err
 		}
 
 		data := &identityWithTodoData{

--- a/app/internal/page/certificateprovider/identity_with_todo_test.go
+++ b/app/internal/page/certificateprovider/identity_with_todo_test.go
@@ -4,14 +4,38 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestGetIdentityWithTodo(t *testing.T) {
+	now := time.Now()
 	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			CertificateProvider: actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+		}, nil)
+	lpaStore.
+		On("Put", r.Context(), &page.Lpa{
+			CertificateProvider: actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+			CertificateProviderIdentityUserData: identity.UserData{
+				OK:          true,
+				Provider:    identity.Passport,
+				FirstNames:  "a",
+				LastName:    "b",
+				RetrievedAt: now,
+			},
+		}).
+		Return(nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -21,20 +45,56 @@ func TestGetIdentityWithTodo(t *testing.T) {
 		}).
 		Return(nil)
 
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	err := IdentityWithTodo(template.Execute, identity.Passport)(testAppData, w, r)
+	err := IdentityWithTodo(template.Execute, lpaStore, func() time.Time { return now }, identity.Passport)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestGetIdentityWithTodoWhenLpaStoreGetErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			CertificateProvider: actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+		}, expectedError)
+
+	err := IdentityWithTodo(nil, lpaStore, nil, identity.Passport)(testAppData, w, r)
+	assert.Equal(t, expectedError, err)
+}
+
+func TestGetIdentityWithTodoWhenLpaStorePutErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			CertificateProvider: actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+		}, nil)
+	lpaStore.
+		On("Put", r.Context(), mock.Anything).
+		Return(expectedError)
+
+	err := IdentityWithTodo(nil, lpaStore, time.Now, identity.Passport)(testAppData, w, r)
+	assert.Equal(t, expectedError, err)
+}
+
 func TestPostIdentityWithTodo(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	err := IdentityWithTodo(nil, identity.Passport)(testAppData, w, r)
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{}, nil)
+
+	err := IdentityWithTodo(nil, lpaStore, nil, identity.Passport)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/certificateprovider/identity_with_yoti.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti.go
@@ -22,7 +22,7 @@ func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient Yoti
 			return err
 		}
 
-		if lpa.CertificateProviderYotiUserData.OK || yotiClient.IsTest() {
+		if lpa.CertificateProviderIdentityConfirmed() || yotiClient.IsTest() {
 			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderIdentityWithYotiCallback)
 		}
 

--- a/app/internal/page/certificateprovider/identity_with_yoti_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_test.go
@@ -43,7 +43,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{CertificateProviderYotiUserData: identity.UserData{OK: true}}, nil)
+	lpaStore.On("Get", r.Context()).Return(&page.Lpa{CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID}}, nil)
 
 	err := IdentityWithYoti(nil, lpaStore, nil, "")(testAppData, w, r)
 	resp := w.Result()

--- a/app/internal/page/certificateprovider/register.go
+++ b/app/internal/page/certificateprovider/register.go
@@ -136,7 +136,7 @@ func Register(
 		page.Paths.CertificateProviderIdentityWithOnlineBankAccount:        identity.OnlineBankAccount,
 	} {
 		handleRoot(path, RequireSession,
-			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), identityOption))
+			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, time.Now, identityOption))
 	}
 
 	handleRoot(page.Paths.CertificateProviderReadTheLpa, RequireSession,

--- a/app/internal/page/certificateprovider/select_your_identity_options.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options.go
@@ -27,7 +27,7 @@ func SelectYourIdentityOptions(tmpl template.Template, lpaStore LpaStore, pageIn
 			App:  appData,
 			Page: pageIndex,
 			Form: &selectYourIdentityOptionsForm{
-				Selected: lpa.IdentityOption,
+				Selected: lpa.DonorIdentityOption,
 			},
 		}
 

--- a/app/internal/page/certificateprovider/select_your_identity_options_test.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options_test.go
@@ -62,7 +62,7 @@ func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 		}, nil)
 
 	template := newMockTemplate(t)

--- a/app/internal/page/data_test.go
+++ b/app/internal/page/data_test.go
@@ -32,13 +32,27 @@ func TestIdentityConfirmed(t *testing.T) {
 		lpa      *Lpa
 		expected bool
 	}{
-		"yoti": {
-			lpa:      &Lpa{YotiUserData: identity.UserData{OK: true}},
+		"set": {
+			lpa: &Lpa{
+				Donor:                 actor.Donor{FirstNames: "a", LastName: "b"},
+				DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "a", LastName: "b"},
+			},
 			expected: true,
 		},
-		"one login": {
-			lpa:      &Lpa{OneLoginUserData: identity.UserData{OK: true}},
-			expected: true,
+		"missing provider": {
+			lpa:      &Lpa{DonorIdentityUserData: identity.UserData{OK: true}},
+			expected: false,
+		},
+		"not ok": {
+			lpa:      &Lpa{DonorIdentityUserData: identity.UserData{Provider: identity.OneLogin}},
+			expected: false,
+		},
+		"no match": {
+			lpa: &Lpa{
+				Donor:                 actor.Donor{FirstNames: "a", LastName: "b"},
+				DonorIdentityUserData: identity.UserData{Provider: identity.OneLogin},
+			},
+			expected: false,
 		},
 		"none": {
 			lpa:      &Lpa{},
@@ -48,7 +62,47 @@ func TestIdentityConfirmed(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.lpa.IdentityConfirmed())
+			assert.Equal(t, tc.expected, tc.lpa.DonorIdentityConfirmed())
+		})
+	}
+}
+
+func TestCertificateProviderIdentityConfirmed(t *testing.T) {
+	testCases := map[string]struct {
+		lpa      *Lpa
+		expected bool
+	}{
+		"set": {
+			lpa: &Lpa{
+				CertificateProvider:                 actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+				CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "a", LastName: "b"},
+			},
+			expected: true,
+		},
+		"missing provider": {
+			lpa:      &Lpa{CertificateProviderIdentityUserData: identity.UserData{OK: true}},
+			expected: false,
+		},
+		"not ok": {
+			lpa:      &Lpa{CertificateProviderIdentityUserData: identity.UserData{Provider: identity.OneLogin}},
+			expected: false,
+		},
+		"no match": {
+			lpa: &Lpa{
+				CertificateProvider:                 actor.CertificateProvider{FirstNames: "a", LastName: "b"},
+				CertificateProviderIdentityUserData: identity.UserData{Provider: identity.OneLogin},
+			},
+			expected: false,
+		},
+		"none": {
+			lpa:      &Lpa{},
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.lpa.CertificateProviderIdentityConfirmed())
 		})
 	}
 }

--- a/app/internal/page/donor/identity_with_one_login_callback.go
+++ b/app/internal/page/donor/identity_with_one_login_callback.go
@@ -27,7 +27,7 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 		}
 
 		if r.Method == http.MethodPost {
-			if lpa.OneLoginUserData.OK {
+			if lpa.DonorIdentityConfirmed() {
 				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
 			} else {
 				return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1)
@@ -36,9 +36,9 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 
 		data := &identityWithOneLoginCallbackData{App: appData}
 
-		if lpa.OneLoginUserData.OK {
-			data.FullName = lpa.OneLoginUserData.FullName
-			data.ConfirmedAt = lpa.OneLoginUserData.RetrievedAt
+		if lpa.DonorIdentityConfirmed() {
+			data.FullName = lpa.DonorIdentityUserData.FirstNames + " " + lpa.DonorIdentityUserData.LastName
+			data.ConfirmedAt = lpa.DonorIdentityUserData.RetrievedAt
 
 			return tmpl(w, data)
 		}
@@ -69,17 +69,17 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 			return err
 		}
 
-		if !userData.OK {
-			data.CouldNotConfirm = true
-		} else {
-			data.FullName = userData.FullName
-			data.ConfirmedAt = userData.RetrievedAt
+		lpa.DonorIdentityUserData = userData
 
-			lpa.OneLoginUserData = userData
-
+		if lpa.DonorIdentityConfirmed() {
 			if err := lpaStore.Put(r.Context(), lpa); err != nil {
 				return err
 			}
+
+			data.FullName = userData.FirstNames + " " + userData.LastName
+			data.ConfirmedAt = userData.RetrievedAt
+		} else {
+			data.CouldNotConfirm = true
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/identity_with_one_login_callback_test.go
+++ b/app/internal/page/donor/identity_with_one_login_callback_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/sessions"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/onelogin"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
@@ -21,15 +22,18 @@ func TestGetIdentityWithOneLoginCallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/?code=a-code", nil)
 	now := time.Now()
 	userInfo := onelogin.UserInfo{CoreIdentityJWT: "an-identity-jwt"}
-	userData := identity.UserData{OK: true, FullName: "John Doe", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "John", LastName: "Doe", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.
 		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "John", LastName: "Doe"},
+		}, nil)
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
-			OneLoginUserData: userData,
+			Donor:                 actor.Donor{FirstNames: "John", LastName: "Doe"},
+			DonorIdentityUserData: userData,
 		}).
 		Return(nil)
 
@@ -252,7 +256,7 @@ func TestGetIdentityWithOneLoginCallbackWhenPutDataStoreError(t *testing.T) {
 		Return(userInfo, nil)
 	oneLoginClient.
 		On("ParseIdentityClaim", mock.Anything, mock.Anything).
-		Return(identity.UserData{OK: true}, nil)
+		Return(identity.UserData{OK: true, Provider: identity.OneLogin}, nil)
 
 	err := IdentityWithOneLoginCallback(nil, oneLoginClient, sessionStore, lpaStore)(testAppData, w, r)
 
@@ -263,16 +267,21 @@ func TestGetIdentityWithOneLoginCallbackWhenReturning(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?code=a-code", nil)
 	now := time.Date(2012, time.January, 1, 2, 3, 4, 5, time.UTC)
-	userData := identity.UserData{OK: true, FullName: "a-full-name", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "first-name", LastName: "last-name", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{OneLoginUserData: userData}, nil)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor:                 actor.Donor{FirstNames: "first-name", LastName: "last-name"},
+			DonorIdentityUserData: userData,
+		}, nil)
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &identityWithOneLoginCallbackData{
 			App:         testAppData,
-			FullName:    "a-full-name",
+			FullName:    "first-name last-name",
 			ConfirmedAt: now,
 		}).
 		Return(nil)
@@ -290,7 +299,7 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{
-		OneLoginUserData: identity.UserData{OK: true},
+		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 	}, nil)
 
 	err := IdentityWithOneLoginCallback(nil, nil, nil, lpaStore)(testAppData, w, r)

--- a/app/internal/page/donor/identity_with_todo.go
+++ b/app/internal/page/donor/identity_with_todo.go
@@ -2,6 +2,7 @@ package donor
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
@@ -15,10 +16,26 @@ type identityWithTodoData struct {
 	IdentityOption identity.Option
 }
 
-func IdentityWithTodo(tmpl template.Template, identityOption identity.Option) page.Handler {
+func IdentityWithTodo(tmpl template.Template, lpaStore LpaStore, now func() time.Time, identityOption identity.Option) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
+		lpa, err := lpaStore.Get(r.Context())
+		if err != nil {
+			return err
+		}
+
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, nil, page.Paths.ReadYourLpa)
+			return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
+		}
+
+		lpa.DonorIdentityUserData = identity.UserData{
+			OK:          true,
+			Provider:    identityOption,
+			FirstNames:  lpa.Donor.FirstNames,
+			LastName:    lpa.Donor.LastName,
+			RetrievedAt: now(),
+		}
+		if err := lpaStore.Put(r.Context(), lpa); err != nil {
+			return err
 		}
 
 		data := &identityWithTodoData{

--- a/app/internal/page/donor/identity_with_todo_test.go
+++ b/app/internal/page/donor/identity_with_todo_test.go
@@ -4,14 +4,38 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestGetIdentityWithTodo(t *testing.T) {
+	now := time.Now()
 	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+		}, nil)
+	lpaStore.
+		On("Put", r.Context(), &page.Lpa{
+			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+			DonorIdentityUserData: identity.UserData{
+				OK:          true,
+				Provider:    identity.Passport,
+				FirstNames:  "a",
+				LastName:    "b",
+				RetrievedAt: now,
+			},
+		}).
+		Return(nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -21,20 +45,65 @@ func TestGetIdentityWithTodo(t *testing.T) {
 		}).
 		Return(nil)
 
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	err := IdentityWithTodo(template.Execute, identity.Passport)(testAppData, w, r)
+	err := IdentityWithTodo(template.Execute, lpaStore, func() time.Time { return now }, identity.Passport)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestGetIdentityWithTodoWhenLpaStoreGetErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+		}, expectedError)
+
+	err := IdentityWithTodo(nil, lpaStore, nil, identity.Passport)(testAppData, w, r)
+	assert.Equal(t, expectedError, err)
+}
+
+func TestGetIdentityWithTodoWhenLpaStorePutErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+		}, nil)
+	lpaStore.
+		On("Put", r.Context(), mock.Anything).
+		Return(expectedError)
+
+	err := IdentityWithTodo(nil, lpaStore, time.Now, identity.Passport)(testAppData, w, r)
+	assert.Equal(t, expectedError, err)
+}
+
 func TestPostIdentityWithTodo(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	err := IdentityWithTodo(nil, identity.Passport)(testAppData, w, r)
+	lpaStore := newMockLpaStore(t)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+			DonorIdentityUserData: identity.UserData{
+				OK:          true,
+				Provider:    identity.Passport,
+				FirstNames:  "a",
+				LastName:    "b",
+				RetrievedAt: now,
+			},
+		}, nil)
+
+	err := IdentityWithTodo(nil, lpaStore, nil, identity.Passport)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/identity_with_yoti.go
+++ b/app/internal/page/donor/identity_with_yoti.go
@@ -22,7 +22,7 @@ func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient Yoti
 			return err
 		}
 
-		if lpa.YotiUserData.OK || yotiClient.IsTest() {
+		if lpa.DonorIdentityConfirmed() || yotiClient.IsTest() {
 			return appData.Redirect(w, r, lpa, page.Paths.IdentityWithYotiCallback)
 		}
 

--- a/app/internal/page/donor/identity_with_yoti_callback_test.go
+++ b/app/internal/page/donor/identity_with_yoti_callback_test.go
@@ -1,25 +1,37 @@
 package donor
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestGetIdentityWithYotiCallback(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?token=a-token", nil)
 	now := time.Now()
-	userData := identity.UserData{FullName: "a-full-name", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.EasyID, FirstNames: "first-name", LastName: "last-name", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
-	lpaStore.On("Put", r.Context(), &page.Lpa{YotiUserData: userData}).Return(nil)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "first-name", LastName: "last-name"},
+		}, nil)
+	lpaStore.
+		On("Put", r.Context(), &page.Lpa{
+			Donor:                 actor.Donor{FirstNames: "first-name", LastName: "last-name"},
+			DonorIdentityUserData: userData,
+		}).
+		Return(nil)
 
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("User", "a-token").Return(userData, nil)
@@ -28,7 +40,7 @@ func TestGetIdentityWithYotiCallback(t *testing.T) {
 	template.
 		On("Execute", w, &identityWithYotiCallbackData{
 			App:         testAppData,
-			FullName:    "a-full-name",
+			FullName:    "first-name last-name",
 			ConfirmedAt: now,
 		}).
 		Return(nil)
@@ -40,19 +52,84 @@ func TestGetIdentityWithYotiCallback(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetIdentityWithYotiCallbackWhenError(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/?token=a-token", nil)
+func TestGetIdentityWithYotiCallbackWhenIdentityNotConfirmed(t *testing.T) {
+	templateCalled := func(t *testing.T, w io.Writer) *mockTemplate {
+		template := newMockTemplate(t)
+		template.
+			On("Execute", w, &identityWithYotiCallbackData{
+				App:             testAppData,
+				CouldNotConfirm: true,
+			}).
+			Return(nil)
+		return template
+	}
 
-	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
+	templateIgnored := func(t *testing.T, w io.Writer) *mockTemplate {
+		return nil
+	}
 
-	yotiClient := newMockYotiClient(t)
-	yotiClient.On("User", "a-token").Return(identity.UserData{}, expectedError)
+	testCases := map[string]struct {
+		yotiClient func(t *testing.T) *mockYotiClient
+		template   func(*testing.T, io.Writer) *mockTemplate
+		url        string
+		error      error
+	}{
+		"not a match": {
+			url: "/?code=a-code",
+			yotiClient: func(t *testing.T) *mockYotiClient {
+				yotiClient := newMockYotiClient(t)
+				yotiClient.
+					On("User", mock.Anything).
+					Return(identity.UserData{OK: true, Provider: identity.EasyID, FirstNames: "x", LastName: "y"}, nil)
+				return yotiClient
+			},
+			template: templateCalled,
+		},
+		"not ok": {
+			url: "/?code=a-code",
+			yotiClient: func(t *testing.T) *mockYotiClient {
+				yotiClient := newMockYotiClient(t)
+				yotiClient.
+					On("User", mock.Anything).
+					Return(identity.UserData{}, nil)
+				return yotiClient
+			},
+			template: templateCalled,
+		},
+		"errored on user": {
+			url: "/?code=a-code",
+			yotiClient: func(t *testing.T) *mockYotiClient {
+				yotiClient := newMockYotiClient(t)
+				yotiClient.
+					On("User", mock.Anything).
+					Return(identity.UserData{OK: true}, expectedError)
+				return yotiClient
+			},
+			template: templateIgnored,
+			error:    expectedError,
+		},
+	}
 
-	err := IdentityWithYotiCallback(nil, yotiClient, lpaStore)(testAppData, w, r)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest(http.MethodGet, tc.url, nil)
 
-	assert.Equal(t, expectedError, err)
+			lpaStore := newMockLpaStore(t)
+			lpaStore.
+				On("Get", r.Context()).
+				Return(&page.Lpa{}, nil)
+
+			yotiClient := tc.yotiClient(t)
+			template := tc.template(t, w)
+
+			err := IdentityWithYotiCallback(template.Execute, yotiClient, lpaStore)(testAppData, w, r)
+			resp := w.Result()
+
+			assert.Equal(t, tc.error, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
 }
 
 func TestGetIdentityWithYotiCallbackWhenGetDataStoreError(t *testing.T) {
@@ -71,11 +148,15 @@ func TestGetIdentityWithYotiCallbackWhenPutDataStoreError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?token=a-token", nil)
 	now := time.Now()
-	userData := identity.UserData{FullName: "a-full-name", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.EasyID, FirstNames: "first-name", LastName: "last-name", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
-	lpaStore.On("Put", r.Context(), &page.Lpa{YotiUserData: userData}).Return(expectedError)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor: actor.Donor{FirstNames: "first-name", LastName: "last-name"},
+		}, nil)
+	lpaStore.On("Put", r.Context(), mock.Anything).Return(expectedError)
 
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("User", "a-token").Return(userData, nil)
@@ -89,16 +170,21 @@ func TestGetIdentityWithYotiCallbackWhenReturning(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?token=a-token", nil)
 	now := time.Date(2012, time.January, 1, 2, 3, 4, 5, time.UTC)
-	userData := identity.UserData{OK: true, FullName: "a-full-name", RetrievedAt: now}
+	userData := identity.UserData{OK: true, Provider: identity.EasyID, FirstNames: "first-name", LastName: "last-name", RetrievedAt: now}
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{YotiUserData: userData}, nil)
+	lpaStore.
+		On("Get", r.Context()).
+		Return(&page.Lpa{
+			Donor:                 actor.Donor{FirstNames: "first-name", LastName: "last-name"},
+			DonorIdentityUserData: userData,
+		}, nil)
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &identityWithYotiCallbackData{
 			App:         testAppData,
-			FullName:    "a-full-name",
+			FullName:    "first-name last-name",
 			ConfirmedAt: now,
 		}).
 		Return(nil)
@@ -116,7 +202,8 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{
-		IdentityOption: identity.EasyID,
+		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID},
+		DonorIdentityOption:   identity.EasyID,
 	}, nil)
 
 	err := IdentityWithYotiCallback(nil, nil, lpaStore)(testAppData, w, r)
@@ -125,4 +212,19 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
 	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ReadYourLpa, resp.Header.Get("Location"))
+}
+
+func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodPost, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
+
+	err := IdentityWithYotiCallback(nil, nil, lpaStore)(testAppData, w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, "/lpa/lpa-id"+page.Paths.SelectYourIdentityOptions1, resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/identity_with_yoti_test.go
+++ b/app/internal/page/donor/identity_with_yoti_test.go
@@ -43,7 +43,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
 	lpaStore := newMockLpaStore(t)
-	lpaStore.On("Get", r.Context()).Return(&page.Lpa{YotiUserData: identity.UserData{OK: true}}, nil)
+	lpaStore.On("Get", r.Context()).Return(&page.Lpa{DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID}}, nil)
 
 	err := IdentityWithYoti(nil, lpaStore, nil, "")(testAppData, w, r)
 	resp := w.Result()

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -231,7 +231,7 @@ func Register(
 		page.Paths.IdentityWithOnlineBankAccount:        identity.OnlineBankAccount,
 	} {
 		handleLpa(path, CanGoBack,
-			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), identityOption))
+			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), lpaStore, time.Now, identityOption))
 	}
 
 	handleLpa(page.Paths.ReadYourLpa, CanGoBack,

--- a/app/internal/page/donor/resend_witness_code_test.go
+++ b/app/internal/page/donor/resend_witness_code_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/validation"
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,10 @@ func TestPostResendWitnessCode(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	lpa := &page.Lpa{Donor: actor.Donor{FirstNames: "john"}}
+	lpa := &page.Lpa{
+		Donor:                 actor.Donor{FirstNames: "john"},
+		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "john"},
+	}
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.

--- a/app/internal/page/donor/select_your_identity_options.go
+++ b/app/internal/page/donor/select_your_identity_options.go
@@ -27,7 +27,7 @@ func SelectYourIdentityOptions(tmpl template.Template, lpaStore LpaStore, pageIn
 			App:  appData,
 			Page: pageIndex,
 			Form: &selectYourIdentityOptionsForm{
-				Selected: lpa.IdentityOption,
+				Selected: lpa.DonorIdentityOption,
 			},
 		}
 
@@ -48,7 +48,7 @@ func SelectYourIdentityOptions(tmpl template.Template, lpaStore LpaStore, pageIn
 			}
 
 			if data.Errors.None() {
-				lpa.IdentityOption = data.Form.Selected
+				lpa.DonorIdentityOption = data.Form.Selected
 				lpa.Tasks.ConfirmYourIdentityAndSign = page.TaskInProgress
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {

--- a/app/internal/page/donor/select_your_identity_options_test.go
+++ b/app/internal/page/donor/select_your_identity_options_test.go
@@ -62,7 +62,7 @@ func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 		}, nil)
 
 	template := newMockTemplate(t)
@@ -116,7 +116,7 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 		Return(&page.Lpa{}, nil)
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 			Tasks: page.Tasks{
 				ConfirmYourIdentityAndSign: page.TaskInProgress,
 			},

--- a/app/internal/page/donor/sign_your_lpa.go
+++ b/app/internal/page/donor/sign_your_lpa.go
@@ -48,15 +48,16 @@ func SignYourLpa(tmpl template.Template, lpaStore LpaStore) page.Handler {
 
 			lpa.WantToApplyForLpa = data.Form.WantToApply
 			lpa.WantToSignLpa = data.Form.WantToSign
+
+			if data.Errors.None() {
+				lpa.Tasks.ConfirmYourIdentityAndSign = page.TaskCompleted
+			}
+
 			if err = lpaStore.Put(r.Context(), lpa); err != nil {
 				return err
 			}
 
 			if data.Errors.None() {
-				lpa.Tasks.ConfirmYourIdentityAndSign = page.TaskCompleted
-				if err = lpaStore.Put(r.Context(), lpa); err != nil {
-					return err
-				}
 				return appData.Redirect(w, r, lpa, page.Paths.WitnessingYourSignature)
 			}
 		}

--- a/app/internal/page/donor/sign_your_lpa_test.go
+++ b/app/internal/page/donor/sign_your_lpa_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/validation"
 	"github.com/stretchr/testify/assert"
@@ -103,15 +104,10 @@ func TestPostSignYourLpa(t *testing.T) {
 	lpaStore := newMockLpaStore(t)
 	lpaStore.
 		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
+		Return(&page.Lpa{DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin}}, nil)
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
-			WantToSignLpa:     true,
-			WantToApplyForLpa: true,
-		}).
-		Return(nil)
-	lpaStore.
-		On("Put", r.Context(), &page.Lpa{
+			DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 			Tasks: page.Tasks{
 				ConfirmYourIdentityAndSign: page.TaskCompleted,
 			},

--- a/app/internal/page/donor/task_list.go
+++ b/app/internal/page/donor/task_list.go
@@ -34,6 +34,11 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) page.Handler {
 			return err
 		}
 
+		signTaskPage := page.Paths.HowToConfirmYourIdentityAndSign
+		if lpa.DonorIdentityConfirmed() {
+			signTaskPage = page.Paths.ReadYourLpa
+		}
+
 		data := &taskListData{
 			App: appData,
 			Lpa: lpa,
@@ -101,7 +106,7 @@ func TaskList(tmpl template.Template, lpaStore LpaStore) page.Handler {
 					Items: []taskListItem{
 						{
 							Name:  "confirmYourIdentityAndSign",
-							Path:  page.Paths.HowToConfirmYourIdentityAndSign,
+							Path:  signTaskPage,
 							State: lpa.Tasks.ConfirmYourIdentityAndSign,
 						},
 					},

--- a/app/internal/page/donor/task_list_test.go
+++ b/app/internal/page/donor/task_list_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -19,6 +20,18 @@ func TestGetTaskList(t *testing.T) {
 		"empty": {
 			lpa: &page.Lpa{},
 			expected: func(sections []taskListSection) []taskListSection {
+				return sections
+			},
+		},
+		"confirmed identity": {
+			lpa: &page.Lpa{
+				DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
+			},
+			expected: func(sections []taskListSection) []taskListSection {
+				sections[2].Items = []taskListItem{
+					{Name: "confirmYourIdentityAndSign", Path: page.Paths.ReadYourLpa},
+				}
+
 				return sections
 			},
 		},

--- a/app/internal/page/donor/witnessing_as_certificate_provider.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider.go
@@ -60,7 +60,7 @@ func WitnessingAsCertificateProvider(tmpl template.Template, lpaStore LpaStore, 
 			}
 
 			if data.Errors.None() {
-				if lpa.CertificateProviderOneLoginUserData.OK {
+				if lpa.CertificateProviderIdentityConfirmed() {
 					if err := shareCodeSender.Send(r.Context(), notify.CertificateProviderReturnEmail, appData, false, lpa); err != nil {
 						return err
 					}

--- a/app/internal/page/donor/witnessing_as_certificate_provider_test.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider_test.go
@@ -128,10 +128,12 @@ func TestPostWitnessingAsCertificateProvider(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			WitnessCodes: page.WitnessCodes{{Code: "1234", Created: now}},
+			DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
+			WitnessCodes:          page.WitnessCodes{{Code: "1234", Created: now}},
 		}, nil)
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
+			DonorIdentityUserData:  identity.UserData{OK: true, Provider: identity.OneLogin},
 			WitnessCodes:           page.WitnessCodes{{Code: "1234", Created: now}},
 			CPWitnessCodeValidated: true,
 			Submitted:              now,
@@ -157,8 +159,9 @@ func TestPostWitnessingAsCertificateProviderWhenIdentityConfirmed(t *testing.T) 
 	now := time.Now()
 
 	lpa := &page.Lpa{
+		DonorIdentityUserData:               identity.UserData{OK: true, Provider: identity.OneLogin},
 		CertificateProvider:                 actor.CertificateProvider{Email: "name@example.com"},
-		CertificateProviderOneLoginUserData: identity.UserData{OK: true},
+		CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 		WitnessCodes:                        page.WitnessCodes{{Code: "1234", Created: now}},
 		CPWitnessCodeValidated:              true,
 		Submitted:                           now,
@@ -167,8 +170,9 @@ func TestPostWitnessingAsCertificateProviderWhenIdentityConfirmed(t *testing.T) 
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
+			DonorIdentityUserData:               identity.UserData{OK: true, Provider: identity.OneLogin},
 			CertificateProvider:                 actor.CertificateProvider{Email: "name@example.com"},
-			CertificateProviderOneLoginUserData: identity.UserData{OK: true},
+			CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 			WitnessCodes:                        page.WitnessCodes{{Code: "1234", Created: now}},
 		}, nil)
 	lpaStore.
@@ -200,7 +204,7 @@ func TestPostWitnessingAsCertificateProviderWhenShareCodeSendErrors(t *testing.T
 
 	lpa := &page.Lpa{
 		CertificateProvider:                 actor.CertificateProvider{Email: "name@example.com"},
-		CertificateProviderOneLoginUserData: identity.UserData{OK: true},
+		CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 		WitnessCodes:                        page.WitnessCodes{{Code: "1234", Created: now}},
 		CPWitnessCodeValidated:              true,
 		Submitted:                           now,
@@ -210,7 +214,7 @@ func TestPostWitnessingAsCertificateProviderWhenShareCodeSendErrors(t *testing.T
 		On("Get", r.Context()).
 		Return(&page.Lpa{
 			CertificateProvider:                 actor.CertificateProvider{Email: "name@example.com"},
-			CertificateProviderOneLoginUserData: identity.UserData{OK: true},
+			CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 			WitnessCodes:                        page.WitnessCodes{{Code: "1234", Created: now}},
 		}, nil)
 	lpaStore.

--- a/app/internal/page/donor/witnessing_your_signature_test.go
+++ b/app/internal/page/donor/witnessing_your_signature_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -76,7 +77,10 @@ func TestPostWitnessingYourSignature(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	lpa := &page.Lpa{CertificateProvider: actor.CertificateProvider{Mobile: "07535111111"}}
+	lpa := &page.Lpa{
+		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
+		CertificateProvider:   actor.CertificateProvider{Mobile: "07535111111"},
+	}
 
 	lpaStore := newMockLpaStore(t)
 	lpaStore.

--- a/app/internal/page/donor/your_chosen_identity_options.go
+++ b/app/internal/page/donor/your_chosen_identity_options.go
@@ -25,12 +25,12 @@ func YourChosenIdentityOptions(tmpl template.Template, lpaStore LpaStore) page.H
 		}
 
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, lpa, identityOptionPath(appData.Paths, lpa.IdentityOption))
+			return appData.Redirect(w, r, lpa, identityOptionPath(appData.Paths, lpa.DonorIdentityOption))
 		}
 
 		data := &yourChosenIdentityOptionsData{
 			App:            appData,
-			IdentityOption: lpa.IdentityOption,
+			IdentityOption: lpa.DonorIdentityOption,
 			You:            lpa.Donor,
 		}
 

--- a/app/internal/page/donor/your_chosen_identity_options_test.go
+++ b/app/internal/page/donor/your_chosen_identity_options_test.go
@@ -19,7 +19,7 @@ func TestGetYourChosenIdentityOptions(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 		}, nil)
 
 	template := newMockTemplate(t)
@@ -59,7 +59,7 @@ func TestGetYourChosenIdentityOptionsWhenTemplateErrors(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 		}, nil)
 
 	template := newMockTemplate(t)
@@ -82,7 +82,7 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			IdentityOption: identity.Passport,
+			DonorIdentityOption: identity.Passport,
 		}, nil)
 
 	err := YourChosenIdentityOptions(nil, lpaStore)(testAppData, w, r)

--- a/app/internal/page/fixtures.go
+++ b/app/internal/page/fixtures.go
@@ -215,10 +215,12 @@ func PayForLpa(lpa *Lpa, store sesh.Store, r *http.Request, w http.ResponseWrite
 }
 
 func ConfirmIdAndSign(lpa *Lpa) {
-	lpa.OneLoginUserData = identity.UserData{
+	lpa.DonorIdentityUserData = identity.UserData{
 		OK:          true,
+		Provider:    identity.OneLogin,
 		RetrievedAt: time.Date(2023, time.January, 2, 3, 4, 5, 6, time.UTC),
-		FullName:    "Jamie Smith",
+		FirstNames:  "Jamie",
+		LastName:    "Smith",
 	}
 
 	lpa.WantToApplyForLpa = true

--- a/app/internal/page/testing_start.go
+++ b/app/internal/page/testing_start.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/notify"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/random"
@@ -161,8 +162,12 @@ func TestingStart(store sesh.Store, lpaStore LpaStore, randomString func(int) st
 				LpaID:          lpa.ID,
 			})
 
-			lpa.CertificateProviderOneLoginUserData.FullName = "Jessie Jones"
-			lpa.CertificateProviderOneLoginUserData.OK = true
+			lpa.CertificateProviderIdentityUserData = identity.UserData{
+				OK:         true,
+				Provider:   identity.OneLogin,
+				FirstNames: "Jessie",
+				LastName:   "Jones",
+			}
 		}
 
 		if r.FormValue("provideCertificate") != "" {

--- a/app/internal/page/testing_start_test.go
+++ b/app/internal/page/testing_start_test.go
@@ -671,10 +671,12 @@ func TestTestingStart(t *testing.T) {
 		lpaStore.
 			On("Put", ctx, &Lpa{
 				ID: "123",
-				OneLoginUserData: identity.UserData{
+				DonorIdentityUserData: identity.UserData{
 					OK:          true,
+					Provider:    identity.OneLogin,
 					RetrievedAt: time.Date(2023, time.January, 2, 3, 4, 5, 6, time.UTC),
-					FullName:    "Jamie Smith",
+					FirstNames:  "Jamie",
+					LastName:    "Smith",
 				},
 				WantToApplyForLpa:      true,
 				WantToSignLpa:          true,
@@ -708,10 +710,12 @@ func TestTestingStart(t *testing.T) {
 		lpaStore.
 			On("Put", ctx, &Lpa{
 				ID: "123",
-				OneLoginUserData: identity.UserData{
+				DonorIdentityUserData: identity.UserData{
 					OK:          true,
+					Provider:    identity.OneLogin,
 					RetrievedAt: time.Date(2023, time.January, 2, 3, 4, 5, 6, time.UTC),
-					FullName:    "Jamie Smith",
+					FirstNames:  "Jamie",
+					LastName:    "Smith",
 				},
 				WantToApplyForLpa:      true,
 				WantToSignLpa:          true,
@@ -882,9 +886,11 @@ func TestTestingStart(t *testing.T) {
 		lpaStore.
 			On("Put", ctx, &Lpa{
 				ID: "123",
-				CertificateProviderOneLoginUserData: identity.UserData{
-					FullName: "Jessie Jones",
-					OK:       true,
+				CertificateProviderIdentityUserData: identity.UserData{
+					OK:         true,
+					Provider:   identity.OneLogin,
+					FirstNames: "Jessie",
+					LastName:   "Jones",
 				},
 			}).
 			Return(nil)
@@ -913,9 +919,11 @@ func TestTestingStart(t *testing.T) {
 		lpaStore.
 			On("Put", ctx, &Lpa{
 				ID: "123",
-				CertificateProviderOneLoginUserData: identity.UserData{
-					FullName: "Jessie Jones",
-					OK:       true,
+				CertificateProviderIdentityUserData: identity.UserData{
+					OK:         true,
+					Provider:   identity.OneLogin,
+					FirstNames: "Jessie",
+					LastName:   "Jones",
 				},
 				CertificateProviderProvidedDetails: actor.CertificateProvider{
 					Mobile: TestMobile,

--- a/cypress/e2e/donor/confirm-your-identity-and-sign.cy.js
+++ b/cypress/e2e/donor/confirm-your-identity-and-sign.cy.js
@@ -31,16 +31,22 @@ describe('Confirm your identity and sign', () => {
         cy.url().should('contain', '/select-your-identity-options');
         cy.checkA11yApp();
 
-        cy.contains('label', 'Your GOV.UK One Login Identity').click();
+        cy.contains('label', 'I do not have either of these types of accounts').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.url().should('contain', '/select-your-identity-options-1');
+        cy.checkA11yApp();
+
+        cy.contains('label', 'Your passport').click();
         cy.contains('button', 'Continue').click();
 
         cy.url().should('contain', '/your-chosen-identity-options');
         cy.checkA11yApp();
-
-        cy.contains('Your GOV.UK One Login Identity');
-        // can't click continue as the real flow would begin
-        cy.visitLpa('/read-your-lpa');
-
+        
+        cy.contains('passport');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Continue').click();
+        
         cy.url().should('contain', '/read-your-lpa');
         cy.checkA11yApp();
 
@@ -122,6 +128,9 @@ describe('Confirm your identity and sign', () => {
     });
 
     it('errors when not witnessed', () => {
+        cy.visitLpa('/id/passport');
+        cy.contains('button', 'Continue').click();
+
         cy.visitLpa('/witnessing-your-signature');
         cy.contains('button', 'Continue').click();
 

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -408,6 +408,7 @@
     "identifyYourselfWithYoti": "Profi pwy ydych chi gyda’r ap Yoti",
     "scanWithTheYotiApp": "Sganiwch gyda’r ap Yoti",
     "yourIdentityConfirmedWithYoti": "Cadarnhawyd eich manylion adnabod gyda Yoti",
+    "yourIdentityNotConfirmedWithYoti": "Welsh",
     "yourIdentityConfirmedWithOneLogin": "Welsh",
     "yourIdentityNotConfirmedWithOneLogin": "Welsh",
     "pleaseContinueWithADifferentMethod": "Welsh",

--- a/lang/en.json
+++ b/lang/en.json
@@ -363,6 +363,7 @@
     "identifyYourselfWithYoti": "Identify yourself with the Yoti app",
     "scanWithTheYotiApp": "Scan with the Yoti app",
     "yourIdentityConfirmedWithYoti": "Your identity details confirmed with Yoti",
+    "yourIdentityNotConfirmedWithYoti": "Your identity details could not be confirmed with Yoti",
     "yourIdentityConfirmedWithOneLogin": "Your identity details confirmed with GOV.UK One Login",
     "yourIdentityNotConfirmedWithOneLogin": "Your identity details could not be confirmed with GOV.UK One Login",
     "pleaseContinueWithADifferentMethod": "Don’t give up, you can (hopefully) continue with a different method.",

--- a/web/template/identity_with_yoti_callback.gohtml
+++ b/web/template/identity_with_yoti_callback.gohtml
@@ -1,31 +1,50 @@
 {{ template "page" . }}
 
-{{ define "pageTitle" }}{{ tr .App "yourIdentityConfirmedWithYoti" }}{{ end }}
+{{ define "serviceName" }}
+  {{ if eq .App.Page .App.Paths.CertificateProviderIdentityWithOneLoginCallback }}
+    {{ tr .App "beACertificateProvider" }}
+  {{ else }}
+    {{ tr .App "serviceName" }}
+  {{ end }}
+{{ end }}
+{{ define "pageTitle" }}
+  {{ if .CouldNotConfirm }}
+    {{ tr .App "yourIdentityNotConfirmedWithYoti" }}
+  {{ else }}
+    {{ tr .App "yourIdentityConfirmedWithYoti" }}
+  {{ end }}
+{{ end }}
 
 {{ define "main" }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ tr .App "yourIdentityConfirmedWithYoti" }}</h1>
+      {{ if .CouldNotConfirm }}
+        <h1 class="govuk-heading-xl">{{ tr .App "yourIdentityNotConfirmedWithYoti" }}</h1>
 
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Full Name
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ .FullName }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Confirmed at
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ formatDateTime .ConfirmedAt }}
-          </dd>
-        </div>
-      </dl>
+        <p class="govuk-body">{{ tr .App "pleaseContinueWithADifferentMethod" }}</p>
+      {{ else }}
+        <h1 class="govuk-heading-xl">{{ tr .App "yourIdentityConfirmedWithYoti" }}</h1>
 
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Full Name
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ .FullName }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Confirmed at
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ formatDateTime .ConfirmedAt }}
+            </dd>
+          </div>
+        </dl>
+      {{ end }}
+      
       <form novalidate method="post">
         {{ template "continue-button" . }}
         {{ template "csrf-field" . }}

--- a/web/template/layout/certificate-provider-details.gohtml
+++ b/web/template/layout/certificate-provider-details.gohtml
@@ -1,35 +1,40 @@
 {{ define "certificate-provider-details" }}
-    <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-                {{ tr .App "name" }}
-            </dt>
-            <dd class="govuk-summary-list__value">
-                {{ .Lpa.CertificateProvider.FirstNames }} {{ .Lpa.CertificateProvider.LastName }}
-            </dd>
-            {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
-                <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
-                        {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ lowerFirst (tr .App "certificateProvider") }}</span>
-                    </a>
-                </dd>
-            {{ end }}
-        </div>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        {{ tr .App "name" }}
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ .Lpa.CertificateProvider.FirstNames }} {{ .Lpa.CertificateProvider.LastName }}
+      </dd>
+      {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
+            {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ lowerFirst (tr .App "certificateProvider") }}</span>
+          </a>
+        </dd>
+      {{ end }}
+      {{ if .Lpa.CertificateProviderIdentityConfirmed }}
+        <dd class="govuk-summary-list__value">
+          <strong class="govuk-tag app-task-list__tag govuk-tag">{{ tr .App "idVerifiedTag" }}</strong>
+        </dd>
+      {{ end }}
+    </div>
 
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-                {{ tr .App "mobile" }}
-            </dt>
-            <dd class="govuk-summary-list__value">
-                {{ .Lpa.CertificateProvider.Mobile }}
-            </dd>
-            {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
-                <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
-                        {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "certificateProviderMobile" }}</span>
-                    </a>
-                </dd>
-            {{ end }}
-        </div>
-    </dl>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        {{ tr .App "mobile" }}
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ .Lpa.CertificateProvider.Mobile }}
+      </dd>
+      {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}">
+            {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "certificateProviderMobile" }}</span>
+          </a>
+        </dd>
+      {{ end }}
+    </div>
+  </dl>
 {{ end }}

--- a/web/template/layout/donor-details.gohtml
+++ b/web/template/layout/donor-details.gohtml
@@ -7,7 +7,7 @@
         <dd class="govuk-summary-list__value">
             {{ .Lpa.Donor.FirstNames }} {{ .Lpa.Donor.LastName }}
         </dd>
-        {{ if .Lpa.IdentityConfirmed }}
+        {{ if .Lpa.DonorIdentityConfirmed }}
             <dd class="govuk-summary-list__value">
                 <strong class="govuk-tag app-task-list__tag govuk-tag">{{ tr .App "idVerifiedTag" }}</strong>
             </dd>


### PR DESCRIPTION
This consolidates the identity info into one field for the donor and one for the certificate provider. I've then expanded the `Lpa.IdentityConfirmed` method (and added a `Lpa.CertificateProviderIdentityConfirmed` method) to check the names of the actor match the data returned. This is first making everything uppercase, then if they don't match making the order of firstnames not matter and transliterating characters using the data from the table in the comments. I have not gone so far as to do alternate transliterations as that will require "actual work" and we aren't sure yet how far this needs to be taken.

I have then also made it so that if identity has been confirmed you will skip to "Read the LPA" from the task list, and blocked progress to some pages if identity has not been confirmed.