### PR TITLE
MLPAB-819 - auto merge minor and patch updates, and wait 3 stability days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,25 @@
     "config:base",
     "schedule:earlyMondays"
   ],
+  "branchPrefix": "renovate-",
+  "commitMessageAction": "Renovate Update",
+  "labels": [
+    "Dependencies",
+    "Renovate"
+  ],
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "separateMultipleMajor": true,
+  "lockFileMaintenance": { "enabled": false },
   "packageRules": [
     {
+      "automerge": true,
+      "groupName": "Patch & Minor Updates",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": [
+        "Dependencies",
+        "Renovate"
+      ],
       "matchPackagePatterns": [
         "*"
       ],
@@ -13,10 +30,21 @@
         "minor",
         "patch"
       ],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
     }
   ],
+  "major": {
+    "automerge": false,
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "prCreation": "not-pending",
+    "stabilityDays": 3,
+    "prPriority": 0
+  },
   "vulnerabilityAlerts": {
     "enabled": false
   }


### PR DESCRIPTION
# Purpose

Automate minor and patch updates and wait a few days for updates to be seen as stable

Fixes MLPAB-819

## Approach

- create package rules for minor and patch updates

## Checklist

* [x] I have performed a self-review of my own code