### PR TITLE
MLPAB-908: Ignore empty names when checking matching names

### DIFF
--- a/app/internal/page/donor/certificate_provider_details.go
+++ b/app/internal/page/donor/certificate_provider_details.go
@@ -115,6 +115,10 @@ func (d *certificateProviderDetailsForm) Validate() validation.List {
 }
 
 func certificateProviderMatches(lpa *page.Lpa, firstNames, lastName string) actor.Type {
+	if firstNames == "" && lastName == "" {
+		return actor.TypeNone
+	}
+
 	if strings.EqualFold(lpa.Donor.FirstNames, firstNames) && strings.EqualFold(lpa.Donor.LastName, lastName) {
 		return actor.TypeDonor
 	}

--- a/app/internal/page/donor/certificate_provider_details_test.go
+++ b/app/internal/page/donor/certificate_provider_details_test.go
@@ -530,3 +530,21 @@ func TestCertificateProviderMatches(t *testing.T) {
 	assert.Equal(t, actor.TypeNone, certificateProviderMatches(lpa, "m", "n"))
 	assert.Equal(t, actor.TypeNone, certificateProviderMatches(lpa, "o", "p"))
 }
+
+func TestCertificateProviderMatchesEmptyNamesIgnored(t *testing.T) {
+	lpa := &page.Lpa{
+		Donor: actor.Donor{FirstNames: "", LastName: ""},
+		Attorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		ReplacementAttorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		CertificateProviderDetails: page.CertificateProviderDetails{FirstNames: "", LastName: ""},
+		PeopleToNotify: actor.PeopleToNotify{
+			{FirstNames: "", LastName: ""},
+		},
+	}
+
+	assert.Equal(t, actor.TypeNone, certificateProviderMatches(lpa, "", ""))
+}

--- a/app/internal/page/donor/choose_attorneys.go
+++ b/app/internal/page/donor/choose_attorneys.go
@@ -173,6 +173,10 @@ func (d *chooseAttorneysForm) DobWarning() string {
 }
 
 func attorneyMatches(lpa *page.Lpa, id, firstNames, lastName string) actor.Type {
+	if firstNames == "" && lastName == "" {
+		return actor.TypeNone
+	}
+
 	if strings.EqualFold(lpa.Donor.FirstNames, firstNames) && strings.EqualFold(lpa.Donor.LastName, lastName) {
 		return actor.TypeDonor
 	}

--- a/app/internal/page/donor/choose_attorneys_test.go
+++ b/app/internal/page/donor/choose_attorneys_test.go
@@ -724,3 +724,22 @@ func TestAttorneyMatches(t *testing.T) {
 	assert.Equal(t, actor.TypePersonToNotify, attorneyMatches(lpa, "123", "M", "N"))
 	assert.Equal(t, actor.TypePersonToNotify, attorneyMatches(lpa, "123", "o", "p"))
 }
+
+func TestAttorneyMatchesEmptyNamesIgnored(t *testing.T) {
+	lpa := &page.Lpa{
+		Donor: actor.Donor{FirstNames: "", LastName: ""},
+		Attorneys: actor.Attorneys{
+			{ID: "123", FirstNames: "", LastName: ""},
+			{FirstNames: "", LastName: ""},
+		},
+		ReplacementAttorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		CertificateProviderDetails: page.CertificateProviderDetails{FirstNames: "", LastName: ""},
+		PeopleToNotify: actor.PeopleToNotify{
+			{FirstNames: "", LastName: ""},
+		},
+	}
+
+	assert.Equal(t, actor.TypeNone, attorneyMatches(lpa, "123", "", ""))
+}

--- a/app/internal/page/donor/choose_people_to_notify.go
+++ b/app/internal/page/donor/choose_people_to_notify.go
@@ -133,6 +133,10 @@ func (f *choosePeopleToNotifyForm) Validate() validation.List {
 }
 
 func personToNotifyMatches(lpa *page.Lpa, id, firstNames, lastName string) actor.Type {
+	if firstNames == "" && lastName == "" {
+		return actor.TypeNone
+	}
+
 	if strings.EqualFold(lpa.Donor.FirstNames, firstNames) && strings.EqualFold(lpa.Donor.LastName, lastName) {
 		return actor.TypeDonor
 	}

--- a/app/internal/page/donor/choose_people_to_notify_test.go
+++ b/app/internal/page/donor/choose_people_to_notify_test.go
@@ -547,3 +547,22 @@ func TestPersonToNotifyMatches(t *testing.T) {
 	assert.Equal(t, actor.TypePersonToNotify, personToNotifyMatches(lpa, "123", "m", "n"))
 	assert.Equal(t, actor.TypeNone, personToNotifyMatches(lpa, "123", "o", "p"))
 }
+
+func TestPersonToNotifyMatchesEmptyNamesIgnored(t *testing.T) {
+	lpa := &page.Lpa{
+		Donor: actor.Donor{FirstNames: "", LastName: ""},
+		Attorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		ReplacementAttorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		CertificateProviderDetails: page.CertificateProviderDetails{FirstNames: "", LastName: ""},
+		PeopleToNotify: actor.PeopleToNotify{
+			{FirstNames: "", LastName: ""},
+			{ID: "123", FirstNames: "", LastName: ""},
+		},
+	}
+
+	assert.Equal(t, actor.TypeNone, personToNotifyMatches(lpa, "123", "", ""))
+}

--- a/app/internal/page/donor/choose_replacement_attorneys.go
+++ b/app/internal/page/donor/choose_replacement_attorneys.go
@@ -104,6 +104,10 @@ func ChooseReplacementAttorneys(tmpl template.Template, lpaStore LpaStore, uuidS
 }
 
 func replacementAttorneyMatches(lpa *page.Lpa, id, firstNames, lastName string) actor.Type {
+	if firstNames == "" && lastName == "" {
+		return actor.TypeNone
+	}
+
 	if strings.EqualFold(lpa.Donor.FirstNames, firstNames) && strings.EqualFold(lpa.Donor.LastName, lastName) {
 		return actor.TypeDonor
 	}

--- a/app/internal/page/donor/choose_replacement_attorneys_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_test.go
@@ -551,3 +551,22 @@ func TestReplacementAttorneyMatches(t *testing.T) {
 	assert.Equal(t, actor.TypePersonToNotify, replacementAttorneyMatches(lpa, "123", "m", "n"))
 	assert.Equal(t, actor.TypePersonToNotify, replacementAttorneyMatches(lpa, "123", "O", "P"))
 }
+
+func TestReplacementAttorneyMatchesEmptyNamesIgnored(t *testing.T) {
+	lpa := &page.Lpa{
+		Donor: actor.Donor{FirstNames: "", LastName: ""},
+		Attorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+		},
+		ReplacementAttorneys: actor.Attorneys{
+			{FirstNames: "", LastName: ""},
+			{ID: "123", FirstNames: "", LastName: ""},
+		},
+		CertificateProviderDetails: page.CertificateProviderDetails{FirstNames: "", LastName: ""},
+		PeopleToNotify: actor.PeopleToNotify{
+			{FirstNames: "", LastName: ""},
+		},
+	}
+
+	assert.Equal(t, actor.TypeNone, replacementAttorneyMatches(lpa, "123", "", ""))
+}


### PR DESCRIPTION
# Purpose

Make sure we don't warn when comparing empty names against other actors.

Fixes MLPAB-908