### PR TITLE
MLPAB-1037 - upgrade allow list module to get new IPs

### DIFF
--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -4,7 +4,7 @@ data "aws_ecr_repository" "app" {
 }
 
 module "allow_list" {
-  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v1.7.1"
+  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v2.3.0"
 }
 
 module "eu_west_1" {


### PR DESCRIPTION
# Purpose

Allow users from new IP ranges to access non-production environments

Fixes MLPAB-1037

## Approach

- Upgrade the allow list module to pull in the new ranges