### PR TITLE
MLPAB-898: Use UUID strings for LPA, Attorney, RA and PTN

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,7 +267,7 @@
         "filename": "app/internal/random/random.go",
         "hashed_secret": "16d55134df951a56cee0d642becebe7089c48c4b",
         "is_verified": false,
-        "line_number": 10,
+        "line_number": 12,
         "is_secret": false
       }
     ],
@@ -325,5 +325,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-25T14:44:51Z"
+  "generated_at": "2023-05-10T15:32:26Z"
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ make app-up-build-dev-arm
 
 Dev mode adds hot reloading via [air](https://github.com/cosmtrek/air) which will watch `.go` and `.gohtml` for changes and recompile the app.
 
-It also enables debugging via [delve](https://github.com/go-delve/delve). Delve runs on `localhost:2345` - add this to your editor/IDE debug config settings and then start adding breakpoints to step through the app code when running on localhost. Example VSCode config:
+It also enables debugging via [delve](https://github.com/go-delve/delve). Delve runs on `localhost:2345` - add this to your editor/IDE debug config settings and then start adding breakpoints to step through the app code when running on localhost. Example VSCode debug config:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ make run-cypress
 
 ### Local development
 
-To run the app in dev mode on arm64/apple silicon:
+To run the app in dev mode on amd64/intel:
 
 ```shell
 make app-up-build-dev
 ```
 
-or the following for amd64/intel:
+or the following for arm64/apple silicon:
 
 ```shell
-make app-up-build-dev-amd
+make app-up-build-dev-arm
 ```
 
 Dev mode adds hot reloading via [air](https://github.com/cosmtrek/air) which will watch `.go` and `.gohtml` for changes and recompile the app.

--- a/app/go.mod
+++ b/app/go.mod
@@ -34,6 +34,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.20.9 // indirect
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/app/go.sum
+++ b/app/go.sum
@@ -276,6 +276,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=

--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -3,10 +3,10 @@ package app
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-go-common/logging"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
@@ -50,7 +50,7 @@ func App(
 	paths page.AppPaths,
 	oneLoginClient *onelogin.Client,
 ) http.Handler {
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: rand.Intn, now: time.Now}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: uuid.NewString, now: time.Now}
 	certificateProviderStore := &certificateProviderStore{dataStore: dataStore, now: time.Now}
 
 	shareCodeSender := page.NewShareCodeSender(dataStore, notifyClient, appPublicUrl, random.String)

--- a/app/internal/app/lpa_store.go
+++ b/app/internal/app/lpa_store.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"errors"
-	"strconv"
 	"time"
 
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
@@ -11,14 +10,14 @@ import (
 )
 
 type lpaStore struct {
-	dataStore DataStore
-	randomInt func(int) int
-	now       func() time.Time
+	dataStore  DataStore
+	uuidString func() string
+	now        func() time.Time
 }
 
 func (s *lpaStore) Create(ctx context.Context) (*page.Lpa, error) {
 	lpa := &page.Lpa{
-		ID:        "10" + strconv.Itoa(s.randomInt(100000)),
+		ID:        s.uuidString(),
 		UpdatedAt: s.now(),
 	}
 

--- a/app/internal/app/lpa_store_test.go
+++ b/app/internal/app/lpa_store_test.go
@@ -42,7 +42,7 @@ func TestLpaStoreGetAll(t *testing.T) {
 	dataStore := newMockDataStore(t)
 	dataStore.ExpectGetAll(ctx, "ActorIndex", "#DONOR#an-id", lpas, nil)
 
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: func() string { return "10100000" }}
 
 	result, err := lpaStore.GetAll(ctx)
 	assert.Nil(t, err)
@@ -52,7 +52,7 @@ func TestLpaStoreGetAll(t *testing.T) {
 func TestLpaStoreGetAllWithSessionMissing(t *testing.T) {
 	ctx := context.Background()
 
-	lpaStore := &lpaStore{dataStore: nil, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: nil, uuidString: func() string { return "10100000" }}
 
 	_, err := lpaStore.GetAll(ctx)
 	assert.Equal(t, page.SessionMissingError{}, err)
@@ -64,7 +64,7 @@ func TestLpaStoreGet(t *testing.T) {
 	dataStore := newMockDataStore(t)
 	dataStore.ExpectGet(ctx, "LPA#an-id", "#DONOR#", &page.Lpa{ID: "an-id"}, nil)
 
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: func() string { return "10100000" }}
 
 	lpa, err := lpaStore.Get(ctx)
 	assert.Nil(t, err)
@@ -74,7 +74,7 @@ func TestLpaStoreGet(t *testing.T) {
 func TestLpaStoreGetWithSessionMissing(t *testing.T) {
 	ctx := context.Background()
 
-	lpaStore := &lpaStore{dataStore: nil, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: nil, uuidString: func() string { return "10100000" }}
 
 	_, err := lpaStore.Get(ctx)
 	assert.Equal(t, page.SessionMissingError{}, err)
@@ -86,7 +86,7 @@ func TestLpaStoreGetWhenDataStoreError(t *testing.T) {
 	dataStore := newMockDataStore(t)
 	dataStore.ExpectGet(ctx, "LPA#an-id", "#DONOR#", &page.Lpa{ID: "an-id"}, expectedError)
 
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: func() string { return "10100000" }}
 
 	_, err := lpaStore.Get(ctx)
 	assert.Equal(t, expectedError, err)
@@ -108,7 +108,7 @@ func TestLpaStorePut(t *testing.T) {
 func TestLpaStorePutWithSessionMissing(t *testing.T) {
 	ctx := context.Background()
 
-	lpaStore := &lpaStore{dataStore: nil, randomInt: func(x int) int { return x }}
+	lpaStore := &lpaStore{dataStore: nil, uuidString: func() string { return "10100000" }}
 
 	err := lpaStore.Put(ctx, &page.Lpa{})
 	assert.Equal(t, page.SessionMissingError{}, err)
@@ -135,7 +135,7 @@ func TestLpaStoreCreate(t *testing.T) {
 	dataStore := newMockDataStore(t)
 	dataStore.On("Create", ctx, "LPA#10100000", "#DONOR#an-id", &page.Lpa{ID: "10100000", UpdatedAt: now}).Return(nil)
 
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: func(x int) int { return x }, now: func() time.Time { return now }}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: func() string { return "10100000" }, now: func() time.Time { return now }}
 
 	lpa, err := lpaStore.Create(ctx)
 	assert.Nil(t, err)
@@ -145,7 +145,7 @@ func TestLpaStoreCreate(t *testing.T) {
 func TestLpaStoreCreateWithSessionMissing(t *testing.T) {
 	ctx := context.Background()
 
-	lpaStore := &lpaStore{dataStore: nil, randomInt: func(x int) int { return x }, now: func() time.Time { return time.Now() }}
+	lpaStore := &lpaStore{dataStore: nil, uuidString: func() string { return "10100000" }, now: func() time.Time { return time.Now() }}
 
 	_, err := lpaStore.Create(ctx)
 	assert.Equal(t, page.SessionMissingError{}, err)
@@ -159,7 +159,7 @@ func TestLpaStoreCreateWhenError(t *testing.T) {
 	dataStore := newMockDataStore(t)
 	dataStore.On("Create", ctx, "LPA#10100000", "#DONOR#an-id", &page.Lpa{ID: "10100000", UpdatedAt: now}).Return(expectedError)
 
-	lpaStore := &lpaStore{dataStore: dataStore, randomInt: func(x int) int { return x }, now: func() time.Time { return now }}
+	lpaStore := &lpaStore{dataStore: dataStore, uuidString: func() string { return "10100000" }, now: func() time.Time { return now }}
 
 	_, err := lpaStore.Create(ctx)
 	assert.Equal(t, expectedError, err)

--- a/app/internal/page/donor/choose_attorneys.go
+++ b/app/internal/page/donor/choose_attorneys.go
@@ -21,7 +21,7 @@ type chooseAttorneysData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, randomString func(int) string) page.Handler {
+func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, uuidString func() string) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
 		lpa, err := lpaStore.Get(r.Context())
 		if err != nil {
@@ -73,7 +73,7 @@ func ChooseAttorneys(tmpl template.Template, lpaStore LpaStore, randomString fun
 						LastName:    data.Form.LastName,
 						Email:       data.Form.Email,
 						DateOfBirth: data.Form.Dob,
-						ID:          randomString(8),
+						ID:          uuidString(),
 					}
 
 					lpa.Attorneys = append(lpa.Attorneys, attorney)

--- a/app/internal/page/donor/choose_attorneys_test.go
+++ b/app/internal/page/donor/choose_attorneys_test.go
@@ -36,7 +36,7 @@ func TestGetChooseAttorneys(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -52,7 +52,7 @@ func TestGetChooseAttorneysWhenStoreErrors(t *testing.T) {
 		On("Get", r.Context()).
 		Return(&page.Lpa{}, expectedError)
 
-	err := ChooseAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -74,7 +74,7 @@ func TestGetChooseAttorneysFromStore(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := ChooseAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -100,7 +100,7 @@ func TestGetChooseAttorneysWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := ChooseAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -195,7 +195,7 @@ func TestPostChooseAttorneysAttorneyDoesNotExist(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -297,7 +297,7 @@ func TestPostChooseAttorneysAttorneyExists(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -365,7 +365,7 @@ func TestPostChooseAttorneysFromAnotherPage(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -507,7 +507,7 @@ func TestPostChooseAttorneysWhenInputRequired(t *testing.T) {
 				})).
 				Return(nil)
 
-			err := ChooseAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -538,7 +538,7 @@ func TestPostChooseAttorneysWhenStoreErrors(t *testing.T) {
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := ChooseAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/choose_people_to_notify.go
+++ b/app/internal/page/donor/choose_people_to_notify.go
@@ -18,7 +18,7 @@ type choosePeopleToNotifyData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func ChoosePeopleToNotify(tmpl template.Template, lpaStore LpaStore, randomString func(int) string) page.Handler {
+func ChoosePeopleToNotify(tmpl template.Template, lpaStore LpaStore, uuidString func() string) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
 		lpa, err := lpaStore.Get(r.Context())
 		if err != nil {
@@ -66,7 +66,7 @@ func ChoosePeopleToNotify(tmpl template.Template, lpaStore LpaStore, randomStrin
 						FirstNames: data.Form.FirstNames,
 						LastName:   data.Form.LastName,
 						Email:      data.Form.Email,
-						ID:         randomString(8),
+						ID:         uuidString(),
 					}
 
 					lpa.PeopleToNotify = append(lpa.PeopleToNotify, personToNotify)

--- a/app/internal/page/donor/choose_people_to_notify_test.go
+++ b/app/internal/page/donor/choose_people_to_notify_test.go
@@ -32,7 +32,7 @@ func TestGetChoosePeopleToNotify(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -48,7 +48,7 @@ func TestGetChoosePeopleToNotifyWhenStoreErrors(t *testing.T) {
 		On("Get", r.Context()).
 		Return(&page.Lpa{}, expectedError)
 
-	err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -76,7 +76,7 @@ func TestGetChoosePeopleToNotifyFromStore(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -101,7 +101,7 @@ func TestGetChoosePeopleToNotifyWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -155,7 +155,7 @@ func TestGetChoosePeopleToNotifyPeopleLimitReached(t *testing.T) {
 					PeopleToNotify: tc.addedPeople,
 				}, nil)
 
-			err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -219,7 +219,7 @@ func TestPostChoosePeopleToNotifyPersonDoesNotExists(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -267,7 +267,7 @@ func TestPostChoosePeopleToNotifyPersonExists(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -333,7 +333,7 @@ func TestPostChoosePeopleToNotifyFromAnotherPage(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -414,7 +414,7 @@ func TestPostChoosePeopleToNotifyWhenInputRequired(t *testing.T) {
 				})).
 				Return(nil)
 
-			err := ChoosePeopleToNotify(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChoosePeopleToNotify(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -442,7 +442,7 @@ func TestPostChoosePeopleToNotifyWhenStoreErrors(t *testing.T) {
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := ChoosePeopleToNotify(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChoosePeopleToNotify(nil, lpaStore, mockUuidString)(testAppData, w, r)
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/choose_replacement_attorneys.go
+++ b/app/internal/page/donor/choose_replacement_attorneys.go
@@ -19,7 +19,7 @@ type chooseReplacementAttorneysData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, randomString func(int) string) page.Handler {
+func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, uuidString func() string) page.Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
 		lpa, err := lpaStore.Get(r.Context())
 		if err != nil {
@@ -70,7 +70,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, rando
 						LastName:    data.Form.LastName,
 						Email:       data.Form.Email,
 						DateOfBirth: data.Form.Dob,
-						ID:          randomString(8),
+						ID:          uuidString(),
 					}
 
 					lpa.ReplacementAttorneys = append(lpa.ReplacementAttorneys, attorney)

--- a/app/internal/page/donor/choose_replacement_attorneys_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_test.go
@@ -35,7 +35,7 @@ func TestGetChooseReplacementAttorneys(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -51,7 +51,7 @@ func TestGetChooseReplacementAttorneysWhenStoreErrors(t *testing.T) {
 		On("Get", r.Context()).
 		Return(&page.Lpa{}, expectedError)
 
-	err := ChooseReplacementAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseReplacementAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -73,7 +73,7 @@ func TestGetChooseReplacementAttorneysFromStore(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -98,7 +98,7 @@ func TestGetChooseReplacementAttorneysWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -187,7 +187,7 @@ func TestPostChooseReplacementAttorneysAttorneyDoesNotExists(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseReplacementAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseReplacementAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -289,7 +289,7 @@ func TestPostChooseReplacementAttorneysAttorneyExists(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseReplacementAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseReplacementAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -357,7 +357,7 @@ func TestPostChooseReplacementAttorneysFromAnotherPage(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := ChooseReplacementAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseReplacementAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -487,7 +487,7 @@ func TestPostChooseReplacementAttorneysWhenInputRequired(t *testing.T) {
 				})).
 				Return(nil)
 
-			err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockRandom)(testAppData, w, r)
+			err := ChooseReplacementAttorneys(template.Execute, lpaStore, mockUuidString)(testAppData, w, r)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -518,7 +518,7 @@ func TestPostChooseReplacementAttorneysWhenStoreErrors(t *testing.T) {
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := ChooseReplacementAttorneys(nil, lpaStore, mockRandom)(testAppData, w, r)
+	err := ChooseReplacementAttorneys(nil, lpaStore, mockUuidString)(testAppData, w, r)
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/mock_test.go
+++ b/app/internal/page/donor/mock_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var mockRandom = func(int) string { return "123" }
+var mockUuidString = func() string { return "123" }
 
 var (
 	testAddress = place.Address{

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -147,7 +147,7 @@ func Register(
 		TaskList(tmpls.Get("task_list.gohtml"), lpaStore))
 
 	handleLpa(page.Paths.ChooseAttorneys, CanGoBack,
-		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), lpaStore, random.String))
+		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), lpaStore, random.UuidString))
 	handleLpa(page.Paths.ChooseAttorneysAddress, CanGoBack,
 		ChooseAttorneysAddress(logger, tmpls.Get("choose_attorneys_address.gohtml"), addressClient, lpaStore))
 	handleLpa(page.Paths.UseExistingAddress, CanGoBack,
@@ -166,7 +166,7 @@ func Register(
 	handleLpa(page.Paths.DoYouWantReplacementAttorneys, CanGoBack,
 		WantReplacementAttorneys(tmpls.Get("do_you_want_replacement_attorneys.gohtml"), lpaStore))
 	handleLpa(page.Paths.ChooseReplacementAttorneys, CanGoBack,
-		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), lpaStore, random.String))
+		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), lpaStore, random.UuidString))
 	handleLpa(page.Paths.ChooseReplacementAttorneysAddress, CanGoBack,
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_replacement_attorneys_address.gohtml"), addressClient, lpaStore))
 	handleLpa(page.Paths.ChooseReplacementAttorneysSummary, CanGoBack,
@@ -204,7 +204,7 @@ func Register(
 	handleLpa(page.Paths.DoYouWantToNotifyPeople, CanGoBack,
 		DoYouWantToNotifyPeople(tmpls.Get("do_you_want_to_notify_people.gohtml"), lpaStore))
 	handleLpa(page.Paths.ChoosePeopleToNotify, CanGoBack,
-		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), lpaStore, random.String))
+		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), lpaStore, random.UuidString))
 	handleLpa(page.Paths.ChoosePeopleToNotifyAddress, CanGoBack,
 		ChoosePeopleToNotifyAddress(logger, tmpls.Get("choose_people_to_notify_address.gohtml"), addressClient, lpaStore))
 	handleLpa(page.Paths.ChoosePeopleToNotifySummary, CanGoBack,

--- a/app/internal/random/random.go
+++ b/app/internal/random/random.go
@@ -2,6 +2,8 @@ package random
 
 import (
 	"crypto/rand"
+
+	"github.com/google/uuid"
 )
 
 var UseTestCode = false
@@ -28,4 +30,8 @@ func fromCharset(length int, charset string) string {
 		bytes[i] = charset[b%byte(len(charset))]
 	}
 	return string(bytes)
+}
+
+func UuidString() string {
+	return uuid.NewString()
 }


### PR DESCRIPTION
# Purpose

We were getting flaky test failures during cypress runs. After some digging the common pattern was an error thrown when getting an entity from dynamodb where we expected a single result but got multiple. Local testing showed we were getting ID collisions on LPAs during multiple cypress test runs which explained why fresh environments (and a clear local dynamodb table) rarely had errors.

This change moves to using UUIDs for LPAs and the associated Attorneys, Replacement Attorneys and People To Notify in to protect against any collisions going forward.

There may be some other flaky tests that were outside of this problem but from running a few concurrent cypress runs locally I've not seen a repeat of the error occur.

Fixes MLPAB-898
