### PR TITLE
MLPAB-963 - refactor regional policies for execution role to region module

### DIFF
--- a/terraform/environment/iam_ecs_execution_role.tf
+++ b/terraform/environment/iam_ecs_execution_role.tf
@@ -24,40 +24,6 @@ resource "aws_iam_role_policy" "execution_role" {
   provider = aws.global
 }
 
-data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id_eu_west_1" {
-  name     = "rum-monitor-identity-pool-id-eu-west-1"
-  provider = aws.eu_west_1
-}
-
-# data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id_eu_west_2" {
-#   name     = "rum-monitor-identity-pool-id-eu-west-2"
-#   provider = aws.eu_west_2
-# }
-
-data "aws_kms_alias" "secrets_manager_secret_encryption_key_eu_west_1" {
-  name     = "alias/${local.default_tags.application}_secrets_manager_secret_encryption_key"
-  provider = aws.eu_west_1
-}
-
-data "aws_kms_alias" "secrets_manager_secret_encryption_key_eu_west_2" {
-  name     = "alias/${local.default_tags.application}_secrets_manager_secret_encryption_key"
-  provider = aws.eu_west_2
-}
-
-resource "aws_secretsmanager_secret" "rum_monitor_application_id_eu_west_1" {
-  name                    = "${local.environment_name}_rum_monitor_application_id"
-  kms_key_id              = data.aws_kms_alias.secrets_manager_secret_encryption_key_eu_west_1.target_key_id
-  recovery_window_in_days = 0
-  provider                = aws.eu_west_1
-}
-
-resource "aws_secretsmanager_secret" "rum_monitor_application_id_eu_west_2" {
-  name                    = "${local.environment_name}_rum_monitor_application_id"
-  kms_key_id              = data.aws_kms_alias.secrets_manager_secret_encryption_key_eu_west_1.target_key_id
-  recovery_window_in_days = 0
-  provider                = aws.eu_west_2
-}
-
 data "aws_iam_policy_document" "execution_role" {
   statement {
     effect    = "Allow"
@@ -75,37 +41,6 @@ data "aws_iam_policy_document" "execution_role" {
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-    ]
-  }
-  statement {
-    effect = "Allow"
-
-    resources = [
-      data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn,
-      # data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_2.arn,
-      aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1.arn,
-      aws_secretsmanager_secret.rum_monitor_application_id_eu_west_2.arn,
-    ]
-
-    actions = [
-      "secretsmanager:GetSecretValue",
-    ]
-  }
-  statement {
-    effect = "Allow"
-
-    resources = [
-      data.aws_kms_alias.secrets_manager_secret_encryption_key_eu_west_1.target_key_arn,
-      data.aws_kms_alias.secrets_manager_secret_encryption_key_eu_west_2.target_key_arn,
-    ]
-
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-      "kms:GenerateDataKeyPair",
-      "kms:GenerateDataKeyPairWithoutPlaintext",
-      "kms:GenerateDataKeyWithoutPlaintext",
-      "kms:DescribeKey",
     ]
   }
   provider = aws.global

--- a/terraform/environment/refactor.tf
+++ b/terraform/environment/refactor.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1
+  to   = module.eu_west_1[0].aws_secretsmanager_secret.rum_monitor_application_id
+}

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -37,7 +37,7 @@ module "app" {
     public_subnets      = data.aws_subnet.public.*.id
   }
   aws_rum_guest_role_arn                               = data.aws_iam_role.rum_monitor_unauthenticated.arn
-  rum_monitor_application_id_secretsmanager_secret_arn = var.rum_monitor_application_id_secretsmanager_secret_id
+  rum_monitor_application_id_secretsmanager_secret_arn = aws_secretsmanager_secret.rum_monitor_application_id.id
   providers = {
     aws.region = aws.region
   }

--- a/terraform/environment/region/iam_execution_policy.tf
+++ b/terraform/environment/region/iam_execution_policy.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role_policy" "execution_role_region" {
 }
 
 data "aws_kms_alias" "secrets_manager_secret_encryption_key" {
-  name     = "alias${data.aws_default_tags.current.tags.application}_secrets_manager_secret_encryption_key"
+  name     = "alias/${data.aws_default_tags.current.tags.application}_secrets_manager_secret_encryption_key"
   provider = aws.region
 }
 

--- a/terraform/environment/region/iam_execution_policy.tf
+++ b/terraform/environment/region/iam_execution_policy.tf
@@ -1,0 +1,43 @@
+resource "aws_iam_role_policy" "execution_role_region" {
+  name     = "${data.aws_default_tags.current.tags.environment-name}-execution-role-${data.aws_region.current.name}"
+  policy   = data.aws_iam_policy_document.execution_role_region.json
+  role     = var.ecs_execution_role.id
+  provider = aws.global
+}
+
+data "aws_kms_alias" "secrets_manager_secret_encryption_key" {
+  name     = "alias${data.aws_default_tags.current.tags.application}_secrets_manager_secret_encryption_key"
+  provider = aws.region
+}
+
+data "aws_iam_policy_document" "execution_role_region" {
+  statement {
+    effect = "Allow"
+
+    resources = [
+      data.aws_secretsmanager_secret_version.rum_monitor_identity_pool_id.arn,
+      aws_secretsmanager_secret.rum_monitor_application_id.arn,
+    ]
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+  }
+  statement {
+    effect = "Allow"
+
+    resources = [
+      data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_arn,
+    ]
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyPair",
+      "kms:GenerateDataKeyPairWithoutPlaintext",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:DescribeKey",
+    ]
+  }
+  provider = aws.global
+}

--- a/terraform/environment/region/rum_monitoring.tf
+++ b/terraform/environment/region/rum_monitoring.tf
@@ -24,8 +24,15 @@ data "aws_iam_policy_document" "rum_monitor_unauthenticated" {
   provider = aws.global
 }
 
+resource "aws_secretsmanager_secret" "rum_monitor_application_id" {
+  name                    = "${data.aws_default_tags.current.tags.environment-name}_rum_monitor_application_id"
+  kms_key_id              = data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_id
+  recovery_window_in_days = 0
+  provider                = aws.region
+}
+
 data "aws_secretsmanager_secret_version" "rum_monitor_identity_pool_id" {
-  secret_id = var.rum_monitor_identity_pool_id_secretsmanager_secret_id
+  secret_id = "rum-monitor-identity-pool-id-${data.aws_region.current.name}"
   provider  = aws.region
 }
 
@@ -52,7 +59,7 @@ resource "aws_rum_app_monitor" "main" {
 }
 
 resource "aws_secretsmanager_secret_version" "rum_monitor_application_id" {
-  secret_id     = var.rum_monitor_application_id_secretsmanager_secret_id
+  secret_id     = aws_secretsmanager_secret.rum_monitor_application_id.id
   secret_string = aws_rum_app_monitor.main.app_monitor_id
   provider      = aws.region
 }

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -64,17 +64,17 @@ variable "public_access_enabled" {
   description = "Enable access to the Modernising LPA service from the public internet"
 }
 
-variable "rum_monitor_identity_pool_id_secretsmanager_secret_id" {
-  type        = string
-  description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
-  nullable    = true
-}
+# variable "rum_monitor_identity_pool_id_secretsmanager_secret_id" {
+#   type        = string
+#   description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
+#   nullable    = true
+# }
 
-variable "rum_monitor_application_id_secretsmanager_secret_id" {
-  type        = string
-  description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
-  nullable    = true
-}
+# variable "rum_monitor_application_id_secretsmanager_secret_id" {
+#   type        = string
+#   description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
+#   nullable    = true
+# }
 
 variable "pagerduty_service_name" {
   type        = string

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -64,18 +64,6 @@ variable "public_access_enabled" {
   description = "Enable access to the Modernising LPA service from the public internet"
 }
 
-# variable "rum_monitor_identity_pool_id_secretsmanager_secret_id" {
-#   type        = string
-#   description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
-#   nullable    = true
-# }
-
-# variable "rum_monitor_application_id_secretsmanager_secret_id" {
-#   type        = string
-#   description = "ARN of the AWS Secrets Manager secret containing the RUM monitor identity pool ID"
-#   nullable    = true
-# }
-
 variable "pagerduty_service_name" {
   type        = string
   description = "Name of the PagerDuty service to use for alerts"

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -25,10 +25,8 @@ module "eu_west_1" {
     arn  = aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
   }
-  app_env_vars          = local.environment.app.env
-  public_access_enabled = var.public_access_enabled
-  # rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn
-  # rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1.id
+  app_env_vars           = local.environment.app.env
+  public_access_enabled  = var.public_access_enabled
   pagerduty_service_name = local.environment.pagerduty_service_name
   providers = {
     aws.region = aws.eu_west_1
@@ -54,10 +52,8 @@ module "eu_west_2" {
     arn  = local.environment.dynamodb.region_replica_enabled ? aws_dynamodb_table_replica.lpas_table[0].arn : aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
   }
-  app_env_vars          = local.environment.app.env
-  public_access_enabled = var.public_access_enabled
-  # rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn # would be updated to eu_west_2 when that region exists
-  # rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_2.id
+  app_env_vars           = local.environment.app.env
+  public_access_enabled  = var.public_access_enabled
   pagerduty_service_name = local.environment.pagerduty_service_name
   providers = {
     aws.region = aws.eu_west_2

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -25,11 +25,11 @@ module "eu_west_1" {
     arn  = aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
   }
-  app_env_vars                                          = local.environment.app.env
-  public_access_enabled                                 = var.public_access_enabled
-  rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn
-  rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1.id
-  pagerduty_service_name                                = local.environment.pagerduty_service_name
+  app_env_vars          = local.environment.app.env
+  public_access_enabled = var.public_access_enabled
+  # rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn
+  # rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_1.id
+  pagerduty_service_name = local.environment.pagerduty_service_name
   providers = {
     aws.region = aws.eu_west_1
     aws.global = aws.global
@@ -54,11 +54,11 @@ module "eu_west_2" {
     arn  = local.environment.dynamodb.region_replica_enabled ? aws_dynamodb_table_replica.lpas_table[0].arn : aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
   }
-  app_env_vars                                          = local.environment.app.env
-  public_access_enabled                                 = var.public_access_enabled
-  rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn # would be updated to eu_west_2 when that region exists
-  rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_2.id
-  pagerduty_service_name                                = local.environment.pagerduty_service_name
+  app_env_vars          = local.environment.app.env
+  public_access_enabled = var.public_access_enabled
+  # rum_monitor_identity_pool_id_secretsmanager_secret_id = data.aws_secretsmanager_secret.rum_monitor_identity_pool_id_eu_west_1.arn # would be updated to eu_west_2 when that region exists
+  # rum_monitor_application_id_secretsmanager_secret_id   = aws_secretsmanager_secret.rum_monitor_application_id_eu_west_2.id
+  pagerduty_service_name = local.environment.pagerduty_service_name
   providers = {
     aws.region = aws.eu_west_2
     aws.global = aws.global


### PR DESCRIPTION
# Purpose

Clean up regional resources in root of environment configuration

Fixes MLPAB-963

## Approach

- Move regional secrets for RUM to region module
- Create regional policy documents and attach them to the ECS execution role