### PR TITLE
MLPAB-1051 - unit tests need tag job outputs for pact publishing

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: ./terraform/environment
         run: |
           terraform workspace select ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
-          terraform destroy -auto-approve
+          terraform destroy -auto-approve -var "pagerduty_api_token=${{ secrets.PAGERDUTY_API_TOKEN }}"
           terraform workspace select default
           terraform workspace delete ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
       - name: Remove protection for environment workspace

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -32,6 +32,7 @@ jobs:
   go_unit_tests:
     name: Run Go unit tests
     uses: ./.github/workflows/go-unit-tests.yml
+    needs: [create_tags]
     with:
       tag: ${{ needs.create_tags.outputs.version_tag }}
       commit_sha: ${{ github.sha }}


### PR DESCRIPTION
# Purpose

Path to live fails due to missing input
Destroy environment job needs pagerduty token

Fixes MLPAB-1051

## Approach

- go_unit_tests needs create_tags
- pass in-line `-var` for pagerduty secret