### PR TITLE
MLPAB-750 - fix path to live

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -9,11 +9,11 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: read
+  pull-requests: write
   actions: none
   checks: none
   deployments: none
-  issues: none
+  issues: write
   packages: none
   repository-projects: none
   statuses: none
@@ -70,6 +70,7 @@ jobs:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
       ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   ui_tests_preproduction_env:
     name: Run Cypress UI Tests On Preproduction Environment
@@ -126,6 +127,7 @@ jobs:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
       ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   end_of_main_workflow:
     name: End of Main Workflow


### PR DESCRIPTION
# Purpose

Fix path to live

Get quick feedback on jobs without having to delve into the actions log

Fixes MLPAB-750

## Approach

- pipe a summary of the plan to an output
- use actions scripts to push a message to PR (or any other issue type) comments

## Learning

- https://github.com/actions/github-script#comment-on-an-issue
- https://github.com/hashicorp/setup-terraform/blob/main/README.md

To capture the plan summary:
The `-no-color` option is used to disable colourised output from the terraform plan command, and the `-ioE` options for grep are used to perform a case-insensitive search (-i), to output only the matching text (-o), and to use extended regular expressions (-E) for matching the numbers in the summary line.

## Checklist

* [x] I have performed a self-review of my own code