### PR TITLE
MLPAB-894 Nest non-donor routes

### DIFF
--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -93,6 +93,7 @@ func App(
 		yotiClient,
 		notifyClient,
 		certificateProviderStore,
+		notFoundHandler,
 	)
 
 	attorney.Register(
@@ -108,6 +109,7 @@ func App(
 		shareCodeStore,
 		errorHandler,
 		notifyClient,
+		notFoundHandler,
 	)
 
 	donor.Register(

--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -77,6 +77,9 @@ func App(
 	handleRoot(paths.SignOut, page.SignOut(logger, sessionStore, oneLoginClient, appPublicURL))
 	handleRoot(paths.Fixtures, page.Fixtures(tmpls.Get("fixtures.gohtml")))
 	handleRoot(paths.YourLegalRightsAndResponsibilities, page.Guidance(tmpls.Get("your_legal_rights_and_responsibilities_general.gohtml")))
+	handleRoot(page.Paths.Start, page.Guidance(tmpls.Get("start.gohtml")))
+	handleRoot(page.Paths.CertificateProviderStart, page.Guidance(tmpls.Get("certificate_provider_start.gohtml")))
+	handleRoot(page.Paths.Attorney.Start, page.Guidance(tmpls.Get("attorney_start.gohtml")))
 
 	certificateprovider.Register(
 		rootMux,

--- a/app/internal/page/app_data.go
+++ b/app/internal/page/app_data.go
@@ -47,6 +47,18 @@ func (d AppData) Redirect(w http.ResponseWriter, r *http.Request, lpa *Lpa, url 
 	return nil
 }
 
+func (d AppData) RedirectCtx(ctx context.Context, w http.ResponseWriter, r *http.Request, url string) error {
+	if fromURL := r.FormValue("from"); fromURL != "" {
+		url = fromURL
+	}
+
+	data, _ := SessionDataFromContext(ctx)
+	d.LpaID = data.LpaID
+
+	http.Redirect(w, r, d.BuildUrl(url), http.StatusFound)
+	return nil
+}
+
 func (d AppData) BuildUrl(url string) string {
 	if d.Lang == localize.Cy {
 		return "/" + localize.Cy.String() + d.BuildUrlWithoutLang(url)
@@ -56,6 +68,14 @@ func (d AppData) BuildUrl(url string) string {
 }
 
 func (d AppData) BuildUrlWithoutLang(url string) string {
+	if IsAttorneyPath(url) {
+		return "/attorney/" + d.LpaID + url
+	}
+
+	if IsCertificateProviderPath(url) {
+		return "/certificate-provider/" + d.LpaID + url
+	}
+
 	if IsLpaPath(url) {
 		return "/lpa/" + d.LpaID + url
 	}

--- a/app/internal/page/attorney/check_your_name_test.go
+++ b/app/internal/page/attorney/check_your_name_test.go
@@ -256,7 +256,7 @@ func TestPostCheckYourName(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
 		})
 	}
 }
@@ -340,7 +340,7 @@ func TestPostCheckYourNameWithCorrectedName(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
 		})
 	}
 }
@@ -416,7 +416,7 @@ func TestPostCheckYourNameWithUnchangedCorrectedName(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.DateOfBirth, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/date_of_birth_test.go
+++ b/app/internal/page/attorney/date_of_birth_test.go
@@ -252,7 +252,7 @@ func TestPostDateOfBirth(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.MobileNumber, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.MobileNumber, resp.Header.Get("Location"))
 		})
 	}
 }
@@ -307,7 +307,7 @@ func TestPostDateOfBirthWhenAttorneyDetailsDontExist(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.MobileNumber, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.MobileNumber, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/enter_reference_number.go
+++ b/app/internal/page/attorney/enter_reference_number.go
@@ -69,7 +69,7 @@ func EnterReferenceNumber(tmpl template.Template, shareCodeStore ShareCodeStore,
 					}
 				}
 
-				return appData.Redirect(w, r, nil, page.Paths.Attorney.CodeOfConduct)
+				return appData.RedirectCtx(ctx, w, r, page.Paths.Attorney.CodeOfConduct)
 			}
 		}
 

--- a/app/internal/page/attorney/enter_reference_number_test.go
+++ b/app/internal/page/attorney/enter_reference_number_test.go
@@ -147,7 +147,7 @@ func TestPostEnterReferenceNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.CodeOfConduct, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.CodeOfConduct, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/mobile_number_test.go
+++ b/app/internal/page/attorney/mobile_number_test.go
@@ -187,7 +187,7 @@ func TestPostMobileNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.YourAddress, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.YourAddress, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/read_the_lpa_test.go
+++ b/app/internal/page/attorney/read_the_lpa_test.go
@@ -177,7 +177,7 @@ func TestPostReadTheLpaWithAttorney(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.RightsAndResponsibilities, resp.Header.Get("Location"))
+	assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.RightsAndResponsibilities, resp.Header.Get("Location"))
 }
 
 func TestPostReadTheLpaWithAttorneyOnDonorStoreError(t *testing.T) {

--- a/app/internal/page/attorney/register.go
+++ b/app/internal/page/attorney/register.go
@@ -91,8 +91,6 @@ func Register(
 ) {
 	handleRoot := makeHandle(rootMux, sessionStore, errorHandler)
 
-	handleRoot(page.Paths.Attorney.Start, None,
-		page.Guidance(tmpls.Get("attorney_start.gohtml")))
 	handleRoot(page.Paths.Attorney.Login, None,
 		Login(logger, oneLoginClient, sessionStore, random.String))
 	handleRoot(page.Paths.Attorney.LoginCallback, None,

--- a/app/internal/page/attorney/sign_test.go
+++ b/app/internal/page/attorney/sign_test.go
@@ -166,7 +166,7 @@ func TestGetSignCantSignYet(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.TaskList, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.TaskList, resp.Header.Get("Location"))
 		})
 	}
 }
@@ -373,7 +373,7 @@ func TestPostSign(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.WhatHappensNext, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.WhatHappensNext, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/your_address_test.go
+++ b/app/internal/page/attorney/your_address_test.go
@@ -232,7 +232,7 @@ func TestPostYourAddressManual(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.ReadTheLpa, resp.Header.Get("Location"))
+			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.ReadTheLpa, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/auth_redirect.go
+++ b/app/internal/page/auth_redirect.go
@@ -29,9 +29,9 @@ func AuthRedirect(logger Logger, store sesh.Store) http.HandlerFunc {
 
 		redirect := Paths.LoginCallback
 		if oneLoginSession.CertificateProvider && oneLoginSession.Identity {
-			redirect = Paths.CertificateProviderIdentityWithOneLoginCallback
+			redirect = Paths.CertificateProvider.IdentityWithOneLoginCallback
 		} else if oneLoginSession.CertificateProvider {
-			redirect = Paths.CertificateProviderLoginCallback
+			redirect = Paths.CertificateProvider.LoginCallback
 		} else if oneLoginSession.Attorney {
 			redirect = Paths.Attorney.LoginCallback
 		} else if oneLoginSession.Identity {

--- a/app/internal/page/auth_redirect_test.go
+++ b/app/internal/page/auth_redirect_test.go
@@ -43,7 +43,7 @@ func TestAuthRedirect(t *testing.T) {
 				SessionID:           "456",
 				LpaID:               "123",
 			},
-			redirect: Paths.CertificateProviderLoginCallback,
+			redirect: Paths.CertificateProvider.LoginCallback,
 		},
 		"certificate provider identity": {
 			session: &sesh.OneLoginSession{
@@ -52,8 +52,9 @@ func TestAuthRedirect(t *testing.T) {
 				Locale:              "en",
 				Identity:            true,
 				CertificateProvider: true,
+				LpaID:               "123",
 			},
-			redirect: Paths.CertificateProviderIdentityWithOneLoginCallback,
+			redirect: "/certificate-provider/123" + Paths.CertificateProvider.IdentityWithOneLoginCallback,
 		},
 		"attorney login": {
 			session: &sesh.OneLoginSession{

--- a/app/internal/page/certificateprovider/check_your_name.go
+++ b/app/internal/page/certificateprovider/check_your_name.go
@@ -64,7 +64,7 @@ func CheckYourName(tmpl template.Template, donorStore DonorStore, notifyClient N
 					}
 				}
 
-				appData.Redirect(w, r, lpa, page.Paths.CertificateProviderEnterDateOfBirth)
+				appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.EnterDateOfBirth)
 				return nil
 			}
 		}

--- a/app/internal/page/certificateprovider/check_your_name_test.go
+++ b/app/internal/page/certificateprovider/check_your_name_test.go
@@ -157,7 +157,7 @@ func TestPostEnterYourName(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderEnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
 }
 
 func TestPostEnterYourNameIsCorrectOnStoreError(t *testing.T) {
@@ -239,7 +239,7 @@ func TestPostEnterYourNameWithCorrectedName(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderEnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
 }
 
 func TestPostEnterYourNameWithCorrectedNameWhenStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/enter_date_of_birth.go
+++ b/app/internal/page/certificateprovider/enter_date_of_birth.go
@@ -58,10 +58,10 @@ func EnterDateOfBirth(tmpl template.Template, donorStore DonorStore, certificate
 					return err
 				}
 
-				redirect := page.Paths.CertificateProviderEnterMobileNumber
+				redirect := page.Paths.CertificateProvider.EnterMobileNumber
 
 				if lpa.CPWitnessCodeValidated {
-					redirect = page.Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity
+					redirect = page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity
 				}
 
 				return appData.Redirect(w, r, lpa, redirect)

--- a/app/internal/page/certificateprovider/enter_date_of_birth_test.go
+++ b/app/internal/page/certificateprovider/enter_date_of_birth_test.go
@@ -209,7 +209,7 @@ func TestPostEnterDateOfBirth(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.CertificateProviderEnterMobileNumber, resp.Header.Get("Location"))
+			assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterMobileNumber, resp.Header.Get("Location"))
 		})
 	}
 }
@@ -248,7 +248,7 @@ func TestPostEnterDateOfBirthWhenCPHasAlreadyWitnessed(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
 }
 
 func TestPostEnterDateOfBirthWhenInputRequired(t *testing.T) {

--- a/app/internal/page/certificateprovider/enter_mobile_number.go
+++ b/app/internal/page/certificateprovider/enter_mobile_number.go
@@ -51,7 +51,7 @@ func EnterMobileNumber(tmpl template.Template, donorStore DonorStore, certificat
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity)
+				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity)
 			}
 		}
 

--- a/app/internal/page/certificateprovider/enter_mobile_number_test.go
+++ b/app/internal/page/certificateprovider/enter_mobile_number_test.go
@@ -182,7 +182,7 @@ func TestPostEnterMobileNumber(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
 
 }
 

--- a/app/internal/page/certificateprovider/enter_reference_number.go
+++ b/app/internal/page/certificateprovider/enter_reference_number.go
@@ -53,7 +53,7 @@ func EnterReferenceNumber(tmpl template.Template, shareCodeStore ShareCodeStore,
 					return err
 				}
 
-				appData.Redirect(w, r, nil, page.Paths.CertificateProviderWhoIsEligible)
+				appData.Redirect(w, r, nil, page.Paths.CertificateProvider.WhoIsEligible)
 				return nil
 			}
 		}

--- a/app/internal/page/certificateprovider/enter_reference_number_test.go
+++ b/app/internal/page/certificateprovider/enter_reference_number_test.go
@@ -109,7 +109,7 @@ func TestPostEnterReferenceNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.CertificateProviderWhoIsEligible, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.CertificateProvider.WhoIsEligible, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/certificateprovider/identity_with_one_login_callback.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_callback.go
@@ -31,9 +31,9 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 
 		if r.Method == http.MethodPost {
 			if certificateProvider.CertificateProviderIdentityConfirmed() {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProviderReadTheLpa)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
 			} else {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProviderSelectYourIdentityOptions1)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
 			}
 		}
 

--- a/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
@@ -331,7 +331,7 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithOneLoginCallbackNotConfirmed(t *testing.T) {
@@ -348,5 +348,5 @@ func TestPostIdentityWithOneLoginCallbackNotConfirmed(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderSelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.SelectYourIdentityOptions1, resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_todo.go
+++ b/app/internal/page/certificateprovider/identity_with_todo.go
@@ -24,7 +24,7 @@ func IdentityWithTodo(tmpl template.Template, now func() time.Time, identityOpti
 		}
 
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, nil, page.Paths.CertificateProviderReadTheLpa)
+			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
 		}
 
 		certificateProvider.IdentityUserData = identity.UserData{

--- a/app/internal/page/certificateprovider/identity_with_todo_test.go
+++ b/app/internal/page/certificateprovider/identity_with_todo_test.go
@@ -94,5 +94,5 @@ func TestPostIdentityWithTodo(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_yoti.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti.go
@@ -24,7 +24,7 @@ func IdentityWithYoti(tmpl template.Template, sessionStore SessionStore, yotiCli
 		}
 
 		if certificateProvider.CertificateProviderIdentityConfirmed() || yotiClient.IsTest() {
-			return appData.Redirect(w, r, nil, page.Paths.CertificateProviderIdentityWithYotiCallback)
+			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.IdentityWithYotiCallback)
 		}
 
 		if err := sesh.SetYoti(sessionStore, r, w, &sesh.YotiSession{

--- a/app/internal/page/certificateprovider/identity_with_yoti_callback.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_callback.go
@@ -29,9 +29,9 @@ func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, cer
 
 		if r.Method == http.MethodPost {
 			if certificateProvider.CertificateProviderIdentityConfirmed() {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProviderReadTheLpa)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
 			} else {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProviderSelectYourIdentityOptions1)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
 			}
 		}
 

--- a/app/internal/page/certificateprovider/identity_with_yoti_callback_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_callback_test.go
@@ -220,7 +220,7 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
@@ -237,5 +237,5 @@ func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderSelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.SelectYourIdentityOptions1, resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_yoti_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_test.go
@@ -99,7 +99,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderIdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithYotiCallback, resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenTest(t *testing.T) {
@@ -119,7 +119,7 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderIdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithYotiCallback, resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenCertificateProviderStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/login_callback.go
+++ b/app/internal/page/certificateprovider/login_callback.go
@@ -52,6 +52,6 @@ func LoginCallback(oneLoginClient OneLoginClient, sessionStore sesh.Store, certi
 			}
 		}
 
-		return appData.Redirect(w, r, nil, page.Paths.CertificateProviderEnterDateOfBirth)
+		return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.EnterDateOfBirth)
 	}
 }

--- a/app/internal/page/certificateprovider/login_callback_test.go
+++ b/app/internal/page/certificateprovider/login_callback_test.go
@@ -79,7 +79,7 @@ func TestLoginCallback(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderEnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
 }
 
 func TestLoginCallbackWhenCertificateProviderExists(t *testing.T) {
@@ -146,7 +146,7 @@ func TestLoginCallbackWhenCertificateProviderExists(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderEnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
 }
 
 func TestLoginCallbackSessionMissing(t *testing.T) {

--- a/app/internal/page/certificateprovider/provide_certificate.go
+++ b/app/internal/page/certificateprovider/provide_certificate.go
@@ -52,7 +52,7 @@ func ProvideCertificate(tmpl template.Template, donorStore DonorStore, now func(
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvided)
+				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.CertificateProvided)
 			}
 		}
 

--- a/app/internal/page/certificateprovider/provide_certificate_test.go
+++ b/app/internal/page/certificateprovider/provide_certificate_test.go
@@ -138,7 +138,7 @@ func TestPostProvideCertificate(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProvided, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.CertificateProvided, resp.Header.Get("Location"))
 }
 
 func TestPostProvideCertificateOnStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/register.go
+++ b/app/internal/page/certificateprovider/register.go
@@ -88,8 +88,6 @@ func Register(
 ) {
 	handleRoot := makeHandle(rootMux, sessionStore, errorHandler)
 
-	handleRoot(page.Paths.CertificateProviderStart, None,
-		Guidance(tmpls.Get("certificate_provider_start.gohtml"), nil, nil))
 	handleRoot(page.Paths.CertificateProviderEnterReferenceNumber, None,
 		EnterReferenceNumber(tmpls.Get("certificate_provider_enter_reference_number.gohtml"), shareCodeStore, sessionStore))
 	handleRoot(page.Paths.CertificateProviderWhoIsEligible, None,

--- a/app/internal/page/certificateprovider/register_test.go
+++ b/app/internal/page/certificateprovider/register_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRegister(t *testing.T) {
 	mux := http.NewServeMux()
-	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, nil, nil, &identity.YotiClient{}, &notify.Client{}, nil)
+	Register(mux, &log.Logger{}, template.Templates{}, nil, nil, &onelogin.Client{}, nil, nil, &identity.YotiClient{}, &notify.Client{}, nil, nil)
 
 	assert.Implements(t, (*http.Handler)(nil), mux)
 }

--- a/app/internal/page/certificateprovider/select_your_identity_options.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options.go
@@ -38,9 +38,9 @@ func SelectYourIdentityOptions(tmpl template.Template, pageIndex int, certificat
 			if data.Form.None {
 				switch pageIndex {
 				case 0:
-					return appData.Redirect(w, r, nil, page.Paths.CertificateProviderSelectYourIdentityOptions1)
+					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
 				case 1:
-					return appData.Redirect(w, r, nil, page.Paths.CertificateProviderSelectYourIdentityOptions2)
+					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions2)
 				default:
 					// will go to vouching flow when that is built
 					return appData.Redirect(w, r, nil, page.Paths.CertificateProviderStart)
@@ -54,7 +54,7 @@ func SelectYourIdentityOptions(tmpl template.Template, pageIndex int, certificat
 					return err
 				}
 
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProviderYourChosenIdentityOptions)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.YourChosenIdentityOptions)
 			}
 		}
 

--- a/app/internal/page/certificateprovider/select_your_identity_options_test.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options_test.go
@@ -124,13 +124,13 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderYourChosenIdentityOptions, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.YourChosenIdentityOptions, resp.Header.Get("Location"))
 }
 
 func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
 	for pageIndex, nextPath := range map[int]string{
-		0: page.Paths.CertificateProviderSelectYourIdentityOptions1,
-		1: page.Paths.CertificateProviderSelectYourIdentityOptions2,
+		0: "/certificate-provider/lpa-id" + page.Paths.CertificateProvider.SelectYourIdentityOptions1,
+		1: "/certificate-provider/lpa-id" + page.Paths.CertificateProvider.SelectYourIdentityOptions2,
 		2: page.Paths.CertificateProviderStart,
 	} {
 		t.Run(fmt.Sprintf("Page%d", pageIndex), func(t *testing.T) {

--- a/app/internal/page/certificateprovider/your_chosen_identity_options.go
+++ b/app/internal/page/certificateprovider/your_chosen_identity_options.go
@@ -38,19 +38,19 @@ func YourChosenIdentityOptions(tmpl template.Template, certificateProviderStore 
 func identityOptionPath(paths page.AppPaths, identityOption identity.Option) string {
 	switch identityOption {
 	case identity.OneLogin:
-		return paths.CertificateProviderIdentityWithOneLogin
+		return paths.CertificateProvider.IdentityWithOneLogin
 	case identity.EasyID:
-		return paths.CertificateProviderIdentityWithYoti
+		return paths.CertificateProvider.IdentityWithYoti
 	case identity.Passport:
-		return paths.CertificateProviderIdentityWithPassport
+		return paths.CertificateProvider.IdentityWithPassport
 	case identity.BiometricResidencePermit:
-		return paths.CertificateProviderIdentityWithBiometricResidencePermit
+		return paths.CertificateProvider.IdentityWithBiometricResidencePermit
 	case identity.DrivingLicencePaper:
-		return paths.CertificateProviderIdentityWithDrivingLicencePaper
+		return paths.CertificateProvider.IdentityWithDrivingLicencePaper
 	case identity.DrivingLicencePhotocard:
-		return paths.CertificateProviderIdentityWithDrivingLicencePhotocard
+		return paths.CertificateProvider.IdentityWithDrivingLicencePhotocard
 	case identity.OnlineBankAccount:
-		return paths.CertificateProviderIdentityWithOnlineBankAccount
+		return paths.CertificateProvider.IdentityWithOnlineBankAccount
 	default:
 		panic("missing case in identityOptionPath")
 	}

--- a/app/internal/page/certificateprovider/your_chosen_identity_options_test.go
+++ b/app/internal/page/certificateprovider/your_chosen_identity_options_test.go
@@ -85,5 +85,5 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderIdentityWithPassport, resp.Header.Get("Location"))
+	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithPassport, resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -132,8 +132,6 @@ func Register(
 
 	handleRoot := makeHandle(rootMux, sessionStore, None, errorHandler)
 
-	handleRoot(page.Paths.Start, None,
-		Guidance(tmpls.Get("start.gohtml"), nil))
 	handleRoot(page.Paths.Login, None,
 		Login(logger, oneLoginClient, sessionStore, random.String))
 	handleRoot(page.Paths.LoginCallback, None,

--- a/app/internal/page/paths.go
+++ b/app/internal/page/paths.go
@@ -7,59 +7,64 @@ import (
 )
 
 type AttorneyPaths struct {
-	Start                     string
+	CheckYourName             string
+	CodeOfConduct             string
+	DateOfBirth               string
+	EnterReferenceNumber      string
 	Login                     string
 	LoginCallback             string
-	EnterReferenceNumber      string
-	CodeOfConduct             string
-	TaskList                  string
-	CheckYourName             string
-	DateOfBirth               string
 	MobileNumber              string
-	YourAddress               string
 	ReadTheLpa                string
 	RightsAndResponsibilities string
-	WhatHappensWhenYouSign    string
 	Sign                      string
+	Start                     string
+	TaskList                  string
 	WhatHappensNext           string
+	WhatHappensWhenYouSign    string
+	YourAddress               string
+}
+
+type CertificateProviderPaths struct {
+	CertificateProvided                  string
+	CheckYourName                        string
+	EnterDateOfBirth                     string
+	EnterMobileNumber                    string
+	EnterReferenceNumber                 string
+	IdentityWithBiometricResidencePermit string
+	IdentityWithDrivingLicencePaper      string
+	IdentityWithDrivingLicencePhotocard  string
+	IdentityWithOneLogin                 string
+	IdentityWithOneLoginCallback         string
+	IdentityWithOnlineBankAccount        string
+	IdentityWithPassport                 string
+	IdentityWithYoti                     string
+	IdentityWithYotiCallback             string
+	Login                                string
+	LoginCallback                        string
+	ProvideCertificate                   string
+	ReadTheLpa                           string
+	SelectYourIdentityOptions            string
+	SelectYourIdentityOptions1           string
+	SelectYourIdentityOptions2           string
+	WhatHappensNext                      string
+	WhatYoullNeedToConfirmYourIdentity   string
+	WhoIsEligible                        string
+	YourChosenIdentityOptions            string
 }
 
 type AppPaths struct {
+	Attorney                                                   AttorneyPaths
+	CertificateProvider                                        CertificateProviderPaths
 	AboutPayment                                               string
 	AreYouHappyIfOneAttorneyCantActNoneCan                     string
 	AreYouHappyIfOneReplacementAttorneyCantActNoneCan          string
 	AreYouHappyIfRemainingAttorneysCanContinueToAct            string
 	AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct string
-	Attorney                                                   AttorneyPaths
 	AuthRedirect                                               string
-	CertificateProvided                                        string
 	CertificateProviderAddress                                 string
-	CertificateProviderCheckYourName                           string
 	CertificateProviderDetails                                 string
-	CertificateProviderEnterDateOfBirth                        string
-	CertificateProviderEnterMobileNumber                       string
-	CertificateProviderEnterReferenceNumber                    string
-	CertificateProviderIdentityWithBiometricResidencePermit    string
-	CertificateProviderIdentityWithDrivingLicencePaper         string
-	CertificateProviderIdentityWithDrivingLicencePhotocard     string
-	CertificateProviderIdentityWithOneLogin                    string
-	CertificateProviderIdentityWithOneLoginCallback            string
-	CertificateProviderIdentityWithOnlineBankAccount           string
-	CertificateProviderIdentityWithPassport                    string
-	CertificateProviderIdentityWithYoti                        string
-	CertificateProviderIdentityWithYotiCallback                string
-	CertificateProviderLogin                                   string
-	CertificateProviderLoginCallback                           string
 	CertificateProviderOptOut                                  string
-	CertificateProviderReadTheLpa                              string
-	CertificateProviderSelectYourIdentityOptions               string
-	CertificateProviderSelectYourIdentityOptions1              string
-	CertificateProviderSelectYourIdentityOptions2              string
 	CertificateProviderStart                                   string
-	CertificateProviderWhatHappensNext                         string
-	CertificateProviderWhatYoullNeedToConfirmYourIdentity      string
-	CertificateProviderWhoIsEligible                           string
-	CertificateProviderYourChosenIdentityOptions               string
 	CheckYourLpa                                               string
 	ChooseAttorneys                                            string
 	ChooseAttorneysAddress                                     string
@@ -99,7 +104,6 @@ type AppPaths struct {
 	LpaType                                                    string
 	PaymentConfirmation                                        string
 	Progress                                                   string
-	ProvideCertificate                                         string
 	ReadYourLpa                                                string
 	RemoveAttorney                                             string
 	RemovePersonToNotify                                       string
@@ -137,51 +141,54 @@ var Paths = AppPaths{
 	AreYouHappyIfRemainingAttorneysCanContinueToAct:            "/are-you-happy-if-remaining-attorneys-can-continue-to-act",
 	AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct: "/are-you-happy-if-remaining-replacement-attorneys-can-continue-to-act",
 	Attorney: AttorneyPaths{
-		Start:                     "/attorney-start",
+		CheckYourName:             "/attorney-check-your-name",
+		CodeOfConduct:             "/attorney-code-of-conduct",
+		DateOfBirth:               "/attorney-date-of-birth",
+		EnterReferenceNumber:      "/attorney-enter-reference-number",
 		Login:                     "/attorney-login",
 		LoginCallback:             "/attorney-login-callback",
-		TaskList:                  "/attorney-task-list",
-		EnterReferenceNumber:      "/attorney-enter-reference-number",
-		CodeOfConduct:             "/attorney-code-of-conduct",
-		CheckYourName:             "/attorney-check-your-name",
-		DateOfBirth:               "/attorney-date-of-birth",
 		MobileNumber:              "/attorney-mobile-number",
-		YourAddress:               "/attorney-your-address",
 		ReadTheLpa:                "/attorney-read-the-lpa",
 		RightsAndResponsibilities: "/attorney-legal-rights-and-responsibilities",
-		WhatHappensWhenYouSign:    "/attorney-what-happens-when-you-sign-the-lpa",
 		Sign:                      "/attorney-sign",
+		Start:                     "/attorney-start",
+		TaskList:                  "/attorney-task-list",
 		WhatHappensNext:           "/attorney-what-happens-next",
+		WhatHappensWhenYouSign:    "/attorney-what-happens-when-you-sign-the-lpa",
+		YourAddress:               "/attorney-your-address",
 	},
-	AuthRedirect:                                            "/auth/redirect",
-	CertificateProvided:                                     "/certificate-provided",
-	CertificateProviderAddress:                              "/certificate-provider-address",
-	CertificateProviderCheckYourName:                        "/certificate-provider-check-your-name",
-	CertificateProviderDetails:                              "/certificate-provider-details",
-	CertificateProviderEnterDateOfBirth:                     "/certificate-provider-enter-date-of-birth",
-	CertificateProviderEnterMobileNumber:                    "/certificate-provider-enter-mobile-number",
-	CertificateProviderEnterReferenceNumber:                 "/certificate-provider-enter-reference-number",
-	CertificateProviderIdentityWithBiometricResidencePermit: "/certificate-provider/id/brp",
-	CertificateProviderIdentityWithDrivingLicencePaper:      "/certificate-provider/id/dlpaper",
-	CertificateProviderIdentityWithDrivingLicencePhotocard:  "/certificate-provider/id/dlphoto",
-	CertificateProviderIdentityWithOneLogin:                 "/certificate-provider-identity-with-one-login",
-	CertificateProviderIdentityWithOneLoginCallback:         "/certificate-provider-identity-with-one-login-callback",
-	CertificateProviderIdentityWithOnlineBankAccount:        "/certificate-provider/id/bank",
-	CertificateProviderIdentityWithPassport:                 "/certificate-provider/id/passport",
-	CertificateProviderIdentityWithYoti:                     "/certificate-provider-identity-with-yoti",
-	CertificateProviderIdentityWithYotiCallback:             "/certificate-provider-identity-with-yoti-callback",
-	CertificateProviderLogin:                                "/certificate-provider-login",
-	CertificateProviderLoginCallback:                        "/certificate-provider-login-callback",
-	CertificateProviderOptOut:                               "/certificate-provider-opt-out",
-	CertificateProviderReadTheLpa:                           "/certificate-provider-read-the-lpa",
-	CertificateProviderSelectYourIdentityOptions1:           "/certificate-provider-select-identity-document",
-	CertificateProviderSelectYourIdentityOptions2:           "/certificate-provider-select-identity-document-2",
-	CertificateProviderSelectYourIdentityOptions:            "/certificate-provider-select-your-identity-options",
-	CertificateProviderStart:                                "/certificate-provider-start",
-	CertificateProviderWhatHappensNext:                      "/certificate-provider-what-happens-next",
-	CertificateProviderWhatYoullNeedToConfirmYourIdentity:   "/certificate-provider-what-youll-need-to-confirm-your-identity",
-	CertificateProviderWhoIsEligible:                        "/certificate-provider-who-is-eligible",
-	CertificateProviderYourChosenIdentityOptions:            "/certificate-provider-your-chosen-identity-options",
+	AuthRedirect:               "/auth/redirect",
+	CertificateProviderDetails: "/certificate-provider-details",
+	CertificateProvider: CertificateProviderPaths{
+		CertificateProvided:                  "/certificate-provided",
+		CheckYourName:                        "/certificate-provider-check-your-name",
+		EnterDateOfBirth:                     "/certificate-provider-enter-date-of-birth",
+		EnterMobileNumber:                    "/certificate-provider-enter-mobile-number",
+		EnterReferenceNumber:                 "/certificate-provider-enter-reference-number",
+		IdentityWithBiometricResidencePermit: "/certificate-provider/id/brp",
+		IdentityWithDrivingLicencePaper:      "/certificate-provider/id/dlpaper",
+		IdentityWithDrivingLicencePhotocard:  "/certificate-provider/id/dlphoto",
+		IdentityWithOneLogin:                 "/certificate-provider-identity-with-one-login",
+		IdentityWithOneLoginCallback:         "/certificate-provider-identity-with-one-login-callback",
+		IdentityWithOnlineBankAccount:        "/certificate-provider/id/bank",
+		IdentityWithPassport:                 "/certificate-provider/id/passport",
+		IdentityWithYoti:                     "/certificate-provider-identity-with-yoti",
+		IdentityWithYotiCallback:             "/certificate-provider-identity-with-yoti-callback",
+		Login:                                "/certificate-provider-login",
+		LoginCallback:                        "/certificate-provider-login-callback",
+		ProvideCertificate:                   "/provide-certificate",
+		ReadTheLpa:                           "/certificate-provider-read-the-lpa",
+		SelectYourIdentityOptions1:           "/certificate-provider-select-identity-document",
+		SelectYourIdentityOptions2:           "/certificate-provider-select-identity-document-2",
+		SelectYourIdentityOptions:            "/certificate-provider-select-your-identity-options",
+		WhatHappensNext:                      "/certificate-provider-what-happens-next",
+		WhatYoullNeedToConfirmYourIdentity:   "/certificate-provider-what-youll-need-to-confirm-your-identity",
+		WhoIsEligible:                        "/certificate-provider-who-is-eligible",
+		YourChosenIdentityOptions:            "/certificate-provider-your-chosen-identity-options",
+	},
+	CertificateProviderOptOut:                            "/certificate-provider-opt-out",
+	CertificateProviderAddress:                           "/certificate-provider-address",
+	CertificateProviderStart:                             "/certificate-provider-start",
 	CheckYourLpa:                                         "/check-your-lpa",
 	ChooseAttorneys:                                      "/choose-attorneys",
 	ChooseAttorneysAddress:                               "/choose-attorneys-address",
@@ -221,7 +228,6 @@ var Paths = AppPaths{
 	LpaType:                                              "/lpa-type",
 	PaymentConfirmation:                                  "/payment-confirmation",
 	Progress:                                             "/progress",
-	ProvideCertificate:                                   "/provide-certificate",
 	ReadYourLpa:                                          "/read-your-lpa",
 	RemoveAttorney:                                       "/remove-attorney",
 	RemovePersonToNotify:                                 "/remove-person-to-notify",
@@ -252,58 +258,76 @@ var Paths = AppPaths{
 	YourLegalRightsAndResponsibilities:                   "/your-legal-rights-and-responsibilities",
 }
 
-func IsLpaPath(url string) bool {
+// IsAttorneyPath checks whether the url should be prefixed with /attorney/.
+func IsAttorneyPath(url string) bool {
 	path, _, _ := strings.Cut(url, "?")
 
-	return !slices.Contains([]string{
-		Paths.YotiRedirect,
-		Paths.Attorney.YourAddress,
+	return slices.Contains([]string{
 		Paths.Attorney.CheckYourName,
 		Paths.Attorney.CodeOfConduct,
 		Paths.Attorney.DateOfBirth,
-		Paths.Attorney.EnterReferenceNumber,
-		Paths.Attorney.Login,
-		Paths.Attorney.LoginCallback,
 		Paths.Attorney.MobileNumber,
 		Paths.Attorney.ReadTheLpa,
 		Paths.Attorney.RightsAndResponsibilities,
 		Paths.Attorney.Sign,
-		Paths.Attorney.Start,
 		Paths.Attorney.TaskList,
-		Paths.Attorney.WhatHappensWhenYouSign,
-		Paths.Attorney.RightsAndResponsibilities,
 		Paths.Attorney.WhatHappensNext,
-		Paths.AuthRedirect,
-		Paths.CertificateProvided,
-		Paths.CertificateProviderCheckYourName,
-		Paths.CertificateProviderEnterReferenceNumber,
-		Paths.CertificateProviderIdentityWithBiometricResidencePermit,
-		Paths.CertificateProviderIdentityWithDrivingLicencePaper,
-		Paths.CertificateProviderIdentityWithDrivingLicencePhotocard,
-		Paths.CertificateProviderIdentityWithOneLogin,
-		Paths.CertificateProviderIdentityWithOneLoginCallback,
-		Paths.CertificateProviderIdentityWithOnlineBankAccount,
-		Paths.CertificateProviderIdentityWithPassport,
-		Paths.CertificateProviderIdentityWithYoti,
-		Paths.CertificateProviderIdentityWithYotiCallback,
-		Paths.CertificateProviderLogin,
-		Paths.CertificateProviderLoginCallback,
-		Paths.CertificateProviderReadTheLpa,
-		Paths.CertificateProviderSelectYourIdentityOptions,
-		Paths.CertificateProviderSelectYourIdentityOptions1,
-		Paths.CertificateProviderSelectYourIdentityOptions2,
-		Paths.CertificateProviderStart,
-		Paths.CertificateProviderWhatHappensNext,
-		Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity,
-		Paths.CertificateProviderYourChosenIdentityOptions,
-		Paths.CertificateProviderEnterDateOfBirth,
-		Paths.CertificateProviderEnterMobileNumber,
-		Paths.CertificateProviderWhoIsEligible,
-		Paths.Dashboard,
-		Paths.Login,
-		Paths.LoginCallback,
-		Paths.ProvideCertificate,
-		Paths.Start,
-		Paths.SignOut,
+		Paths.Attorney.WhatHappensWhenYouSign,
+		Paths.Attorney.YourAddress,
 	}, path)
+}
+
+// IsCertificateProviderPath checks whether the url should be prefixed with /certificate-provider/.
+func IsCertificateProviderPath(url string) bool {
+	path, _, _ := strings.Cut(url, "?")
+
+	return slices.Contains([]string{
+		Paths.CertificateProvider.CertificateProvided,
+		Paths.CertificateProvider.CheckYourName,
+		Paths.CertificateProvider.EnterDateOfBirth,
+		Paths.CertificateProvider.EnterMobileNumber,
+		Paths.CertificateProvider.IdentityWithBiometricResidencePermit,
+		Paths.CertificateProvider.IdentityWithDrivingLicencePaper,
+		Paths.CertificateProvider.IdentityWithDrivingLicencePhotocard,
+		Paths.CertificateProvider.IdentityWithOneLogin,
+		Paths.CertificateProvider.IdentityWithOneLoginCallback,
+		Paths.CertificateProvider.IdentityWithOnlineBankAccount,
+		Paths.CertificateProvider.IdentityWithPassport,
+		Paths.CertificateProvider.IdentityWithYoti,
+		Paths.CertificateProvider.IdentityWithYotiCallback,
+		Paths.CertificateProvider.ProvideCertificate,
+		Paths.CertificateProvider.ReadTheLpa,
+		Paths.CertificateProvider.SelectYourIdentityOptions,
+		Paths.CertificateProvider.SelectYourIdentityOptions1,
+		Paths.CertificateProvider.SelectYourIdentityOptions2,
+		Paths.CertificateProvider.WhatHappensNext,
+		Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity,
+		Paths.CertificateProvider.YourChosenIdentityOptions,
+	}, path)
+}
+
+// IsLpaPath checks whether the url should be prefixed with /lpa/.
+func IsLpaPath(url string) bool {
+	path, _, _ := strings.Cut(url, "?")
+
+	return !IsAttorneyPath(url) &&
+		!IsCertificateProviderPath(url) &&
+		!slices.Contains([]string{
+			Paths.Attorney.EnterReferenceNumber,
+			Paths.Attorney.Login,
+			Paths.Attorney.LoginCallback,
+			Paths.Attorney.Start,
+			Paths.AuthRedirect,
+			Paths.CertificateProvider.EnterReferenceNumber,
+			Paths.CertificateProvider.Login,
+			Paths.CertificateProvider.LoginCallback,
+			Paths.CertificateProvider.WhoIsEligible,
+			Paths.CertificateProviderStart,
+			Paths.Dashboard,
+			Paths.Login,
+			Paths.LoginCallback,
+			Paths.SignOut,
+			Paths.Start,
+			Paths.YotiRedirect,
+		}, path)
 }

--- a/app/internal/page/yoti_redirect.go
+++ b/app/internal/page/yoti_redirect.go
@@ -24,7 +24,7 @@ func YotiRedirect(logger Logger, store sesh.Store) http.HandlerFunc {
 
 		redirect := Paths.IdentityWithYotiCallback
 		if yotiSession.CertificateProvider {
-			redirect = Paths.CertificateProviderIdentityWithYotiCallback
+			redirect = Paths.CertificateProvider.IdentityWithYotiCallback
 		}
 		appData.Redirect(w, r, nil, redirect+"?"+r.URL.RawQuery)
 	}

--- a/app/internal/page/yoti_redirect_test.go
+++ b/app/internal/page/yoti_redirect_test.go
@@ -34,7 +34,7 @@ func TestYotiRedirect(t *testing.T) {
 				LpaID:               "123",
 				CertificateProvider: true,
 			},
-			redirect: Paths.CertificateProviderIdentityWithYotiCallback,
+			redirect: "/certificate-provider/123" + Paths.CertificateProvider.IdentityWithYotiCallback,
 		},
 	}
 

--- a/web/template/attorney_code_of_conduct.gohtml
+++ b/web/template/attorney_code_of_conduct.gohtml
@@ -46,7 +46,7 @@
       "DonorFullNamePossessive" (possessive .App .Lpa.Donor.FullName)
       "DonorFirstNamesPossessive" (possessive .App .Lpa.Donor.FirstNames) }}
 
-      <a class="govuk-button" href="{{.App.Paths.Attorney.TaskList}}">{{ tr .App "continue" }}</a>
+      <a class="govuk-button" href="{{ link .App .App.Paths.Attorney.TaskList }}">{{ tr .App "continue" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/certificate_provider_read_the_lpa.gohtml
+++ b/web/template/certificate_provider_read_the_lpa.gohtml
@@ -27,7 +27,7 @@
         {{ if $progress.LpaSigned.Completed }}
           <a class="govuk-button" href="{{ link .App .App.Paths.ProvideCertificate }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
         {{ else }}
-          <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProviderWhatHappensNext }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+          <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.WhatHappensNext }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
         {{ end }}
       </p>
     </div>

--- a/web/template/certificate_provider_start.gohtml
+++ b/web/template/certificate_provider_start.gohtml
@@ -8,7 +8,7 @@
       {{ trHtml .App "beACertificateProviderContent" }}
 
       <p class="govuk-body">
-        <a href="{{ link .App .App.Paths.CertificateProviderEnterReferenceNumber }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="{{ link .App .App.Paths.CertificateProvider.EnterReferenceNumber }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           {{ tr .App "start" }}
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/web/template/certificate_provider_what_youll_need_to_confirm_your_identity.gohtml
+++ b/web/template/certificate_provider_what_youll_need_to_confirm_your_identity.gohtml
@@ -9,7 +9,7 @@
 
       {{ trHtml .App "confirmYourIdentityContent" }}
 
-      <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App .App.Paths.CertificateProviderSelectYourIdentityOptions }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
+      <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App .App.Paths.CertificateProvider.SelectYourIdentityOptions }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/certificate_provider_who_is_eligible.gohtml
+++ b/web/template/certificate_provider_who_is_eligible.gohtml
@@ -38,7 +38,7 @@
 
         {{ template "warning" (warning .App "ifAnyStatementsApplyYouCannotBeACertificateProvider") }}
 
-        <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProviderLogin }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+        <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.Login }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
     </div>
 </div>
 {{ end }}

--- a/web/template/what_youll_need_to_confirm_your_identity.gohtml
+++ b/web/template/what_youll_need_to_confirm_your_identity.gohtml
@@ -9,7 +9,7 @@
 
       {{ trHtml .App "whatYoullNeedToConfirmYourIdentityContent" }}
 
-      {{ if eq .App.Page .App.Paths.CertificateProviderWhatYoullNeedToConfirmYourIdentity }}
+      {{ if eq .App.Page .App.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity }}
         <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App .App.Paths.CertificateProviderSelectYourIdentityOptions }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
       {{ else }}
         <div class="govuk-button-group govuk-!-margin-top-4">


### PR DESCRIPTION
As we're going to be allowing people to freely move between viewing an LPA as a donor, attorney or certificate provider we need to put the LpaID in the URL as opposed to the session (which won't change after signing in). 