### PR TITLE
MLPAB0-838 - differentiate images built for the UR environment

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -65,7 +65,7 @@ jobs:
           ECR_REPOSITORY: modernising-lpa/app
         run: |
           docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.tag }}
-          if ${{ github.ref == 'refs/heads/main' }}; then
+          if ${{ github.workflow == 'Path To Live' }}; then
             docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
             docker tag app:latest $ECR_REGISTRY/$ECR_REPOSITORY:main-${{ inputs.tag }}
           fi

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -28,6 +28,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.checkout_tag }}
+      - name: Check name of workflow
+        id: check_workflow_name
+        run: |
+          echo ${{ github.workflow }}
       - name: Build Image
         id: build_image
         run: |

--- a/.github/workflows/workflow_deploy_to_ur_environment.yml
+++ b/.github/workflows/workflow_deploy_to_ur_environment.yml
@@ -30,7 +30,7 @@ jobs:
     name: Docker Build, Scan and Push
     uses: ./.github/workflows/docker_job.yml
     with:
-      tag: ${{ inputs.tag_to_deploy }}
+      tag: ur-${{ inputs.tag_to_deploy }}
       checkout_tag : ${{ inputs.tag_to_deploy }}
 
   ui_tests_image:


### PR DESCRIPTION
# Purpose

Allow UR images to have their own retention policy so they are kept for longer than the images created for production.

UR is required to remain fixed to a version longer than production.

Fixes MLPAB-838

## Approach

- pass in a `ur-` prefix for the image tag during the UR deployment workflow
- Update the docker job to only tag `latest` and `main-` when called from the path to live workflow

## Learning

- https://docs.github.com/en/actions/learn-github-actions/contexts

## Checklist

* [ ] I have performed a self-review of my own code