### PR TITLE
Detect changes when PR is first opened against main

### DIFF
--- a/.github/workflows/detect_changes_to_app_job.yml
+++ b/.github/workflows/detect_changes_to_app_job.yml
@@ -3,59 +3,45 @@ on:
     outputs:
       changes_detected:
         description: "Boolean value for changes detected in /app, /web and /lang"
-        value: ${{ jobs.compare_to_main.outputs.changes_detected }}
-      branch_changes_detected:
-        description: "Boolean value for changes detected in /app, /web and /lang since last push"
-        value: ${{ jobs.compare_to_last_push.outputs.branch_changes_detected }}
+        value: ${{ jobs.compare_changes.outputs.changes_detected }}
 
 jobs:
-  compare_to_main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Fetch all history for all tags and branches
-      - name: Detect changes in /app, /web and /lang compared to main using git diff
-        id: detect_changes
-        if: github.ref != 'refs/heads/main'
-        run: |
-          git diff --quiet HEAD origin/main -- app lang web Dockerfile package.json yarn.lock && \
-          echo "changes=${{ false }}" || \
-          echo "changes=${{ true }}"
-
-          git diff --quiet HEAD origin/main -- app lang web Dockerfile package.json yarn.lock && \
-          echo "changes=${{ false }}" >> $GITHUB_OUTPUT || \
-          echo "changes=${{ true }}" >> $GITHUB_OUTPUT
-    outputs:
-      changes_detected: ${{ steps.detect_changes.outputs.changes }}
-
-  compare_to_last_push:
+  compare_changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.ref }}
           fetch-depth: 0 # Fetch all history for all tags and branches
-      - name: Detect changes in /app, /web and /lang compared to last push using git diff
-        id: detect_branch_changes
+      - name: Detect changes in /app, /web and /lang using git diff
+        id: detect_changes
         if: github.ref != 'refs/heads/main'
         run: |
-          git diff --quiet ${{github.event.before}} ${{github.event.after}} -- app lang web Dockerfile package.json yarn.lock && \
-          echo "branch_changes=${{ false }}" || \
-          echo "branch_changes=${{ true }}"
+          if [[ "${{github.event.action}}" != "opened" ]]; then
+            echo "Checking against last push"
+            git diff --quiet ${{github.event.before}} ${{github.event.after}} -- app lang web Dockerfile package.json yarn.lock && \
+            echo "changes=${{ false }}" || \
+            echo "changes=${{ true }}"
 
-          git diff --quiet ${{github.event.before}} ${{github.event.after}} -- app lang web Dockerfile package.json yarn.lock && \
-          echo "branch_changes=${{ false }}" >> $GITHUB_OUTPUT || \
-          echo "branch_changes=${{ true }}" >> $GITHUB_OUTPUT
+            git diff --quiet ${{github.event.before}} ${{github.event.after}} -- app lang web Dockerfile package.json yarn.lock && \
+            echo "changes=${{ false }}" >> $GITHUB_OUTPUT || \
+            echo "changes=${{ true }}" >> $GITHUB_OUTPUT
+          else
+            echo "No last push, checking against origin/main"
+            git diff --quiet HEAD origin/main -- app lang web Dockerfile package.json yarn.lock && \
+            echo "changes=${{ false }}" || \
+            echo "changes=${{ true }}"
+
+            git diff --quiet HEAD origin/main -- app lang web Dockerfile package.json yarn.lock && \
+            echo "changes=${{ false }}" >> $GITHUB_OUTPUT || \
+            echo "changes=${{ true }}" >> $GITHUB_OUTPUT
+          fi
     outputs:
-      branch_changes_detected: ${{ steps.detect_branch_changes.outputs.branch_changes }}
+      changes_detected: ${{ steps.detect_changes.outputs.changes }}
 
   notify_previous_build_will_be_deployed:
-    needs: [
-      compare_to_main,
-      compare_to_last_push,
-    ]
-    if: needs.compare_to_main.outputs.changes_detected == 'false' || needs.compare_to_last_push.outputs.branch_changes_detected == 'false'
+    needs: compare_changes
+    if: needs.compare_changes.outputs.changes_detected == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Previous build on this branch will be deployed

--- a/.github/workflows/tags_job.yml
+++ b/.github/workflows/tags_job.yml
@@ -5,10 +5,6 @@ on:
         description: 'Boolean value for changes detected in /app from main'
         required: true
         type: string
-      branch_changes_detected:
-        description: 'Boolean value for changes detected in /app from previous push'
-        required: true
-        type: string
     outputs:
       version_tag:
         description: "Docker Image Tag"
@@ -19,7 +15,7 @@ on:
 
 jobs:
   create_tags:
-    if : ${{ inputs.branch_changes_detected == 'true' }}
+    if : ${{ inputs.changes_detected == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -28,7 +28,6 @@ jobs:
     uses: ./.github/workflows/tags_job.yml
     with:
       changes_detected: 'true'
-      branch_changes_detected: 'true'
 
   go_unit_tests:
     name: Run Go unit tests

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -33,17 +33,16 @@ jobs:
     uses: ./.github/workflows/tags_job.yml
     with:
       changes_detected: ${{ needs.detect_changes.outputs.changes_detected }}
-      branch_changes_detected: ${{ needs.detect_changes.outputs.branch_changes_detected }}
 
   go_unit_tests:
     name: Run Go unit tests
-    if: needs.detect_changes.outputs.branch_changes_detected == 'true'
+    if: needs.detect_changes.outputs.changes_detected == 'true'
     needs: create_tags
     uses: ./.github/workflows/go-unit-tests.yml
 
   docker_build_scan_push:
     name: Docker Build, Scan and Push
-    if: needs.detect_changes.outputs.branch_changes_detected == 'true' &&
+    if: needs.detect_changes.outputs.changes_detected == 'true' &&
       (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped')
     uses: ./.github/workflows/docker_job.yml
     needs: [
@@ -84,7 +83,7 @@ jobs:
 
   ui_tests_image:
     name: Run Cypress UI Tests On Images
-    if: needs.detect_changes.outputs.branch_changes_detected == 'true' &&
+    if: needs.detect_changes.outputs.changes_detected == 'true' &&
       (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped')
     uses: ./.github/workflows/ui_test_job.yml
     needs: [docker_build_scan_push, create_tags]


### PR DESCRIPTION
On https://github.com/ministryofjustice/opg-modernising-lpa/pull/429 I spotted that it wasn't actually doing the build/test/etc. on the first commit. I think this fixes that by checking against `origin/main` if the PR is opened, otherwise doing the last push. But I'm not entirely sure why they were separated out, so maybe this breaks something else?