### PR TITLE
MLPAB-799 - Toggle public access for UR environment

### DIFF
--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -18,7 +18,7 @@ on:
         description: 'Enable public access to the environment?'
         default: false
         required: false
-        type: string
+        type: boolean
     outputs:
       terraform_workspace_name:
         description: "Name of Terraform workspace"

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -14,6 +14,11 @@ on:
         default: ${{ github.ref }}
         required: false
         type: string
+      public_access_enabled:
+        description: 'Enable public access to the environment?'
+        default: false
+        required: false
+        type: string
     outputs:
       terraform_workspace_name:
         description: "Name of Terraform workspace"
@@ -88,8 +93,8 @@ jobs:
           TF_VAR_container_version: ${{ inputs.version_tag }}
         run: |
           terraform workspace show
-          echo "plan_summary=$(terraform plan -no-color -lock-timeout=300s -input=false -parallelism=30 | grep -ioE 'Plan: [[:digit:]]+ to add, [[:digit:]]+ to change, [[:digit:]]+ to destroy|No changes. Your infrastructure matches the configuration.')" >> $GITHUB_OUTPUT
-          terraform plan -lock-timeout=300s -input=false -parallelism=30
+          echo "plan_summary=$(terraform plan -var public_access_enabled=${{ inputs.public_access_enabled }} -no-color -lock-timeout=300s -input=false -parallelism=30 | grep -ioE 'Plan: [[:digit:]]+ to add, [[:digit:]]+ to change, [[:digit:]]+ to destroy|No changes. Your infrastructure matches the configuration.')" >> $GITHUB_OUTPUT
+          terraform plan -var public_access_enabled=${{ inputs.public_access_enabled }} -lock-timeout=300s -input=false -parallelism=30
 
         working-directory: ./terraform/environment
 
@@ -147,7 +152,7 @@ jobs:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
           TF_VAR_container_version: ${{ inputs.version_tag }}
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30
+          terraform apply -var public_access_enabled=${{ inputs.public_access_enabled }} -lock-timeout=300s -input=false -auto-approve -parallelism=30
         working-directory: ./terraform/environment
 
       - name: upload environment config file

--- a/.github/workflows/toggle_public_access_job.yml
+++ b/.github/workflows/toggle_public_access_job.yml
@@ -19,13 +19,7 @@ on:
       ssh_deploy_key:
         description: 'SSH Deploy Key'
         required: true
-      github_access_token:
-        description: 'Github Token'
-        required: true
 
-permissions:
-  pull-requests: write
-  issues: write
 
 jobs:
   terraform_environment_workflow:

--- a/.github/workflows/toggle_public_access_job.yml
+++ b/.github/workflows/toggle_public_access_job.yml
@@ -1,0 +1,61 @@
+on:
+  workflow_call:
+    inputs:
+      workspace_name:
+        description: 'The terraform workspace to target for environment actions'
+        required: true
+        type: string
+      public_access_enabled:
+        description: 'Enable public access to the UR environment?'
+        required: true
+        type: boolean
+    secrets:
+      aws_access_key_id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS Secret Access Key'
+        required: true
+      ssh_deploy_key:
+        description: 'SSH Deploy Key'
+        required: true
+      github_access_token:
+        description: 'Github Token'
+        required: true
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  terraform_environment_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: unfor19/install-aws-cli-action@v1
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.6
+          terraform_wrapper: false
+      - name: Configure AWS Credentials For Terraform
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: eu-west-1
+          role-duration-seconds: 3600
+          role-session-name: OPGModernisingLPATerraformGithubAction
+      - uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.ssh_deploy_key }}
+
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ./terraform/environment
+
+      - name: Terraform Toggle Public Access for ${{ inputs.workspace_name }}
+        env:
+          TF_WORKSPACE: ${{ inputs.workspace_name }}
+        run: |
+          terraform apply -lock-timeout=300s  -input=false -auto-approve -var public_access_enabled=${{ inputs.public_access_enabled }} -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress[0]'
+        working-directory: ./terraform/environment

--- a/.github/workflows/toggle_public_access_job.yml
+++ b/.github/workflows/toggle_public_access_job.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
       public_access_enabled:
-        description: 'Enable public access to the UR environment?'
+        description: 'Enable public access to the environment?'
         required: true
         type: boolean
     secrets:

--- a/.github/workflows/toggle_public_access_job.yml
+++ b/.github/workflows/toggle_public_access_job.yml
@@ -22,7 +22,7 @@ on:
 
 
 jobs:
-  terraform_environment_workflow:
+  toggle_public_access:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workflow_manage_public_access_ur_environment.yml
+++ b/.github/workflows/workflow_manage_public_access_ur_environment.yml
@@ -37,4 +37,3 @@ jobs:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
         ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_manage_public_access_ur_environment.yml
+++ b/.github/workflows/workflow_manage_public_access_ur_environment.yml
@@ -1,4 +1,4 @@
-name: "Deploy to UR Environment"
+name: "Toggle public access to UR environment"
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 jobs:
-  ur_deploy:
+  ur_toggle_public_access:
       name: UR Environment Deploy
       needs: [ui_tests_image]
       uses: ./.github/workflows/toggle_public_access_job.yml

--- a/.github/workflows/workflow_manage_public_access_ur_environment.yml
+++ b/.github/workflows/workflow_manage_public_access_ur_environment.yml
@@ -1,0 +1,40 @@
+name: "Deploy to UR Environment"
+
+on:
+  workflow_dispatch:
+    inputs:
+      public_access_enabled:
+        description: 'Enable public access to the UR environment?'
+        required: true
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
+  pull-requests: write
+  actions: none
+  checks: none
+  deployments: none
+  issues: write
+  packages: none
+  repository-projects: none
+  statuses: none
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ur_deploy:
+      name: UR Environment Deploy
+      needs: [ui_tests_image]
+      uses: ./.github/workflows/toggle_public_access_job.yml
+      with:
+        workspace_name: 411mlpab799
+        public_access_enabled: ${{ inputs.public_access_enabled}}
+      secrets:
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+        ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -66,7 +66,6 @@ jobs:
     with:
       workspace_name: preproduction
       version_tag: ${{ needs.create_tags.outputs.version_tag }}
-      public_access_enabled: false
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -66,6 +66,7 @@ jobs:
     with:
       workspace_name: preproduction
       version_tag: ${{ needs.create_tags.outputs.version_tag }}
+      public_access_enabled: false
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
@@ -123,6 +124,7 @@ jobs:
     with:
       workspace_name: production
       version_tag: ${{ needs.create_tags.outputs.version_tag }}
+      public_access_enabled: false
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -117,7 +117,6 @@ jobs:
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
         version_tag: ${{ needs.create_tags.outputs.version_tag }}
-        public_access_enabled: false
       secrets:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -117,6 +117,7 @@ jobs:
       with:
         workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
         version_tag: ${{ needs.create_tags.outputs.version_tag }}
+        public_access_enabled: false
       secrets:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -22,7 +22,7 @@ module "eu_west_1" {
   alb_deletion_protection_enabled                       = local.environment.application_load_balancer.deletion_protection_enabled
   lpas_table                                            = aws_dynamodb_table.lpas_table
   app_env_vars                                          = local.environment.app.env
-  public_access_enabled                                 = local.environment.app.public_access_enabled
+  public_access_enabled                                 = var.public_access_enabled
   rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn
   rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1.id
   providers = {
@@ -46,7 +46,7 @@ module "eu_west_2" {
   alb_deletion_protection_enabled                       = local.environment.application_load_balancer.deletion_protection_enabled
   lpas_table                                            = aws_dynamodb_table.lpas_table
   app_env_vars                                          = local.environment.app.env
-  public_access_enabled                                 = local.environment.app.public_access_enabled
+  public_access_enabled                                 = var.public_access_enabled
   rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn # would be updated to eu_west_2 when that region exists
   rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_2.id
   providers = {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -8,7 +8,6 @@
         "eu-west-1"
       ],
       "app": {
-        "public_access_enabled": false,
         "env": {
           "app_public_url": "",
           "auth_redirect_base_url": "https://opg-lpa-fd-prototype.apps.live.cloud-platform.service.justice.gov.uk",
@@ -45,7 +44,6 @@
         "eu-west-1"
       ],
       "app": {
-        "public_access_enabled": false,
         "env": {
           "app_public_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
@@ -82,7 +80,6 @@
         "eu-west-1"
       ],
       "app": {
-        "public_access_enabled": false,
         "env": {
           "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
@@ -119,7 +116,6 @@
         "eu-west-1"
       ],
       "app": {
-        "public_access_enabled": false,
         "env": {
           "app_public_url": "https://app.modernising.opg.service.justice.gov.uk",
           "auth_redirect_base_url": "https://app.modernising.opg.service.justice.gov.uk",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -7,6 +7,11 @@ variable "container_version" {
   default = "latest"
 }
 
+variable "public_access_enabled" {
+  type    = bool
+  default = false
+}
+
 output "container_version" {
   value = var.container_version
 }
@@ -19,14 +24,13 @@ variable "environments" {
       is_production = bool
       regions       = list(string)
       app = object({
-        public_access_enabled = bool
         env = object({
-          app_public_url                        = string
-          auth_redirect_base_url                = string
-          notify_is_production                  = string
-          yoti_client_sdk_id                    = string
-          yoti_scenario_id                      = string
-          yoti_sandbox                          = string
+          app_public_url         = string
+          auth_redirect_base_url = string
+          notify_is_production   = string
+          yoti_client_sdk_id     = string
+          yoti_scenario_id       = string
+          yoti_sandbox           = string
         })
       })
       backups = object({

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -16,6 +16,10 @@ output "container_version" {
   value = var.container_version
 }
 
+output "public_access_enabled" {
+  value = var.public_access_enabled
+}
+
 variable "environments" {
   type = map(
     object({


### PR DESCRIPTION
# Purpose

Make it easy for team members to toggle UR availability using github actions

Fixes MLPAB-799

## Approach

- split public access variable into separate var
- create a job to toggle public access from github actions
- manage public access for production env specifically

## Notes

- Configuring this to target a single environment that isn't ur for now while I test

## Checklist

* [] I have performed a self-review of my own code