### PR TITLE
MLPAB-1035 - Use table replica resource instead of inline block

### DIFF
--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -29,16 +29,6 @@ resource "aws_dynamodb_table" "lpas_table" {
     kms_key_arn = data.aws_kms_alias.dynamodb_encryption_key_eu_west_1.target_key_arn
   }
 
-  dynamic "replica" {
-    for_each = local.environment.dynamodb.region_replica_enabled ? [1] : []
-    content {
-      region_name            = "eu-west-2"
-      kms_key_arn            = data.aws_kms_alias.dynamodb_encryption_key_eu_west_2.target_key_arn
-      point_in_time_recovery = true
-      propagate_tags         = true
-    }
-  }
-
   attribute {
     name = "PK"
     type = "S"
@@ -55,7 +45,7 @@ resource "aws_dynamodb_table" "lpas_table" {
 
   lifecycle {
     prevent_destroy = false
-    # ignore_changes = [replica]
+    ignore_changes  = [replica]
   }
   provider = aws.eu_west_1
 }

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -55,7 +55,15 @@ resource "aws_dynamodb_table" "lpas_table" {
 
   lifecycle {
     prevent_destroy = false
+    # ignore_changes = [replica]
   }
-
   provider = aws.eu_west_1
+}
+
+resource "aws_dynamodb_table_replica" "lpas_table" {
+  count                  = local.environment.dynamodb.region_replica_enabled ? 1 : 0
+  global_table_arn       = aws_dynamodb_table.lpas_table.arn
+  kms_key_arn            = data.aws_kms_alias.dynamodb_encryption_key_eu_west_2.target_key_arn
+  point_in_time_recovery = true
+  provider               = aws.eu_west_2
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -50,7 +50,7 @@ module "eu_west_2" {
   ingress_allow_list_cidr         = module.allow_list.moj_sites
   alb_deletion_protection_enabled = local.environment.application_load_balancer.deletion_protection_enabled
   lpas_table = {
-    arn  = [for o in aws_dynamodb_table.lpas_table.replica : o][0].arn,
+    arn  = local.environment.dynamodb.region_replica_enabled ? aws_dynamodb_table_replica.lpas_table[0].arn : aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
   }
   app_env_vars                                          = local.environment.app.env

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -28,7 +28,7 @@
       },
       "dynamodb": {
         "region_replica_enabled": false,
-        "stream_enabled": true
+        "stream_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -27,8 +27,8 @@
           "copy_action_enabled": false
       },
       "dynamodb": {
-        "region_replica_enabled": false,
-        "stream_enabled": false
+        "region_replica_enabled": true,
+        "stream_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -27,8 +27,8 @@
           "copy_action_enabled": false
       },
       "dynamodb": {
-        "region_replica_enabled": true,
-        "stream_enabled": true
+        "region_replica_enabled": false,
+        "stream_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -28,7 +28,7 @@
       },
       "dynamodb": {
         "region_replica_enabled": false,
-        "stream_enabled": false
+        "stream_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true


### PR DESCRIPTION
# Purpose

Use the V2 method for creating a global table replica in a second region

Fixes MLPAB-1035

## Approach

- Add table replica block
- remove inline block
- ignore table replicas in the dynamodb table resource

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_replica

## Checklist

* [x] I have performed a self-review of my own code