### PR TITLE
MLPAB-890: Rename dynamodb table back to lpas

### DIFF
--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -9,7 +9,7 @@ data "aws_kms_alias" "dynamodb_encryption_key_eu_west_2" {
 }
 
 resource "aws_dynamodb_table" "lpas_table" {
-  name         = "${local.environment_name}-Lpas2"
+  name         = "${local.environment_name}-Lpas"
   billing_mode = "PAY_PER_REQUEST"
   # see docs/runbooks/disabling_dynamodb_global_tables.md when Global Tables needs to be disabled
   stream_enabled   = local.environment.dynamodb.stream_enabled
@@ -54,7 +54,7 @@ resource "aws_dynamodb_table" "lpas_table" {
   }
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 
   provider = aws.eu_west_1


### PR DESCRIPTION
# Purpose

So we can rebuild the table following changes in #447 and because the table name has a 2 in it 🙄 

Fixes MLPAB-890