### PR TITLE
MLPAB-912 - Fixes to second region deployment

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.66.1"
-  constraints = "4.66.1"
+  constraints = ">= 2.7.0, 4.66.1"
   hashes = [
     "h1:0yBLFi5YZ3P0dJHGrrHMmsnbjuZsjRHECP2x/8L9q7Y=",
     "h1:7GytS2hRFKZDR1GgcS/nNQlyAjaMelF09HJ5xFFWneM=",
@@ -19,5 +19,20 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:i5PN+Xs0DXLe6a512XELJcYvFN4oYOkg+WMT39AzgRw=",
     "h1:kl2Tj+8F62SDeN2h7L8nEZkxQHJBUZICuaZhQJbUKNc=",
     "h1:oi2xfTwb5ZgjA1OluE4KThAQF4+1kN0yNbUu5053rsA=",
+    "zh:001c707174b7d6bf89a96cf806f925bb852d1a285fb80b81222cbeb4743bcb79",
+    "zh:19bc6ac0a7fd1c564fd56c536f1743f71a5e7ca724e21ea51a6a79218939733d",
+    "zh:3dac5c27f40b511239e9fe6f97dc0b6c95f630ba328001820ddc764e766a5ca2",
+    "zh:49092c92e2565db4cd4c98ec6878386e6957525d3392b63f0d5df4c48a7c1913",
+    "zh:4f9e2e1d0c5365a4e6689096cc91ba88ca9c0dc7c633377ba674c1dd856b6a9f",
+    "zh:57e32bb454f2dc17d5631a9559e36188761d8ae95a452478f81f41bb568a3a42",
+    "zh:678b78ba629dd833f0705ac90630969f514a54013ab9713ce7ceda55fc5ea138",
+    "zh:8aab1d76348cf2a685f72382cb838a910b77353179e81ab5794b9c45c8fb36a3",
+    "zh:8b6791bf0948aa8b49258863992a8ad7e7332dcae1a889e86da0e5ab778dc3b6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a36f2777452c2cebdaa8a27378416d512ead367acc078a671bb12276dd4bc9dd",
+    "zh:c492e6f685882fad6481f4793e696d9e1b01aaae419225c2db0a484b632d1cac",
+    "zh:d4418e0d1d18e321db364a91d7a768e274bb0fb46df9f3cb5b9debb2bb6917b9",
+    "zh:d5b4310ef2b2ec22ae14cf909deb1231b56bdd79dc2b51e5db4e46a05e0110c4",
+    "zh:dedfb01e26b34fb61a52b7e953b8bf5d7a69971187e91697b67221298bbed377",
   ]
 }

--- a/terraform/account/cloudwatch_kms.tf
+++ b/terraform/account/cloudwatch_kms.tf
@@ -11,6 +11,7 @@ resource "aws_kms_replica_key" "cloudwatch_replica" {
   description             = "${local.default_tags.application} Cloudwatch application logs Multi-Region replica key"
   deletion_window_in_days = 7
   primary_key_arn         = aws_kms_key.cloudwatch.arn
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.cloudwatch_kms_merged.json : data.aws_iam_policy_document.cloudwatch_kms.json
   provider                = aws.eu_west_2
 }
 

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -3,12 +3,6 @@ resource "aws_s3_bucket" "access_log" {
   bucket   = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-lb-access-logs-${data.aws_region.current.name}"
 }
 
-resource "aws_s3_bucket_acl" "access_log" {
-  provider = aws.region
-  bucket   = aws_s3_bucket.access_log.id
-  acl      = "private"
-}
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
   provider = aws.region
   bucket   = aws_s3_bucket.access_log.id
@@ -79,7 +73,7 @@ data "aws_iam_policy_document" "access_log" {
     resources = [
       aws_s3_bucket.access_log.arn,
       "${aws_s3_bucket.access_log.arn}/*",
-      "${aws_s3_bucket.access_log.arn}/*/AWSLogs/your-aws-account-id/*",
+      "${aws_s3_bucket.access_log.arn}/*/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
     effect  = "Allow"
     actions = ["s3:PutObject"]


### PR DESCRIPTION
# Purpose

Deploy the second region resources

Fixes MLPAB-912

## Approach

- Do not create an S3 ACL as they are no longer enabled/allowed for bucket by default (the default permissions are the same as the "private" ACL. This is suitable for the use case.
- ensure that replicated KMS keys also have the correct policies attached

## Learning

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

## Checklist

* [x] I have performed a self-review of my own code