### PR TITLE
MLPAB-785 Fix yoti redirect

### DIFF
--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -38,8 +38,6 @@ func App(
 	appPublicUrl string,
 	payClient *pay.Client,
 	yotiClient *identity.YotiClient,
-	yotiDonorScenarioID string,
-	yotiCertificateProviderScenarioID string,
 	notifyClient *notify.Client,
 	addressClient *place.Client,
 	rumConfig page.RumConfig,
@@ -74,7 +72,6 @@ func App(
 		addressClient,
 		errorHandler,
 		yotiClient,
-		yotiCertificateProviderScenarioID,
 		notifyClient,
 	)
 
@@ -89,7 +86,6 @@ func App(
 		appPublicUrl,
 		payClient,
 		yotiClient,
-		yotiDonorScenarioID,
 		notifyClient,
 		shareCodeSender,
 		errorHandler,

--- a/app/internal/app/app_test.go
+++ b/app/internal/app/app_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestApp(t *testing.T) {
-	app := App(&logging.Logger{}, &localize.Localizer{}, localize.En, template.Templates{}, nil, &dynamo.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, "yoti-donor-scenario-id", "yoti-certificate-provider-scenario-id", &notify.Client{}, &place.Client{}, page.RumConfig{}, "?%3fNEI0t9MN", page.Paths, &onelogin.Client{})
+	app := App(&logging.Logger{}, &localize.Localizer{}, localize.En, template.Templates{}, nil, &dynamo.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, &notify.Client{}, &place.Client{}, page.RumConfig{}, "?%3fNEI0t9MN", page.Paths, &onelogin.Client{})
 
 	assert.Implements(t, (*http.Handler)(nil), app)
 }

--- a/app/internal/identity/yoti_client.go
+++ b/app/internal/identity/yoti_client.go
@@ -12,14 +12,15 @@ import (
 const yotiSandboxBaseURL = "https://api.yoti.com/sandbox/v1"
 
 type YotiClient struct {
-	yoti      *yoti.Client
-	isSandbox bool
-	details   profile.ActivityDetails
+	yoti       *yoti.Client
+	isSandbox  bool
+	details    profile.ActivityDetails
+	scenarioID string
 }
 
-func NewYotiClient(clientID string, privateKeyBytes []byte) (*YotiClient, error) {
+func NewYotiClient(scenarioID, clientID string, privateKeyBytes []byte) (*YotiClient, error) {
 	if clientID == "" {
-		return &YotiClient{}, nil
+		return &YotiClient{scenarioID: scenarioID}, nil
 	}
 
 	client, err := yoti.NewClient(clientID, privateKeyBytes)
@@ -27,7 +28,7 @@ func NewYotiClient(clientID string, privateKeyBytes []byte) (*YotiClient, error)
 		return nil, err
 	}
 
-	return &YotiClient{yoti: client}, nil
+	return &YotiClient{yoti: client, scenarioID: scenarioID}, nil
 }
 
 func (c *YotiClient) SetupSandbox() error {
@@ -48,6 +49,10 @@ func (c *YotiClient) SetupSandbox() error {
 	c.details = details
 
 	return err
+}
+
+func (c *YotiClient) ScenarioID() string {
+	return c.scenarioID
 }
 
 func (c *YotiClient) SdkID() string {
@@ -91,7 +96,7 @@ func (c *YotiClient) User(token string) (UserData, error) {
 		return UserData{}, err
 	}
 
-	dateOfBirth, err := c.details.UserProfile.DateOfBirth()
+	dateOfBirth, err := details.UserProfile.DateOfBirth()
 	if err != nil {
 		return UserData{}, err
 	}

--- a/app/internal/identity/yoti_client.go
+++ b/app/internal/identity/yoti_client.go
@@ -35,7 +35,9 @@ func (c *YotiClient) SetupSandbox() error {
 	sandboxClient := &sandbox.Client{ClientSdkID: c.yoti.SdkID, Key: c.yoti.Key, BaseURL: yotiSandboxBaseURL}
 
 	tokenRequest := (&sandbox.TokenRequest{}).
-		WithFullName("Test Person", nil)
+		WithGivenNames("Test", nil).
+		WithFamilyName("Person", nil).
+		WithDateOfBirth(time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC), nil)
 
 	sandboxToken, err := sandboxClient.SetupSharingProfile(tokenRequest)
 	if err != nil {

--- a/app/internal/identity/yoti_client_test.go
+++ b/app/internal/identity/yoti_client_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestMockClient(t *testing.T) {
-	client, err := NewYotiClient("", []byte("hey"))
+	client, err := NewYotiClient("xyz", "", []byte("hey"))
 	assert.Nil(t, err)
 	assert.True(t, client.IsTest())
+	assert.Equal(t, "xyz", client.ScenarioID())
 
 	user, err := client.User("xyz")
 	assert.Nil(t, err)

--- a/app/internal/page/certificateprovider/identity_with_yoti.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/sesh"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/validation"
 )
 
@@ -15,7 +16,7 @@ type identityWithYotiData struct {
 	ScenarioID  string
 }
 
-func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient YotiClient, yotiScenarioID string) page.Handler {
+func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, sessionStore SessionStore, yotiClient YotiClient) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
 		lpa, err := lpaStore.Get(r.Context())
 		if err != nil {
@@ -26,10 +27,18 @@ func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient Yoti
 			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderIdentityWithYotiCallback)
 		}
 
+		if err := sesh.SetYoti(sessionStore, r, w, &sesh.YotiSession{
+			Locale:              appData.Lang.String(),
+			LpaID:               appData.LpaID,
+			CertificateProvider: true,
+		}); err != nil {
+			return err
+		}
+
 		data := &identityWithYotiData{
 			App:         appData,
 			ClientSdkID: yotiClient.SdkID(),
-			ScenarioID:  yotiScenarioID,
+			ScenarioID:  yotiClient.ScenarioID(),
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/certificateprovider/identity_with_yoti_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_test.go
@@ -5,8 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/sessions"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/identity"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/sesh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,9 +20,26 @@ func TestGetIdentityWithYoti(t *testing.T) {
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
 
+	sessionStore := newMockSessionStore(t)
+	session := sessions.NewSession(sessionStore, "yoti")
+	session.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   600,
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: true,
+		Secure:   true,
+	}
+	session.Values = map[any]any{
+		"yoti": &sesh.YotiSession{Locale: "en", LpaID: "lpa-id", CertificateProvider: true},
+	}
+	sessionStore.
+		On("Save", r, w, session).
+		Return(nil)
+
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("IsTest").Return(false)
 	yotiClient.On("SdkID").Return("an-sdk-id")
+	yotiClient.On("ScenarioID").Return("a-scenario-id")
 
 	template := newMockTemplate(t)
 	template.
@@ -31,11 +50,31 @@ func TestGetIdentityWithYoti(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := IdentityWithYoti(template.Execute, lpaStore, yotiClient, "a-scenario-id")(testAppData, w, r)
+	err := IdentityWithYoti(template.Execute, lpaStore, sessionStore, yotiClient)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestGetIdentityWithYotiWhenSessionErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpaStore := newMockLpaStore(t)
+	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
+
+	yotiClient := newMockYotiClient(t)
+	yotiClient.On("IsTest").Return(false)
+
+	sessionStore := newMockSessionStore(t)
+	sessionStore.
+		On("Save", r, w, mock.Anything).
+		Return(expectedError)
+
+	err := IdentityWithYoti(nil, lpaStore, sessionStore, yotiClient)(testAppData, w, r)
+
+	assert.Equal(t, expectedError, err)
 }
 
 func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
@@ -45,7 +84,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{CertificateProviderIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID}}, nil)
 
-	err := IdentityWithYoti(nil, lpaStore, nil, "")(testAppData, w, r)
+	err := IdentityWithYoti(nil, lpaStore, nil, nil)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -63,7 +102,7 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("IsTest").Return(true)
 
-	err := IdentityWithYoti(nil, lpaStore, yotiClient, "")(testAppData, w, r)
+	err := IdentityWithYoti(nil, lpaStore, nil, yotiClient)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -78,7 +117,7 @@ func TestGetIdentityWithYotiWhenDataStoreError(t *testing.T) {
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, expectedError)
 
-	err := IdentityWithYoti(nil, lpaStore, nil, "a-scenario-id")(testAppData, w, r)
+	err := IdentityWithYoti(nil, lpaStore, nil, nil)(testAppData, w, r)
 
 	assert.Equal(t, expectedError, err)
 }
@@ -90,16 +129,22 @@ func TestGetIdentityWithYotiWhenTemplateError(t *testing.T) {
 	lpaStore := newMockLpaStore(t)
 	lpaStore.On("Get", r.Context()).Return(&page.Lpa{}, nil)
 
+	sessionStore := newMockSessionStore(t)
+	sessionStore.
+		On("Save", r, w, mock.Anything).
+		Return(nil)
+
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("IsTest").Return(false)
 	yotiClient.On("SdkID").Return("an-sdk-id")
+	yotiClient.On("ScenarioID").Return("a-scenario-id")
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.Anything).
 		Return(expectedError)
 
-	err := IdentityWithYoti(template.Execute, lpaStore, yotiClient, "a-scenario-id")(testAppData, w, r)
+	err := IdentityWithYoti(template.Execute, lpaStore, sessionStore, yotiClient)(testAppData, w, r)
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/certificateprovider/mock_YotiClient_test.go
+++ b/app/internal/page/certificateprovider/mock_YotiClient_test.go
@@ -26,6 +26,20 @@ func (_m *mockYotiClient) IsTest() bool {
 	return r0
 }
 
+// ScenarioID provides a mock function with given fields:
+func (_m *mockYotiClient) ScenarioID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // SdkID provides a mock function with given fields:
 func (_m *mockYotiClient) SdkID() string {
 	ret := _m.Called()

--- a/app/internal/page/certificateprovider/register.go
+++ b/app/internal/page/certificateprovider/register.go
@@ -64,6 +64,7 @@ type SessionStore interface {
 type YotiClient interface {
 	IsTest() bool
 	SdkID() string
+	ScenarioID() string
 	User(string) (identity.UserData, error)
 }
 
@@ -85,7 +86,6 @@ func Register(
 	addressClient AddressClient,
 	errorHandler page.ErrorHandler,
 	yotiClient YotiClient,
-	yotiScenarioID string,
 	notifyClient NotifyClient,
 ) {
 	handleRoot := makeHandle(rootMux, sessionStore, errorHandler)
@@ -120,7 +120,7 @@ func Register(
 	handleRoot(page.Paths.CertificateProviderYourChosenIdentityOptions, RequireSession,
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml"), lpaStore))
 	handleRoot(page.Paths.CertificateProviderIdentityWithYoti, RequireSession,
-		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), lpaStore, yotiClient, yotiScenarioID))
+		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), lpaStore, sessionStore, yotiClient))
 	handleRoot(page.Paths.CertificateProviderIdentityWithYotiCallback, RequireSession,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, lpaStore))
 	handleRoot(page.Paths.CertificateProviderIdentityWithOneLogin, RequireSession,

--- a/app/internal/page/certificateprovider/register_test.go
+++ b/app/internal/page/certificateprovider/register_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestRegister(t *testing.T) {
 	mux := http.NewServeMux()
-	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, nil, &place.Client{}, nil, &identity.YotiClient{}, "", &notify.Client{})
+	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, nil, &place.Client{}, nil, &identity.YotiClient{}, &notify.Client{})
 
 	assert.Implements(t, (*http.Handler)(nil), mux)
 }

--- a/app/internal/page/donor/identity_with_yoti.go
+++ b/app/internal/page/donor/identity_with_yoti.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/sesh"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/validation"
 )
 
@@ -15,7 +16,7 @@ type identityWithYotiData struct {
 	ScenarioID  string
 }
 
-func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient YotiClient, yotiScenarioID string) page.Handler {
+func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, sessionStore SessionStore, yotiClient YotiClient) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
 		lpa, err := lpaStore.Get(r.Context())
 		if err != nil {
@@ -26,10 +27,17 @@ func IdentityWithYoti(tmpl template.Template, lpaStore LpaStore, yotiClient Yoti
 			return appData.Redirect(w, r, lpa, page.Paths.IdentityWithYotiCallback)
 		}
 
+		if err := sesh.SetYoti(sessionStore, r, w, &sesh.YotiSession{
+			Locale: appData.Lang.String(),
+			LpaID:  appData.LpaID,
+		}); err != nil {
+			return err
+		}
+
 		data := &identityWithYotiData{
 			App:         appData,
 			ClientSdkID: yotiClient.SdkID(),
-			ScenarioID:  yotiScenarioID,
+			ScenarioID:  yotiClient.ScenarioID(),
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/mock_YotiClient_test.go
+++ b/app/internal/page/donor/mock_YotiClient_test.go
@@ -26,6 +26,20 @@ func (_m *mockYotiClient) IsTest() bool {
 	return r0
 }
 
+// ScenarioID provides a mock function with given fields:
+func (_m *mockYotiClient) ScenarioID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // SdkID provides a mock function with given fields:
 func (_m *mockYotiClient) SdkID() string {
 	ret := _m.Called()

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -57,6 +57,7 @@ type ShareCodeSender interface {
 type YotiClient interface {
 	IsTest() bool
 	SdkID() string
+	ScenarioID() string
 	User(string) (identity.UserData, error)
 }
 
@@ -98,7 +99,6 @@ func Register(
 	appPublicUrl string,
 	payClient PayClient,
 	yotiClient YotiClient,
-	yotiScenarioID string,
 	notifyClient NotifyClient,
 	shareCodeSender ShareCodeSender,
 	errorHandler page.ErrorHandler,
@@ -215,7 +215,7 @@ func Register(
 	handleLpa(page.Paths.YourChosenIdentityOptions, CanGoBack,
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml"), lpaStore))
 	handleLpa(page.Paths.IdentityWithYoti, CanGoBack,
-		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), lpaStore, yotiClient, yotiScenarioID))
+		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), lpaStore, sessionStore, yotiClient))
 	handleLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, lpaStore))
 	handleLpa(page.Paths.IdentityWithOneLogin, CanGoBack,

--- a/app/internal/page/donor/register_test.go
+++ b/app/internal/page/donor/register_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRegister(t *testing.T) {
 	mux := http.NewServeMux()
-	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, &place.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, "yoti-scenario-id", &notify.Client{}, nil, nil, nil)
+	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, &place.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, &notify.Client{}, nil, nil, nil)
 
 	assert.Implements(t, (*http.Handler)(nil), mux)
 }

--- a/app/internal/page/paths.go
+++ b/app/internal/page/paths.go
@@ -95,6 +95,7 @@ type AppPaths struct {
 	WhoIsTheLpaFor                                          string
 	WitnessingAsCertificateProvider                         string
 	WitnessingYourSignature                                 string
+	YotiRedirect                                            string
 	YouHaveSubmittedYourLpa                                 string
 	YourAddress                                             string
 	YourChosenIdentityOptions                               string
@@ -191,6 +192,7 @@ var Paths = AppPaths{
 	WhoIsTheLpaFor:                                          "/who-is-the-lpa-for",
 	WitnessingAsCertificateProvider:                         "/witnessing-as-certificate-provider",
 	WitnessingYourSignature:                                 "/witnessing-your-signature",
+	YotiRedirect:                                            "/yoti/redirect",
 	YouHaveSubmittedYourLpa:                                 "/you-have-submitted-your-lpa",
 	YourAddress:                                             "/your-address",
 	YourChosenIdentityOptions:                               "/your-chosen-identity-options",
@@ -202,6 +204,7 @@ func IsLpaPath(url string) bool {
 	path, _, _ := strings.Cut(url, "?")
 
 	return !slices.Contains([]string{
+		Paths.YotiRedirect,
 		Paths.AuthRedirect,
 		Paths.CertificateProvided,
 		Paths.CertificateProviderCheckYourName,

--- a/app/internal/page/yoti_redirect.go
+++ b/app/internal/page/yoti_redirect.go
@@ -1,0 +1,31 @@
+package page
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/localize"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/sesh"
+)
+
+func YotiRedirect(logger Logger, store sesh.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		yotiSession, err := sesh.Yoti(store, r)
+		if err != nil {
+			logger.Print(err)
+			return
+		}
+
+		lang := localize.En
+		if yotiSession.Locale == "cy" {
+			lang = localize.Cy
+		}
+
+		appData := AppData{Lang: lang, LpaID: yotiSession.LpaID}
+
+		redirect := Paths.IdentityWithYotiCallback
+		if yotiSession.CertificateProvider {
+			redirect = Paths.CertificateProviderIdentityWithYotiCallback
+		}
+		appData.Redirect(w, r, nil, redirect+"?"+r.URL.RawQuery)
+	}
+}

--- a/app/internal/page/yoti_redirect_test.go
+++ b/app/internal/page/yoti_redirect_test.go
@@ -1,0 +1,81 @@
+package page
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/sessions"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/sesh"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYotiRedirect(t *testing.T) {
+	testcases := map[string]struct {
+		session  *sesh.YotiSession
+		redirect string
+	}{
+		"donor identity": {
+			session: &sesh.YotiSession{
+				LpaID: "123",
+			},
+			redirect: "/lpa/123" + Paths.IdentityWithYotiCallback,
+		},
+		"donor identity welsh": {
+			session: &sesh.YotiSession{
+				Locale: "cy",
+				LpaID:  "123",
+			},
+			redirect: "/cy/lpa/123" + Paths.IdentityWithYotiCallback,
+		},
+		"certificate provider identity": {
+			session: &sesh.YotiSession{
+				Locale:              "en",
+				LpaID:               "123",
+				CertificateProvider: true,
+			},
+			redirect: Paths.CertificateProviderIdentityWithYotiCallback,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest(http.MethodGet, "/?token=my-token", nil)
+
+			sessionStore := newMockSessionStore(t)
+			sessionStore.
+				On("Get", r, "yoti").
+				Return(&sessions.Session{
+					Values: map[any]any{
+						"yoti": tc.session,
+					},
+				}, nil)
+
+			YotiRedirect(nil, sessionStore)(w, r)
+			resp := w.Result()
+
+			assert.Equal(t, http.StatusFound, resp.StatusCode)
+			assert.Equal(t, tc.redirect+"?token=my-token", resp.Header.Get("Location"))
+		})
+	}
+}
+
+func TestYotiRedirectSessionMissing(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?token=my-token", nil)
+
+	logger := newMockLogger(t)
+	logger.
+		On("Print", ExpectedError)
+
+	sessionStore := newMockSessionStore(t)
+	sessionStore.
+		On("Get", r, "yoti").
+		Return(nil, ExpectedError)
+
+	YotiRedirect(logger, sessionStore)(w, r)
+	resp := w.Result()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/app/main.go
+++ b/app/main.go
@@ -42,24 +42,23 @@ func main() {
 	logger := logging.New(os.Stdout, "opg-modernising-lpa")
 
 	var (
-		appPublicURL                      = env.Get("APP_PUBLIC_URL", "http://localhost:5050")
-		authRedirectBaseURL               = env.Get("AUTH_REDIRECT_BASE_URL", "http://localhost:5050")
-		webDir                            = env.Get("WEB_DIR", "web")
-		awsBaseURL                        = env.Get("AWS_BASE_URL", "")
-		clientID                          = env.Get("CLIENT_ID", "client-id-value")
-		issuer                            = env.Get("ISSUER", "http://sign-in-mock:7012")
-		dynamoTableLpas                   = env.Get("DYNAMODB_TABLE_LPAS", "")
-		notifyBaseURL                     = env.Get("GOVUK_NOTIFY_BASE_URL", "")
-		notifyIsProduction                = env.Get("GOVUK_NOTIFY_IS_PRODUCTION", "") == "1"
-		ordnanceSurveyBaseUrl             = env.Get("ORDNANCE_SURVEY_BASE_URL", "http://ordnance-survey-mock:4011")
-		payBaseUrl                        = env.Get("GOVUK_PAY_BASE_URL", "http://pay-mock:4010")
-		port                              = env.Get("APP_PORT", "8080")
-		yotiClientSdkID                   = env.Get("YOTI_CLIENT_SDK_ID", "")
-		yotiDonorScenarioID               = env.Get("YOTI_SCENARIO_ID", "")
-		yotiCertificateProviderScenarioID = env.Get("YOTI_CERTIFICATE_PROVIDER_SCENARIO_ID", "")
-		yotiSandbox                       = env.Get("YOTI_SANDBOX", "") == "1"
-		xrayEnabled                       = env.Get("XRAY_ENABLED", "") == "1"
-		rumConfig                         = page.RumConfig{
+		appPublicURL          = env.Get("APP_PUBLIC_URL", "http://localhost:5050")
+		authRedirectBaseURL   = env.Get("AUTH_REDIRECT_BASE_URL", "http://localhost:5050")
+		webDir                = env.Get("WEB_DIR", "web")
+		awsBaseURL            = env.Get("AWS_BASE_URL", "")
+		clientID              = env.Get("CLIENT_ID", "client-id-value")
+		issuer                = env.Get("ISSUER", "http://sign-in-mock:7012")
+		dynamoTableLpas       = env.Get("DYNAMODB_TABLE_LPAS", "")
+		notifyBaseURL         = env.Get("GOVUK_NOTIFY_BASE_URL", "")
+		notifyIsProduction    = env.Get("GOVUK_NOTIFY_IS_PRODUCTION", "") == "1"
+		ordnanceSurveyBaseUrl = env.Get("ORDNANCE_SURVEY_BASE_URL", "http://ordnance-survey-mock:4011")
+		payBaseUrl            = env.Get("GOVUK_PAY_BASE_URL", "http://pay-mock:4010")
+		port                  = env.Get("APP_PORT", "8080")
+		yotiClientSdkID       = env.Get("YOTI_CLIENT_SDK_ID", "")
+		yotiScenarioID        = env.Get("YOTI_SCENARIO_ID", "")
+		yotiSandbox           = env.Get("YOTI_SANDBOX", "") == "1"
+		xrayEnabled           = env.Get("XRAY_ENABLED", "") == "1"
+		rumConfig             = page.RumConfig{
 			GuestRoleArn:      env.Get("AWS_RUM_GUEST_ROLE_ARN", ""),
 			Endpoint:          env.Get("AWS_RUM_ENDPOINT", ""),
 			ApplicationRegion: env.Get("AWS_RUM_APPLICATION_REGION", ""),
@@ -155,7 +154,7 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	yotiClient, err := identity.NewYotiClient(yotiClientSdkID, yotiPrivateKey)
+	yotiClient, err := identity.NewYotiClient(yotiScenarioID, yotiClientSdkID, yotiPrivateKey)
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -189,9 +188,10 @@ func main() {
 	})
 	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlHeaders(http.FileServer(http.Dir(webDir+"/static/"))))))
 	mux.Handle(page.Paths.AuthRedirect, page.AuthRedirect(logger, sessionStore))
+	mux.Handle(page.Paths.YotiRedirect, page.YotiRedirect(logger, sessionStore))
 	mux.Handle(page.Paths.CookiesConsent, page.CookieConsent(page.Paths))
-	mux.Handle("/cy/", http.StripPrefix("/cy", app.App(logger, bundle.For("cy"), localize.Cy, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, yotiDonorScenarioID, yotiCertificateProviderScenarioID, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient)))
-	mux.Handle("/", app.App(logger, bundle.For("en"), localize.En, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, yotiDonorScenarioID, yotiCertificateProviderScenarioID, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient))
+	mux.Handle("/cy/", http.StripPrefix("/cy", app.App(logger, bundle.For("cy"), localize.Cy, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient)))
+	mux.Handle("/", app.App(logger, bundle.For("en"), localize.En, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient))
 
 	var handler http.Handler = mux
 	if xrayEnabled {

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -301,10 +301,6 @@ locals {
           value = var.app_env_vars.yoti_scenario_id
         },
         {
-          name  = "YOTI_CERTIFICATE_PROVIDER_SCENARIO_ID",
-          value = var.app_env_vars.yoti_certificate_provider_scenario_id,
-        },
-        {
           name  = "YOTI_SANDBOX",
           value = var.app_env_vars.yoti_sandbox
         },

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -15,7 +15,6 @@
           "notify_is_production": "",
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",
-          "yoti_certificate_provider_scenario_id": "6bf90e26-28cb-45aa-bd3b-2ad93e4e7d3b",
           "yoti_sandbox": "1"
         }
       },
@@ -53,7 +52,6 @@
           "notify_is_production": "",
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",
-          "yoti_certificate_provider_scenario_id": "6bf90e26-28cb-45aa-bd3b-2ad93e4e7d3b",
           "yoti_sandbox": "1"
         }
       },
@@ -91,7 +89,6 @@
           "notify_is_production": "",
           "yoti_client_sdk_id": "8ebb1f85-5921-4b24-978d-b145071b4965",
           "yoti_scenario_id": "bad5778b-c948-4779-8f47-0c835d0491d4",
-          "yoti_certificate_provider_scenario_id": "a7ae38dc-849b-4967-af6e-2a3bc188af16",
           "yoti_sandbox": ""
         }
       },
@@ -129,7 +126,6 @@
           "notify_is_production": "1",
           "yoti_client_sdk_id": "d920d4fe-bddf-45a3-bed5-234b4a1e78b8",
           "yoti_scenario_id": "04371367-fcee-4bc0-a0e5-cdd5855861ea",
-          "yoti_certificate_provider_scenario_id": "6265b885-403f-4f9e-985a-7b2f68a63b9c",
           "yoti_sandbox": ""
         }
       },

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -26,7 +26,6 @@ variable "environments" {
           notify_is_production                  = string
           yoti_client_sdk_id                    = string
           yoti_scenario_id                      = string
-          yoti_certificate_provider_scenario_id = string
           yoti_sandbox                          = string
         })
       })


### PR DESCRIPTION
I think that having a single scenario like this will make life easier, since we want the same data from both actors. I'm using the same pattern as we do for One Login, storing data in a session and adding a facade redirect handler. 