### PR TITLE
MLPAB-1057 - set env vars for both destory jobs where they need a pagerduty api key

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -71,9 +71,11 @@ jobs:
         working-directory: ./terraform/environment
       - name: Destroy PR environment and Terraform workspace
         working-directory: ./terraform/environment
+        env:
+          TF_VAR_pagerduty_api_key:  ${{ secrets.PAGERDUTY_API_KEY }}
         run: |
           terraform workspace select ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
-          terraform destroy -auto-approve -var "pagerduty_api_key=${{ secrets.PAGERDUTY_API_KEY }}"
+          terraform destroy -auto-approve
           terraform workspace select default
           terraform workspace delete ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
       - name: Remove protection for environment workspace

--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -53,5 +53,7 @@ jobs:
 
       - name: Destroy PR Terraform Workspaces
         working-directory: ./terraform/environment
+        env:
+          TF_VAR_pagerduty_api_key: ${{ secrets.PAGERDUTY_API_KEY }}
         run: |
           ../../scripts/workspace_cleanup.sh $(terraform-workspace-manager -protected-workspaces=true -aws-account-id=653761790766 -aws-iam-role=modernising-lpa-ci)


### PR DESCRIPTION
# Purpose

Scheduled destroy job is failing due to missing input variable

Fixes MLPAB-1057

## Approach

- Add input variable to environment