### PR TITLE
MLPAB-827 Determine the attorney/replacement task states on change

### DIFF
--- a/app/internal/actor/attorney_decisions.go
+++ b/app/internal/actor/attorney_decisions.go
@@ -35,3 +35,10 @@ func MakeAttorneyDecisions(existing AttorneyDecisions, how, details string) Atto
 func (d AttorneyDecisions) RequiresHappiness(attorneyCount int) bool {
 	return attorneyCount > 1 && (d.How == Jointly || d.How == JointlyForSomeSeverallyForOthers)
 }
+
+func (d AttorneyDecisions) IsComplete(attorneyCount int) bool {
+	return d.How != "" &&
+		(!d.RequiresHappiness(attorneyCount) ||
+			d.HappyIfOneCannotActNoneCan == "yes" ||
+			d.HappyIfOneCannotActNoneCan == "no" && d.HappyIfRemainingCanContinueToAct != "")
+}

--- a/app/internal/actor/attorney_decisions_test.go
+++ b/app/internal/actor/attorney_decisions_test.go
@@ -82,3 +82,58 @@ func TestAttorneyDecisionsRequiresHappiness(t *testing.T) {
 		})
 	}
 }
+
+func TestAttorneyDecisionsIsComplete(t *testing.T) {
+	testcases := map[string]struct {
+		attorneyCount int
+		decisions     AttorneyDecisions
+		expected      bool
+	}{
+		"jointly attorneys, happy": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: Jointly, HappyIfOneCannotActNoneCan: "yes"},
+			expected:      true,
+		},
+		"jointly for some severally for others attorney, happy": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: JointlyForSomeSeverallyForOthers, HappyIfOneCannotActNoneCan: "yes"},
+			expected:      true,
+		},
+		"jointly attorneys, unhappy": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: Jointly, HappyIfOneCannotActNoneCan: "no", HappyIfRemainingCanContinueToAct: "no"},
+			expected:      true,
+		},
+		"jointly attorneys, mixed happy": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: Jointly, HappyIfOneCannotActNoneCan: "no", HappyIfRemainingCanContinueToAct: "yes"},
+			expected:      true,
+		},
+		"jointly attorneys, unhappy missing": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: Jointly, HappyIfOneCannotActNoneCan: "no"},
+			expected:      false,
+		},
+		"jointly and severally attorney": {
+			attorneyCount: 2,
+			decisions:     AttorneyDecisions{How: JointlyAndSeverally},
+			expected:      true,
+		},
+		"single attorney": {
+			attorneyCount: 1,
+			decisions:     AttorneyDecisions{How: Jointly},
+			expected:      true,
+		},
+		"missing how": {
+			attorneyCount: 1,
+			decisions:     AttorneyDecisions{},
+			expected:      false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.decisions.IsComplete(tc.attorneyCount))
+		})
+	}
+}

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
@@ -33,18 +33,18 @@ func AreYouHappyIfOneAttorneyCantActNoneCan(tmpl template.Template, lpaStore Lpa
 
 			if data.Errors.None() {
 				lpa.AttorneyDecisions.HappyIfOneCannotActNoneCan = form.Happy
-
-				redirect := page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct
-				if form.Happy == "yes" {
-					redirect = page.Paths.DoYouWantReplacementAttorneys
-					lpa.Tasks.ChooseAttorneys = page.TaskCompleted
-				}
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, redirect)
+				if form.Happy == "yes" {
+					return appData.Redirect(w, r, lpa, page.Paths.DoYouWantReplacementAttorneys)
+				} else {
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct)
+				}
 			}
 		}
 

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
@@ -77,26 +77,12 @@ func TestGetAreYouHappyIfOneAttorneyCantActNoneCanWhenTemplateErrors(t *testing.
 }
 
 func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
-	testcases := map[string]struct {
-		lpa      *page.Lpa
-		redirect string
-	}{
-		"yes": {
-			lpa: &page.Lpa{
-				AttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: "yes"},
-				Tasks:             page.Tasks{ChooseAttorneys: page.TaskCompleted},
-			},
-			redirect: page.Paths.DoYouWantReplacementAttorneys,
-		},
-		"no": {
-			lpa: &page.Lpa{
-				AttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: "no"},
-			},
-			redirect: page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct,
-		},
+	testcases := map[string]string{
+		"yes": page.Paths.DoYouWantReplacementAttorneys,
+		"no":  page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct,
 	}
 
-	for happy, tc := range testcases {
+	for happy, redirect := range testcases {
 		t.Run(happy, func(t *testing.T) {
 			form := url.Values{
 				"happy": {happy},
@@ -111,7 +97,9 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 				On("Get", r.Context()).
 				Return(&page.Lpa{}, nil)
 			lpaStore.
-				On("Put", r.Context(), tc.lpa).
+				On("Put", r.Context(), &page.Lpa{
+					AttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: happy},
+				}).
 				Return(nil)
 
 			err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, lpaStore)(testAppData, w, r)
@@ -119,7 +107,7 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+tc.redirect, resp.Header.Get("Location"))
+			assert.Equal(t, "/lpa/lpa-id"+redirect, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
@@ -33,6 +33,7 @@ func AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpl template.Template, l
 
 			if data.Errors.None() {
 				lpa.ReplacementAttorneyDecisions.HappyIfOneCannotActNoneCan = form.Happy
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
@@ -33,7 +33,8 @@ func AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpl template.Template, lpa
 
 			if data.Errors.None() {
 				lpa.AttorneyDecisions.HappyIfRemainingCanContinueToAct = form.Happy
-				lpa.Tasks.ChooseAttorneys = page.TaskCompleted
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
@@ -94,7 +94,6 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToAct(t *testing.T) {
 			lpaStore.
 				On("Put", r.Context(), &page.Lpa{
 					AttorneyDecisions: actor.AttorneyDecisions{HappyIfRemainingCanContinueToAct: happy},
-					Tasks:             page.Tasks{ChooseAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 

--- a/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
@@ -33,6 +33,7 @@ func AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpl template.Te
 
 			if data.Errors.None() {
 				lpa.ReplacementAttorneyDecisions.HappyIfRemainingCanContinueToAct = form.Happy
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/choose_attorneys.go
+++ b/app/internal/page/donor/choose_attorneys.go
@@ -85,9 +85,8 @@ func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, randomString fun
 					lpa.Attorneys.Put(attorney)
 				}
 
-				if !attorneyFound {
-					lpa.Tasks.ChooseAttorneys = page.TaskInProgress
-				}
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/choose_attorneys_address.go
+++ b/app/internal/page/donor/choose_attorneys_address.go
@@ -59,7 +59,8 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 			if data.Form.Action == "skip" {
 				attorney.Address = place.Address{}
 				lpa.Attorneys.Put(attorney)
-				lpa.Tasks.ChooseAttorneys = page.TaskCompleted
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
@@ -71,7 +72,8 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 			if data.Form.Action == "manual" && data.Errors.None() {
 				attorney.Address = *data.Form.Address
 				lpa.Attorneys.Put(attorney)
-				lpa.Tasks.ChooseAttorneys = page.TaskCompleted
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
@@ -86,6 +88,8 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 
 				attorney.Address = *data.Form.Address
 				lpa.Attorneys.Put(attorney)
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/choose_attorneys_address_test.go
+++ b/app/internal/page/donor/choose_attorneys_address_test.go
@@ -200,12 +200,14 @@ func TestPostChooseAttorneysAddressSkip(t *testing.T) {
 			lpaStore.
 				On("Get", r.Context()).
 				Return(&page.Lpa{Attorneys: actor.Attorneys{{
-					ID:      "123",
-					Address: place.Address{Line1: "abc"},
+					ID:         "123",
+					FirstNames: "a",
+					Email:      "a",
+					Address:    place.Address{Line1: "abc"},
 				}}}, nil)
 			lpaStore.
 				On("Put", r.Context(), &page.Lpa{
-					Attorneys: actor.Attorneys{{ID: "123"}},
+					Attorneys: actor.Attorneys{{ID: "123", FirstNames: "a", Email: "a"}},
 					Tasks:     page.Tasks{ChooseAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
@@ -268,16 +270,17 @@ func TestPostChooseAttorneysAddressManual(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{Attorneys: actor.Attorneys{{
-			ID:      "123",
-			Address: place.Address{},
+			ID:         "123",
+			FirstNames: "a",
+			Address:    place.Address{},
 		}}}, nil)
-
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
 			Tasks: page.Tasks{ChooseAttorneys: page.TaskCompleted},
 			Attorneys: actor.Attorneys{{
-				ID:      "123",
-				Address: testAddress,
+				ID:         "123",
+				FirstNames: "a",
+				Address:    testAddress,
 			}},
 		}).
 		Return(nil)
@@ -434,11 +437,6 @@ func TestPostChooseAttorneysAddressSelect(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	lpaStore := newMockLpaStore(t)
-	lpaStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorney}}, nil)
-
 	updatedAttorney := actor.Attorney{
 		ID: "123",
 		Address: place.Address{
@@ -450,8 +448,15 @@ func TestPostChooseAttorneysAddressSelect(t *testing.T) {
 		},
 	}
 
+	lpaStore := newMockLpaStore(t)
 	lpaStore.
-		On("Put", r.Context(), &page.Lpa{Attorneys: actor.Attorneys{updatedAttorney}}).
+		On("Get", r.Context()).
+		Return(&page.Lpa{Attorneys: actor.Attorneys{attorney}}, nil)
+	lpaStore.
+		On("Put", r.Context(), &page.Lpa{
+			Attorneys: actor.Attorneys{updatedAttorney},
+			Tasks:     page.Tasks{ChooseAttorneys: page.TaskInProgress},
+		}).
 		Return(nil)
 
 	template := newMockTemplate(t)
@@ -464,16 +469,10 @@ func TestPostChooseAttorneysAddressSelect(t *testing.T) {
 				LookupPostcode: "NG1",
 				Address:        &testAddress,
 			},
-			Lpa: &page.Lpa{Attorneys: actor.Attorneys{{
-				ID: "123",
-				Address: place.Address{
-					Line1:      "a",
-					Line2:      "b",
-					Line3:      "c",
-					TownOrCity: "d",
-					Postcode:   "e",
-				}},
-			}},
+			Lpa: &page.Lpa{
+				Attorneys: actor.Attorneys{updatedAttorney},
+				Tasks:     page.Tasks{ChooseAttorneys: page.TaskInProgress},
+			},
 		}).
 		Return(nil)
 

--- a/app/internal/page/donor/choose_attorneys_test.go
+++ b/app/internal/page/donor/choose_attorneys_test.go
@@ -191,7 +191,7 @@ func TestPostChooseAttorneysAttorneyDoesNotExist(t *testing.T) {
 						LastName:   "Doe",
 					},
 					Attorneys: actor.Attorneys{tc.attorney},
-					Tasks:     page.Tasks{ChooseAttorneys: page.TaskInProgress},
+					Tasks:     page.Tasks{ChooseAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 
@@ -293,6 +293,7 @@ func TestPostChooseAttorneysAttorneyExists(t *testing.T) {
 				On("Put", r.Context(), &page.Lpa{
 					Donor:     actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					Attorneys: actor.Attorneys{tc.attorney},
+					Tasks:     page.Tasks{ChooseAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 
@@ -360,6 +361,7 @@ func TestPostChooseAttorneysFromAnotherPage(t *testing.T) {
 							Address:     place.Address{Line1: "abc"},
 						},
 					},
+					Tasks: page.Tasks{ChooseAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 

--- a/app/internal/page/donor/choose_replacement_attorneys.go
+++ b/app/internal/page/donor/choose_replacement_attorneys.go
@@ -82,9 +82,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, rando
 					lpa.ReplacementAttorneys.Put(attorney)
 				}
 
-				if !attorneyFound {
-					lpa.Tasks.ChooseReplacementAttorneys = page.TaskInProgress
-				}
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/choose_replacement_attorneys_address.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address.go
@@ -55,7 +55,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 			if data.Form.Action == "skip" {
 				attorney.Address = place.Address{}
 				lpa.ReplacementAttorneys.Put(attorney)
-				lpa.Tasks.ChooseReplacementAttorneys = page.TaskCompleted
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
@@ -67,7 +67,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 			if data.Form.Action == "manual" && data.Errors.None() {
 				attorney.Address = *data.Form.Address
 				lpa.ReplacementAttorneys.Put(attorney)
-				lpa.Tasks.ChooseReplacementAttorneys = page.TaskCompleted
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
@@ -82,6 +82,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 
 				attorney.Address = *data.Form.Address
 				lpa.ReplacementAttorneys.Put(attorney)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/choose_replacement_attorneys_address_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address_test.go
@@ -197,13 +197,15 @@ func TestPostChooseReplacementAttorneysAddressSkip(t *testing.T) {
 				On("Get", r.Context()).
 				Return(&page.Lpa{
 					ReplacementAttorneys: actor.Attorneys{{
-						ID:      "123",
-						Address: place.Address{Line1: "abc"},
+						ID:         "123",
+						FirstNames: "a",
+						Email:      "a",
+						Address:    place.Address{Line1: "abc"},
 					}},
 				}, nil)
 			lpaStore.
 				On("Put", r.Context(), &page.Lpa{
-					ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+					ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a", Email: "a"}},
 					Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
@@ -236,14 +238,15 @@ func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
 	lpaStore.
 		On("Get", r.Context()).
 		Return(&page.Lpa{
-			ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+			ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a"}},
 		}, nil)
 
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
 			ReplacementAttorneys: actor.Attorneys{{
-				ID:      "123",
-				Address: testAddress,
+				ID:         "123",
+				FirstNames: "a",
+				Address:    testAddress,
 			}},
 			Tasks: page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 		}).
@@ -396,11 +399,6 @@ func TestPostChooseReplacementAttorneysAddressSelect(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	lpaStore := newMockLpaStore(t)
-	lpaStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
-
 	updatedRa := actor.Attorney{
 		ID: "123",
 		Address: place.Address{
@@ -412,8 +410,15 @@ func TestPostChooseReplacementAttorneysAddressSelect(t *testing.T) {
 		},
 	}
 
+	lpaStore := newMockLpaStore(t)
 	lpaStore.
-		On("Put", r.Context(), &page.Lpa{ReplacementAttorneys: actor.Attorneys{updatedRa}}).
+		On("Get", r.Context()).
+		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
+	lpaStore.
+		On("Put", r.Context(), &page.Lpa{
+			ReplacementAttorneys: actor.Attorneys{updatedRa},
+			Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskInProgress},
+		}).
 		Return(nil)
 
 	template := newMockTemplate(t)
@@ -426,7 +431,10 @@ func TestPostChooseReplacementAttorneysAddressSelect(t *testing.T) {
 				LookupPostcode: "NG1",
 				Address:        &testAddress,
 			},
-			Lpa: &page.Lpa{ReplacementAttorneys: actor.Attorneys{updatedRa}},
+			Lpa: &page.Lpa{
+				ReplacementAttorneys: actor.Attorneys{updatedRa},
+				Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskInProgress},
+			},
 		}).
 		Return(nil)
 

--- a/app/internal/page/donor/choose_replacement_attorneys_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_test.go
@@ -183,7 +183,7 @@ func TestPostChooseReplacementAttorneysAttorneyDoesNotExists(t *testing.T) {
 				On("Put", r.Context(), &page.Lpa{
 					Donor:                actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					ReplacementAttorneys: actor.Attorneys{tc.attorney},
-					Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskInProgress},
+					Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 
@@ -285,6 +285,7 @@ func TestPostChooseReplacementAttorneysAttorneyExists(t *testing.T) {
 				On("Put", r.Context(), &page.Lpa{
 					Donor:                actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					ReplacementAttorneys: actor.Attorneys{tc.attorney},
+					Tasks:                page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 
@@ -352,6 +353,7 @@ func TestPostChooseReplacementAttorneysFromAnotherPage(t *testing.T) {
 							Address:     place.Address{Line1: "abc"},
 						},
 					},
+					Tasks: page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 				}).
 				Return(nil)
 

--- a/app/internal/page/donor/how_should_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_attorneys_make_decisions.go
@@ -41,18 +41,18 @@ func HowShouldAttorneysMakeDecisions(tmpl template.Template, lpaStore LpaStore) 
 					lpa.AttorneyDecisions,
 					data.Form.DecisionsType,
 					data.Form.DecisionsDetails)
-
-				redirect := page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan
-				if !lpa.AttorneyDecisions.RequiresHappiness(len(lpa.Attorneys)) {
-					lpa.Tasks.ChooseAttorneys = page.TaskCompleted
-					redirect = page.Paths.DoYouWantReplacementAttorneys
-				}
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, redirect)
+				if lpa.AttorneyDecisions.RequiresHappiness(len(lpa.Attorneys)) {
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan)
+				} else {
+					return appData.Redirect(w, r, lpa, page.Paths.DoYouWantReplacementAttorneys)
+				}
 			}
 		}
 

--- a/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
@@ -39,6 +39,7 @@ func HowShouldReplacementAttorneysMakeDecisions(tmpl template.Template, lpaStore
 					lpa.ReplacementAttorneyDecisions,
 					data.Form.DecisionsType,
 					data.Form.DecisionsDetails)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/donor/how_should_replacement_attorneys_make_decisions_test.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_make_decisions_test.go
@@ -149,7 +149,7 @@ func TestPostHowShouldReplacementAttorneysMakeDecisionsFromStore(t *testing.T) {
 				"mixed-details": {"some details"},
 			},
 			existing:  actor.AttorneyDecisions{How: actor.JointlyAndSeverally},
-			attorneys: actor.Attorneys{{}},
+			attorneys: actor.Attorneys{{FirstNames: "a", Email: "a"}},
 			updated:   actor.AttorneyDecisions{How: actor.JointlyForSomeSeverallyForOthers, Details: "some details"},
 			redirect:  page.Paths.TaskList,
 		},
@@ -159,7 +159,7 @@ func TestPostHowShouldReplacementAttorneysMakeDecisionsFromStore(t *testing.T) {
 				"mixed-details": {"some details"},
 			},
 			existing:  actor.AttorneyDecisions{How: actor.JointlyForSomeSeverallyForOthers, Details: "some details"},
-			attorneys: actor.Attorneys{{}},
+			attorneys: actor.Attorneys{{FirstNames: "a", Email: "a"}},
 			updated:   actor.AttorneyDecisions{How: actor.Jointly},
 			redirect:  page.Paths.TaskList,
 		},
@@ -169,7 +169,7 @@ func TestPostHowShouldReplacementAttorneysMakeDecisionsFromStore(t *testing.T) {
 				"mixed-details": {"some details"},
 			},
 			existing:  actor.AttorneyDecisions{How: actor.JointlyForSomeSeverallyForOthers, Details: "some details"},
-			attorneys: actor.Attorneys{{}, {}},
+			attorneys: actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}},
 			updated:   actor.AttorneyDecisions{How: actor.Jointly},
 			redirect:  page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan,
 		},
@@ -184,9 +184,16 @@ func TestPostHowShouldReplacementAttorneysMakeDecisionsFromStore(t *testing.T) {
 			lpaStore := newMockLpaStore(t)
 			lpaStore.
 				On("Get", r.Context()).
-				Return(&page.Lpa{ReplacementAttorneys: tc.attorneys, ReplacementAttorneyDecisions: tc.existing}, nil)
+				Return(&page.Lpa{
+					ReplacementAttorneys:         tc.attorneys,
+					ReplacementAttorneyDecisions: tc.existing,
+				}, nil)
 			lpaStore.
-				On("Put", r.Context(), &page.Lpa{ReplacementAttorneys: tc.attorneys, ReplacementAttorneyDecisions: tc.updated}).
+				On("Put", r.Context(), &page.Lpa{
+					ReplacementAttorneys:         tc.attorneys,
+					ReplacementAttorneyDecisions: tc.updated,
+					Tasks:                        page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
+				}).
 				Return(nil)
 
 			template := newMockTemplate(t)

--- a/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
@@ -43,6 +43,8 @@ func HowShouldReplacementAttorneysStepIn(tmpl template.Template, lpaStore LpaSto
 					lpa.HowShouldReplacementAttorneysStepInDetails = data.Form.OtherDetails
 				}
 
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
+
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err
 				}

--- a/app/internal/page/donor/how_should_replacement_attorneys_step_in_test.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_step_in_test.go
@@ -126,6 +126,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 		HowReplacementAttorneysMakeDecisions string
 		HowShouldReplacementAttorneysStepIn  string
 		ExpectedRedirectUrl                  string
+		TaskState                            page.TaskState
 	}{
 		"multiple attorneys acting jointly and severally replacements step in when none left": {
 			Attorneys: actor.Attorneys{
@@ -139,15 +140,18 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			HowAttorneysMakeDecisions:           actor.JointlyAndSeverally,
 			HowShouldReplacementAttorneysStepIn: page.AllCanNoLongerAct,
 			ExpectedRedirectUrl:                 "/lpa/lpa-id" + page.Paths.HowShouldReplacementAttorneysMakeDecisions,
+			TaskState:                           page.TaskInProgress,
 		},
 		"multiple attorneys acting jointly": {
 			ReplacementAttorneys: actor.Attorneys{
 				{ID: "123"},
 				{ID: "123"},
 			},
-			HowReplacementAttorneysMakeDecisions: actor.Jointly,
+			HowAttorneysMakeDecisions:            actor.Jointly,
 			HowShouldReplacementAttorneysStepIn:  page.OneCanNoLongerAct,
+			HowReplacementAttorneysMakeDecisions: actor.Jointly,
 			ExpectedRedirectUrl:                  "/lpa/lpa-id" + page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan,
+			TaskState:                            page.TaskInProgress,
 		},
 		"multiple attorneys acting jointly and severally replacements step in when one loses capacity": {
 			Attorneys: actor.Attorneys{
@@ -157,6 +161,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			HowAttorneysMakeDecisions:           actor.JointlyAndSeverally,
 			HowShouldReplacementAttorneysStepIn: page.OneCanNoLongerAct,
 			ExpectedRedirectUrl:                 "/lpa/lpa-id" + page.Paths.TaskList,
+			TaskState:                           page.TaskNotStarted,
 		},
 		"multiple attorneys acting jointly and severally": {
 			Attorneys: actor.Attorneys{
@@ -170,6 +175,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 			HowAttorneysMakeDecisions:           actor.JointlyAndSeverally,
 			HowShouldReplacementAttorneysStepIn: page.OneCanNoLongerAct,
 			ExpectedRedirectUrl:                 "/lpa/lpa-id" + page.Paths.TaskList,
+			TaskState:                           page.TaskInProgress,
 		},
 	}
 
@@ -199,6 +205,7 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 					ReplacementAttorneys:                tc.ReplacementAttorneys,
 					ReplacementAttorneyDecisions:        actor.AttorneyDecisions{How: tc.HowReplacementAttorneysMakeDecisions},
 					HowShouldReplacementAttorneysStepIn: tc.HowShouldReplacementAttorneysStepIn,
+					Tasks:                               page.Tasks{ChooseReplacementAttorneys: tc.TaskState},
 				}).
 				Return(nil)
 

--- a/app/internal/page/donor/remove_attorney.go
+++ b/app/internal/page/donor/remove_attorney.go
@@ -44,13 +44,10 @@ func RemoveAttorney(logger Logger, tmpl template.Template, lpaStore LpaStore) pa
 
 			if data.Form.RemoveAttorney == "yes" && data.Errors.None() {
 				lpa.Attorneys.Delete(attorney)
-				if len(lpa.Attorneys) == 0 {
-					lpa.Tasks.ChooseAttorneys = page.TaskInProgress
-				}
+				lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
-				err = lpaStore.Put(r.Context(), lpa)
-
-				if err != nil {
+				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					logger.Print(fmt.Sprintf("error removing Attorney from LPA: %s", err.Error()))
 					return err
 				}

--- a/app/internal/page/donor/remove_attorney_test.go
+++ b/app/internal/page/donor/remove_attorney_test.go
@@ -133,7 +133,10 @@ func TestPostRemoveAttorney(t *testing.T) {
 		On("Get", r.Context()).
 		Return(&page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}}, nil)
 	lpaStore.
-		On("Put", r.Context(), &page.Lpa{Attorneys: actor.Attorneys{attorneyWithAddress}}).
+		On("Put", r.Context(), &page.Lpa{
+			Attorneys: actor.Attorneys{attorneyWithAddress},
+			Tasks:     page.Tasks{ChooseAttorneys: page.TaskInProgress},
+		}).
 		Return(nil)
 
 	err := RemoveAttorney(logger, template.Execute, lpaStore)(testAppData, w, r)
@@ -216,7 +219,7 @@ func TestPostRemoveAttorneyErrorOnPutStore(t *testing.T) {
 		On("Get", r.Context()).
 		Return(&page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}}, nil)
 	lpaStore.
-		On("Put", r.Context(), &page.Lpa{Attorneys: actor.Attorneys{attorneyWithAddress}}).
+		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
 	err := RemoveAttorney(logger, template.Execute, lpaStore)(testAppData, w, r)
@@ -277,9 +280,15 @@ func TestRemoveAttorneyRemoveLastAttorneyRedirectsToChooseAttorney(t *testing.T)
 	lpaStore := newMockLpaStore(t)
 	lpaStore.
 		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{{ID: "without-address"}}, Tasks: page.Tasks{ChooseAttorneys: page.TaskCompleted}}, nil)
+		Return(&page.Lpa{
+			Attorneys: actor.Attorneys{{ID: "without-address"}},
+			Tasks:     page.Tasks{ChooseAttorneys: page.TaskCompleted},
+		}, nil)
 	lpaStore.
-		On("Put", r.Context(), &page.Lpa{Attorneys: actor.Attorneys{}, Tasks: page.Tasks{ChooseAttorneys: page.TaskInProgress}}).
+		On("Put", r.Context(), &page.Lpa{
+			Attorneys: actor.Attorneys{},
+			Tasks:     page.Tasks{ChooseAttorneys: page.TaskNotStarted},
+		}).
 		Return(nil)
 
 	err := RemoveAttorney(logger, template.Execute, lpaStore)(testAppData, w, r)

--- a/app/internal/page/donor/remove_replacement_attorney.go
+++ b/app/internal/page/donor/remove_replacement_attorney.go
@@ -44,13 +44,9 @@ func RemoveReplacementAttorney(logger Logger, tmpl template.Template, lpaStore L
 
 			if data.Form.RemoveAttorney == "yes" && data.Errors.None() {
 				lpa.ReplacementAttorneys.Delete(attorney)
-				if len(lpa.ReplacementAttorneys) == 0 {
-					lpa.Tasks.ChooseReplacementAttorneys = page.TaskInProgress
-				}
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
-				err = lpaStore.Put(r.Context(), lpa)
-
-				if err != nil {
+				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					logger.Print(fmt.Sprintf("error removing replacement Attorney from LPA: %s", err.Error()))
 					return err
 				}

--- a/app/internal/page/donor/use_existing_address.go
+++ b/app/internal/page/donor/use_existing_address.go
@@ -65,8 +65,11 @@ func UseExistingAddress(tmpl template.Template, lpaStore LpaStore) page.Handler 
 
 				if attorneyType == "attorney" {
 					lpa.Attorneys.Put(subject)
+					lpa.Tasks.ChooseAttorneys = page.ChooseAttorneysState(lpa.Attorneys, lpa.AttorneyDecisions)
+					lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 				} else {
 					lpa.ReplacementAttorneys.Put(subject)
+					lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 					redirect = appData.Paths.ChooseReplacementAttorneysSummary
 				}
 

--- a/app/internal/page/donor/use_existing_address_test.go
+++ b/app/internal/page/donor/use_existing_address_test.go
@@ -176,26 +176,36 @@ func TestPostUseExistingAddress(t *testing.T) {
 		ExpectedUrl string
 	}{
 		"subject is attorney": {
-			Lpa: &page.Lpa{Attorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
-			}},
-			UpdatedLpa: &page.Lpa{Attorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
-			}},
+			Lpa: &page.Lpa{
+				Attorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
+				},
+			},
+			UpdatedLpa: &page.Lpa{
+				Attorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
+				},
+				Tasks: page.Tasks{ChooseAttorneys: page.TaskInProgress},
+			},
 			Type:        "attorney",
 			ExpectedUrl: "/lpa/lpa-id" + testAppData.Paths.ChooseAttorneysSummary,
 		},
 		"subject is replacement attorney": {
-			Lpa: &page.Lpa{ReplacementAttorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
-			}},
-			UpdatedLpa: &page.Lpa{ReplacementAttorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
-			}},
+			Lpa: &page.Lpa{
+				ReplacementAttorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
+				},
+			},
+			UpdatedLpa: &page.Lpa{
+				ReplacementAttorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
+				},
+				Tasks: page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
+			},
 			Type:        "replacementAttorney",
 			ExpectedUrl: "/lpa/lpa-id" + testAppData.Paths.ChooseReplacementAttorneysSummary,
 		},
@@ -255,7 +265,6 @@ func TestPostUseExistingAddressWithMultipleAddresses(t *testing.T) {
 			},
 			CertificateProvider: actor.CertificateProvider{FirstNames: "Jorge", LastName: "Smith", Address: newAddress},
 		}, nil)
-
 	lpaStore.
 		On("Put", r.Context(), &page.Lpa{
 			Attorneys: []actor.Attorney{
@@ -267,6 +276,7 @@ func TestPostUseExistingAddressWithMultipleAddresses(t *testing.T) {
 				{ID: "2", FirstNames: "JoJo", LastName: "Smith", Address: newAddress},
 			},
 			CertificateProvider: actor.CertificateProvider{FirstNames: "Jorge", LastName: "Smith", Address: newAddress},
+			Tasks:               page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
 		}).
 		Return(nil)
 
@@ -288,26 +298,36 @@ func TestPostUseExistingAddressStoreError(t *testing.T) {
 		ExpectedUrl string
 	}{
 		"subject is attorney": {
-			Lpa: &page.Lpa{Attorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
-			}},
-			UpdatedLpa: &page.Lpa{Attorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
-			}},
+			Lpa: &page.Lpa{
+				Attorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
+				},
+			},
+			UpdatedLpa: &page.Lpa{
+				Attorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
+				},
+				Tasks: page.Tasks{ChooseAttorneys: page.TaskInProgress},
+			},
 			Type:        "attorney",
 			ExpectedUrl: "/lpa/lpa-id" + testAppData.Paths.ChooseAttorneysSummary,
 		},
 		"subject is replacement attorney": {
-			Lpa: &page.Lpa{ReplacementAttorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
-			}},
-			UpdatedLpa: &page.Lpa{ReplacementAttorneys: []actor.Attorney{
-				{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
-				{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
-			}},
+			Lpa: &page.Lpa{
+				ReplacementAttorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: testAddress},
+				},
+			},
+			UpdatedLpa: &page.Lpa{
+				ReplacementAttorneys: []actor.Attorney{
+					{ID: "1", FirstNames: "Joe", LastName: "Smith", Address: newAddress},
+					{ID: "2", FirstNames: "Joan", LastName: "Smith", Address: newAddress},
+				},
+				Tasks: page.Tasks{ChooseReplacementAttorneys: page.TaskCompleted},
+			},
 			Type:        "replacementAttorney",
 			ExpectedUrl: "/lpa/lpa-id" + testAppData.Paths.ChooseReplacementAttorneysSummary,
 		},

--- a/app/internal/page/donor/want_replacement_attorneys.go
+++ b/app/internal/page/donor/want_replacement_attorneys.go
@@ -39,16 +39,16 @@ func WantReplacementAttorneys(tmpl template.Template, lpaStore LpaStore) page.Ha
 
 				if form.Want == "no" {
 					lpa.ReplacementAttorneys = actor.Attorneys{}
-					lpa.Tasks.ChooseReplacementAttorneys = page.TaskCompleted
 					if lpa.Type == page.LpaTypeHealthWelfare {
 						redirectUrl = page.Paths.LifeSustainingTreatment
 					} else {
 						redirectUrl = page.Paths.WhenCanTheLpaBeUsed
 					}
 				} else {
-					lpa.Tasks.ChooseReplacementAttorneys = page.TaskInProgress
 					redirectUrl = appData.Paths.ChooseReplacementAttorneys
 				}
+
+				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
 
 				if err := lpaStore.Put(r.Context(), lpa); err != nil {
 					return err

--- a/app/internal/page/testing_start.go
+++ b/app/internal/page/testing_start.go
@@ -70,6 +70,10 @@ func TestingStart(store sesh.Store, lpaStore LpaStore, randomString func(int) st
 			CompleteHowAttorneysAct(lpa, r.FormValue("howAttorneysAct"))
 		}
 
+		if r.FormValue("withReplacementAttorney") != "" {
+			AddReplacementAttorneys(lpa, 1)
+		}
+
 		if r.FormValue("withReplacementAttorneys") != "" || r.FormValue("completeLpa") != "" {
 			AddReplacementAttorneys(lpa, 2)
 		}

--- a/cypress/e2e/donor/choose-attorneys-task.cy.js
+++ b/cypress/e2e/donor/choose-attorneys-task.cy.js
@@ -1,0 +1,165 @@
+import {TestEmail} from "../../support/e2e";
+
+describe('Choose attorneys task', () => {
+    it('is not started when no attorneys are set', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('Not started');
+    });
+
+    it('is in progress if I start adding an attorney', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('In progress (1)');
+    });
+
+    it('is completed if enter an attorneys details', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('Completed (1)');
+    });
+
+    it('is completed if enter an attorneys details using address', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('In progress (1)');
+        cy.go('back');
+        
+        cy.get('#f-lookup-postcode').type('B14 7ED');
+        cy.contains('button', 'Find address').click();
+        cy.get('#f-select-address').select('2 RICHMOND PLACE, BIRMINGHAM, B14 7ED');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('Completed (1)');
+    });
+
+    it('is in progress if I enter multiple attorneys details', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorney=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('In progress (2)');
+    });
+    
+    it('is completed if I enter multiple attorneys details with how they act', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorney=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Skip').click();
+
+        cy.contains('label', 'No').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('input[value=jointly-and-severally]').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('Completed (2)');
+    });
+    
+    it('is in progress if I enter multiple attorneys details when jointly but not answer happy questions', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorney=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Skip').click();
+
+        cy.contains('label', 'No').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('input[value=jointly]').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('In progress (2)');
+    });
+    
+    it('is completed if I enter multiple attorneys details when jointly and answered happy questions', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorney=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Skip').click();
+
+        cy.contains('label', 'No').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('input[value=jointly]').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your attorneys').parent().parent().contains('Completed (2)');
+    });
+});

--- a/cypress/e2e/donor/choose-replacement-attorneys-task.cy.js
+++ b/cypress/e2e/donor/choose-replacement-attorneys-task.cy.js
@@ -1,0 +1,367 @@
+import {TestEmail} from "../../support/e2e";
+
+describe('Choose replacement attorneys task', () => {
+    it('is not started when no replacement attorneys are set', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+
+        cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Not started');
+    });
+
+    it('is completed if I do not want replacement attorneys', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+        cy.contains('label', 'No').click();
+        cy.contains('button', 'Continue').click();
+        
+        cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed');
+    });
+
+    it('is in progress if I do want replacement attorneys', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress');
+    });
+
+    it('is completed if enter a replacement attorneys details', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (1)');
+    });
+
+    it('is in progress if enter a replacement attorneys details then add attorneys', () => {
+        cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorney=1&cookiesAccepted=1');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('#f-first-names').type('John');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+
+        cy.contains('a', 'Choose your attorneys').click();
+
+        cy.contains('label', 'Yes').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('#f-first-names').type('Janet');
+        cy.get('#f-last-name').type('Doe');
+        cy.get('#f-email').type(TestEmail);
+        cy.get('#f-date-of-birth').type('1');
+        cy.get('#f-date-of-birth-month').type('2');
+        cy.get('#f-date-of-birth-year').type('1990');
+        cy.contains('button', 'Continue').click();
+        cy.contains('button', 'Skip').click();
+
+        cy.contains('label', 'No').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.get('input[value=jointly-and-severally]').click();
+        cy.contains('button', 'Continue').click();
+
+        cy.visitLpa('/task-list');
+        cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (1)');
+    });
+
+    describe('having jointly and severally attorneys', () => {
+        beforeEach(() => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=jointly-and-severally&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+        });
+
+        it('is completed if enter a replacement attorneys details step in as soon as one', () => {
+            cy.contains('label', 'As soon as one').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (1)');
+        });
+
+        it('is completed if enter a replacement attorneys details step in when none', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (1)');
+        });
+    });
+
+    describe('having jointly attorneys', () => {
+        it('is completed if enter a replacement attorneys details step in as soon as one', () => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=jointly&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+                        
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (1)');
+        });
+    });
+
+    describe('having jointly for some attorneys', () => {
+        it('is completed if enter a replacement attorneys details step in as soon as one', () => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=mixed&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+                        
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (1)');
+        });
+    });
+    
+    describe('having jointly and severally attorneys and multiple replacement attorneys', () => {
+        beforeEach(() => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=jointly-and-severally&withReplacementAttorney=1&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+        });
+
+        it('is completed if step in as soon as one', () => {            
+            cy.contains('label', 'As soon as one').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+
+        it('is in progress if step in when none', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (2)');
+        });
+
+        it('is completed if step in when none and jointly and severally', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly-and-severally]').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+
+        it('is in progress if step in when none and jointly', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly]').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (2)');
+        });
+
+        it('is complete if step in when none and jointly and happy', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly]').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+    });
+
+    describe('having jointly attorneys and multiple replacement attorneys', () => {
+        beforeEach(() => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=jointly-and-severally&withReplacementAttorney=1&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+        });
+
+        it('is completed if enter a replacement attorneys details step in as soon as one', () => {
+            cy.contains('label', 'As soon as one').click();
+            cy.contains('button', 'Continue').click();
+                        
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+
+        it('is in progress if enter a replacement attorneys details step in when none', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (2)');
+        });
+
+        it('is completed if enter a replacement attorneys details step in when none and jointly and severally', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly-and-severally]').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+
+        it('is in progress if enter a replacement attorneys details step in when none and jointly', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly]').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (2)');
+        });
+
+        it('is completed if enter a replacement attorneys details step in when none and jointly and happy', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=jointly]').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+
+        it('is in progress if enter a replacement attorneys details step in when none and jointly for some', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=mixed]').click();
+            cy.get('textarea').type('Some details');
+            cy.contains('button', 'Continue').click();
+            
+            cy.visitLpa('/task-list');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('In progress (2)');
+        });
+
+        it('is completed if enter a replacement attorneys details step in when none and jointly for some and happy', () => {
+            cy.contains('label', 'When none').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('input[value=mixed]').click();
+            cy.get('textarea').type('Some details');
+            cy.contains('button', 'Continue').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+            
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+    });
+    
+    describe('having jointly for some attorneys and multiple replacement attorneys', () => {
+        it('is completed if enter a replacement attorneys details step in as soon as one', () => {
+            cy.visit('/testing-start?redirect=/task-list&donorDetails=1&withAttorneys=1&howAttorneysAct=mixed&withReplacementAttorney=1&cookiesAccepted=1');
+            cy.contains('a', 'Choose your replacement attorneys (optional)').click();
+
+            cy.contains('label', 'Yes').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.get('#f-first-names').type('John');
+            cy.get('#f-last-name').type('Doe');
+            cy.get('#f-email').type(TestEmail);
+            cy.get('#f-date-of-birth').type('1');
+            cy.get('#f-date-of-birth-month').type('2');
+            cy.get('#f-date-of-birth-year').type('1990');
+            cy.contains('button', 'Continue').click();
+            cy.contains('button', 'Skip').click();
+
+            cy.contains('label', 'No').click();
+            cy.contains('button', 'Continue').click();
+
+            cy.contains('a', 'Choose your replacement attorneys (optional)').parent().parent().contains('Completed (2)');
+        });
+    });
+});

--- a/web/template/how_should_replacement_attorneys_make_decisions.gohtml
+++ b/web/template/how_should_replacement_attorneys_make_decisions.gohtml
@@ -55,7 +55,7 @@
 
                 <div class="govuk-radios__conditional" id="decision-type-3-conditional-div">
                   <div class="govuk-form-group {{ if .Errors.Has "mixed-details" }}govuk-form-group--error{{ end }}">
-                    <p class="govuk-body">{{ tr .App "decisionDetailsHint" }}</p>
+                    <p class="govuk-body">{{ trHtml .App "decisionDetailsHint" }}</p>
                     <label class="govuk-label" for="f-mixed-details">
                       {{ tr .App "details" }}
                     </label>


### PR DESCRIPTION
What makes this annoying is that you can change the state of "Choose replacement attorneys" by making changes to the attorneys. 

~I'm 50% on deleting the Cypress tests, so let me know whether you'd rather keep them or not.~ Probably worth keeping until we do MLPAB-790 and fix the page ordering.