### PR TITLE
MLPAB-1054: Refactor LPA reliant donor handlers

### DIFF
--- a/app/internal/page/donor/about_payment.go
+++ b/app/internal/page/donor/about_payment.go
@@ -20,13 +20,8 @@ type aboutPaymentData struct {
 	CertificateProvider actor.CertificateProvider
 }
 
-func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.Store, payClient PayClient, appPublicUrl string, randomString func(int) string, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.Store, payClient PayClient, appPublicUrl string, randomString func(int) string) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &aboutPaymentData{
 			App:                 appData,
 			CertificateProvider: lpa.CertificateProvider,

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
@@ -15,13 +15,8 @@ type areYouHappyIfOneAttorneyCantActNoneCanData struct {
 	Happy  string
 }
 
-func AreYouHappyIfOneAttorneyCantActNoneCan(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func AreYouHappyIfOneAttorneyCantActNoneCan(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &areYouHappyIfOneAttorneyCantActNoneCanData{
 			App:   appData,
 			Happy: lpa.AttorneyDecisions.HappyIfOneCannotActNoneCan,

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
@@ -18,11 +18,6 @@ func TestGetAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfOneAttorneyCantActNoneCanData{
@@ -30,37 +25,16 @@ func TestGetAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetAreYouHappyIfOneAttorneyCantActNoneCanWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetAreYouHappyIfOneAttorneyCantActNoneCanWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -69,7 +43,7 @@ func TestGetAreYouHappyIfOneAttorneyCantActNoneCanWhenTemplateErrors(t *testing.
 		}).
 		Return(expectedError)
 
-	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -94,15 +68,12 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					AttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: happy},
 				}).
 				Return(nil)
 
-			err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
+			err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -123,13 +94,10 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCanWhenStoreErrors(t *testing.T)
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -139,11 +107,6 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCanWhenValidationErrors(t *testi
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfOneAttorneyCantActNoneCanData{
@@ -152,7 +115,7 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCanWhenValidationErrors(t *testi
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
@@ -15,13 +15,8 @@ type areYouHappyIfOneReplacementAttorneyCantActNoneCanData struct {
 	Happy  string
 }
 
-func AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &areYouHappyIfOneReplacementAttorneyCantActNoneCanData{
 			App:   appData,
 			Happy: lpa.ReplacementAttorneyDecisions.HappyIfOneCannotActNoneCan,

--- a/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can_test.go
+++ b/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can_test.go
@@ -18,11 +18,6 @@ func TestGetAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfOneReplacementAttorneyCantActNoneCanData{
@@ -30,37 +25,16 @@ func TestGetAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -69,7 +43,7 @@ func TestGetAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenTemplateErrors(
 		}).
 		Return(expectedError)
 
-	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -112,15 +86,12 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{
-					Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
-				}, nil)
-			donorStore.
 				On("Put", r.Context(), tc.lpa).
 				Return(nil)
 
-			err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
+			err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
+			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -141,13 +112,10 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenStoreErrors(t 
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -157,11 +125,6 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenValidationErro
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfOneReplacementAttorneyCantActNoneCanData{
@@ -170,7 +133,7 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCanWhenValidationErro
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
@@ -15,13 +15,8 @@ type areYouHappyIfRemainingAttorneysCanContinueToActData struct {
 	Happy  string
 }
 
-func AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &areYouHappyIfRemainingAttorneysCanContinueToActData{
 			App:   appData,
 			Happy: lpa.AttorneyDecisions.HappyIfRemainingCanContinueToAct,

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
@@ -18,11 +18,6 @@ func TestGetAreYouHappyIfRemainingAttorneysCanContinueToAct(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfRemainingAttorneysCanContinueToActData{
@@ -30,37 +25,16 @@ func TestGetAreYouHappyIfRemainingAttorneysCanContinueToAct(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetAreYouHappyIfRemainingAttorneysCanContinueToActWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetAreYouHappyIfRemainingAttorneysCanContinueToActWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -69,7 +43,7 @@ func TestGetAreYouHappyIfRemainingAttorneysCanContinueToActWhenTemplateErrors(t 
 		}).
 		Return(expectedError)
 
-	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -89,15 +63,12 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToAct(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					AttorneyDecisions: actor.AttorneyDecisions{HappyIfRemainingCanContinueToAct: happy},
 				}).
 				Return(nil)
 
-			err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
+			err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -118,13 +89,10 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToActWhenStoreErrors(t *t
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -134,11 +102,6 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToActWhenValidationErrors
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfRemainingAttorneysCanContinueToActData{
@@ -147,7 +110,7 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToActWhenValidationErrors
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
@@ -15,13 +15,8 @@ type areYouHappyIfRemainingReplacementAttorneysCanContinueToActData struct {
 	Happy  string
 }
 
-func AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &areYouHappyIfRemainingReplacementAttorneysCanContinueToActData{
 			App:   appData,
 			Happy: lpa.ReplacementAttorneyDecisions.HappyIfRemainingCanContinueToAct,

--- a/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act_test.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act_test.go
@@ -18,11 +18,6 @@ func TestGetAreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(t *testin
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfRemainingReplacementAttorneysCanContinueToActData{
@@ -30,37 +25,16 @@ func TestGetAreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(t *testin
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -69,7 +43,7 @@ func TestGetAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenTempla
 		}).
 		Return(expectedError)
 
-	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -89,18 +63,15 @@ func TestPostAreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(t *testi
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{
-					Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
-				}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					ReplacementAttorneyDecisions: actor.AttorneyDecisions{HappyIfRemainingCanContinueToAct: happy},
 					Tasks:                        page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 				}).
 				Return(nil)
 
-			err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
+			err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
+			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -121,13 +92,10 @@ func TestPostAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenStore
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -137,11 +105,6 @@ func TestPostAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenValid
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &areYouHappyIfRemainingReplacementAttorneysCanContinueToActData{
@@ -150,7 +113,7 @@ func TestPostAreYouHappyIfRemainingReplacementAttorneysCanContinueToActWhenValid
 		}).
 		Return(nil)
 
-	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, donorStore)(testAppData, w, r)
+	err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/certificate_provider_address.go
+++ b/app/internal/page/donor/certificate_provider_address.go
@@ -9,13 +9,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 )
 
-func CertificateProviderAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func CertificateProviderAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &chooseAddressData{
 			App:        appData,
 			ActorLabel: "certificateProvider",

--- a/app/internal/page/donor/certificate_provider_address_test.go
+++ b/app/internal/page/donor/certificate_provider_address_test.go
@@ -26,11 +26,6 @@ func TestGetCertificateProviderAddress(t *testing.T) {
 		Address:    place.Address{},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{CertificateProvider: certificateProvider}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -41,26 +36,10 @@ func TestGetCertificateProviderAddress(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{CertificateProvider: certificateProvider})
 	resp := w.Result()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetCertificateProviderAddressWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -71,13 +50,6 @@ func TestGetCertificateProviderAddressFromStore(t *testing.T) {
 	certificateProvider := actor.CertificateProvider{
 		Address: testAddress,
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			CertificateProvider: certificateProvider,
-		}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -92,7 +64,7 @@ func TestGetCertificateProviderAddressFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{CertificateProvider: certificateProvider})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -107,11 +79,6 @@ func TestGetCertificateProviderAddressManual(t *testing.T) {
 		Address: testAddress,
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{CertificateProvider: certificateProvider}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -125,7 +92,7 @@ func TestGetCertificateProviderAddressManual(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{CertificateProvider: certificateProvider})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -135,11 +102,6 @@ func TestGetCertificateProviderAddressManual(t *testing.T) {
 func TestGetCertificateProviderAddressWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -151,7 +113,7 @@ func TestGetCertificateProviderAddressWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -174,16 +136,12 @@ func TestPostCertificateProviderAddressManual(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			CertificateProvider: actor.CertificateProvider{Address: testAddress},
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -207,16 +165,12 @@ func TestPostCertificateProviderAddressManualWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			CertificateProvider: actor.CertificateProvider{Address: testAddress},
 		}).
 		Return(expectedError)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -237,16 +191,6 @@ func TestPostCertificateProviderAddressManualFromStore(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			CertificateProvider: actor.CertificateProvider{
-				FirstNames: "John",
-				Address:    place.Address{Line1: "abc"},
-			},
-			WhoFor: "me",
-		}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			CertificateProvider: actor.CertificateProvider{
 				FirstNames: "John",
@@ -256,7 +200,13 @@ func TestPostCertificateProviderAddressManualFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		CertificateProvider: actor.CertificateProvider{
+			FirstNames: "John",
+			Address:    place.Address{Line1: "abc"},
+		},
+		WhoFor: "me",
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -275,11 +225,6 @@ func TestPostCertificateProviderAddressManualWhenValidationError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	invalidAddress := &place.Address{
 		Line2:      "b",
@@ -301,7 +246,7 @@ func TestPostCertificateProviderAddressManualWhenValidationError(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -319,11 +264,6 @@ func TestPostCertificateProviderPostcodeSelect(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -338,7 +278,7 @@ func TestPostCertificateProviderPostcodeSelect(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -358,11 +298,6 @@ func TestPostCertificateProviderPostcodeSelectWhenValidationError(t *testing.T) 
 	addresses := []place.Address{
 		{Line1: "1 Road Way", TownOrCity: "Townville"},
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -384,7 +319,7 @@ func TestPostCertificateProviderPostcodeSelectWhenValidationError(t *testing.T) 
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -410,11 +345,6 @@ func TestPostCertificateProviderPostcodeLookup(t *testing.T) {
 		On("LookupPostcode", mock.Anything, "NG1").
 		Return(addresses, nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -429,7 +359,7 @@ func TestPostCertificateProviderPostcodeLookup(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -449,11 +379,6 @@ func TestPostCertificateProviderPostcodeLookupError(t *testing.T) {
 	logger := newMockLogger(t)
 	logger.
 		On("Print", expectedError)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -475,7 +400,7 @@ func TestPostCertificateProviderPostcodeLookupError(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -501,11 +426,6 @@ func TestPostCertificateProviderPostcodeLookupInvalidPostcodeError(t *testing.T)
 	logger.
 		On("Print", invalidPostcodeErr)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	addressClient := newMockAddressClient(t)
 	addressClient.
 		On("LookupPostcode", mock.Anything, "XYZ").
@@ -526,7 +446,7 @@ func TestPostCertificateProviderPostcodeLookupInvalidPostcodeError(t *testing.T)
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -545,11 +465,6 @@ func TestPostCertificateProviderPostcodeLookupValidPostcodeNoAddresses(t *testin
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 	logger := newMockLogger(t)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -571,7 +486,7 @@ func TestPostCertificateProviderPostcodeLookupValidPostcodeNoAddresses(t *testin
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -587,11 +502,6 @@ func TestPostCertificateProviderPostcodeLookupWhenValidationError(t *testing.T) 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -605,7 +515,7 @@ func TestPostCertificateProviderPostcodeLookupWhenValidationError(t *testing.T) 
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -620,13 +530,6 @@ func TestPostCertificateProviderAddressReuse(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{Address: place.Address{Line1: "donor lane"}},
-		}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -640,7 +543,9 @@ func TestPostCertificateProviderAddressReuse(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{Address: place.Address{Line1: "donor lane"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -659,9 +564,6 @@ func TestPostCertificateProviderAddressReuseSelect(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			CertificateProvider: actor.CertificateProvider{
 				Address: place.Address{
@@ -675,7 +577,7 @@ func TestPostCertificateProviderAddressReuseSelect(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -692,13 +594,6 @@ func TestPostCertificateProviderAddressReuseSelectWhenValidationError(t *testing
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{Address: place.Address{Line1: "donor lane"}},
-		}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -713,7 +608,9 @@ func TestPostCertificateProviderAddressReuseSelectWhenValidationError(t *testing
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := CertificateProviderAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{Address: place.Address{Line1: "donor lane"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/certificate_provider_details.go
+++ b/app/internal/page/donor/certificate_provider_details.go
@@ -18,13 +18,8 @@ type certificateProviderDetailsData struct {
 	SameLastnameAsDonor bool
 }
 
-func CertificateProviderDetails(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func CertificateProviderDetails(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &certificateProviderDetailsData{
 			App: appData,
 			Form: &certificateProviderDetailsForm{

--- a/app/internal/page/donor/check_your_lpa.go
+++ b/app/internal/page/donor/check_your_lpa.go
@@ -17,13 +17,8 @@ type checkYourLpaData struct {
 	Completed bool
 }
 
-func CheckYourLpa(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func CheckYourLpa(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &checkYourLpaData{
 			App: appData,
 			Lpa: lpa,

--- a/app/internal/page/donor/check_your_lpa_test.go
+++ b/app/internal/page/donor/check_your_lpa_test.go
@@ -18,11 +18,6 @@ func TestGetCheckYourLpa(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &checkYourLpaData{
@@ -32,26 +27,10 @@ func TestGetCheckYourLpa(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CheckYourLpa(template.Execute, donorStore)(testAppData, w, r)
+	err := CheckYourLpa(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetCheckYourLpaWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := CheckYourLpa(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -63,11 +42,6 @@ func TestGetCheckYourLpaFromStore(t *testing.T) {
 		Checked:      true,
 		HappyToShare: true,
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -81,7 +55,7 @@ func TestGetCheckYourLpaFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CheckYourLpa(template.Execute, donorStore)(testAppData, w, r)
+	err := CheckYourLpa(template.Execute, nil)(testAppData, w, r, lpa)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -106,9 +80,6 @@ func TestPostCheckYourLpa(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			Checked:      true,
 			HappyToShare: true,
@@ -116,7 +87,7 @@ func TestPostCheckYourLpa(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CheckYourLpa(nil, donorStore)(testAppData, w, r)
+	err := CheckYourLpa(nil, donorStore)(testAppData, w, r, lpa)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -136,9 +107,6 @@ func TestPostCheckYourLpaWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			Checked:      true,
 			HappyToShare: true,
@@ -146,7 +114,7 @@ func TestPostCheckYourLpaWhenStoreErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := CheckYourLpa(nil, donorStore)(testAppData, w, r)
+	err := CheckYourLpa(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -160,11 +128,6 @@ func TestPostCheckYourLpaWhenValidationErrors(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.MatchedBy(func(data *checkYourLpaData) bool {
@@ -172,7 +135,7 @@ func TestPostCheckYourLpaWhenValidationErrors(t *testing.T) {
 		})).
 		Return(nil)
 
-	err := CheckYourLpa(template.Execute, donorStore)(testAppData, w, r)
+	err := CheckYourLpa(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/choose_attorneys_address.go
+++ b/app/internal/page/donor/choose_attorneys_address.go
@@ -9,13 +9,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 )
 
-func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		attorneyId := r.FormValue("id")
 		attorney, found := lpa.Attorneys.Get(attorneyId)
 

--- a/app/internal/page/donor/choose_attorneys_summary.go
+++ b/app/internal/page/donor/choose_attorneys_summary.go
@@ -16,14 +16,8 @@ type chooseAttorneysSummaryData struct {
 	Lpa    *page.Lpa
 }
 
-func ChooseAttorneysSummary(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func ChooseAttorneysSummary(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.Attorneys) == 0 {
 			return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys))
 		}

--- a/app/internal/page/donor/choose_people_to_notify.go
+++ b/app/internal/page/donor/choose_people_to_notify.go
@@ -18,13 +18,8 @@ type choosePeopleToNotifyData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func ChoosePeopleToNotify(tmpl template.Template, donorStore DonorStore, uuidString func() string) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ChoosePeopleToNotify(tmpl template.Template, donorStore DonorStore, uuidString func() string) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) > 4 {
 			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
 		}

--- a/app/internal/page/donor/choose_people_to_notify_address.go
+++ b/app/internal/page/donor/choose_people_to_notify_address.go
@@ -10,13 +10,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 )
 
-func ChoosePeopleToNotifyAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ChoosePeopleToNotifyAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		personId := r.FormValue("id")
 		personToNotify, found := lpa.PeopleToNotify.Get(personId)
 

--- a/app/internal/page/donor/choose_people_to_notify_summary.go
+++ b/app/internal/page/donor/choose_people_to_notify_summary.go
@@ -16,14 +16,8 @@ type choosePeopleToNotifySummaryData struct {
 	Lpa    *page.Lpa
 }
 
-func ChoosePeopleToNotifySummary(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func ChoosePeopleToNotifySummary(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) == 0 {
 			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople)
 		}
@@ -47,7 +41,6 @@ func ChoosePeopleToNotifySummary(logger Logger, tmpl template.Template, donorSto
 
 				return appData.Redirect(w, r, lpa, redirectUrl)
 			}
-
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/choose_replacement_attorneys.go
+++ b/app/internal/page/donor/choose_replacement_attorneys.go
@@ -19,13 +19,8 @@ type chooseReplacementAttorneysData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func ChooseReplacementAttorneys(tmpl template.Template, donorStore DonorStore, uuidString func() string) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ChooseReplacementAttorneys(tmpl template.Template, donorStore DonorStore, uuidString func() string) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		addAnother := r.FormValue("addAnother") == "1"
 		attorney, attorneyFound := lpa.ReplacementAttorneys.Get(r.URL.Query().Get("id"))
 

--- a/app/internal/page/donor/choose_replacement_attorneys_address.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address.go
@@ -9,13 +9,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 )
 
-func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		attorneyId := r.FormValue("id")
 		attorney, _ := lpa.ReplacementAttorneys.Get(attorneyId)
 

--- a/app/internal/page/donor/choose_replacement_attorneys_address_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address_test.go
@@ -27,11 +27,6 @@ func TestGetChooseReplacementAttorneysAddress(t *testing.T) {
 		Address:    place.Address{},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -44,26 +39,10 @@ func TestGetChooseReplacementAttorneysAddress(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetChooseReplacementAttorneysAddressWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -75,11 +54,6 @@ func TestGetChooseReplacementAttorneysAddressFromStore(t *testing.T) {
 		ID:      "123",
 		Address: testAddress,
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -96,7 +70,7 @@ func TestGetChooseReplacementAttorneysAddressFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -111,11 +85,6 @@ func TestGetChooseReplacementAttorneysAddressManual(t *testing.T) {
 		ID:      "123",
 		Address: testAddress,
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -132,7 +101,7 @@ func TestGetChooseReplacementAttorneysAddressManual(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -148,11 +117,6 @@ func TestGetChooseReplacementAttorneysAddressWhenTemplateErrors(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -165,7 +129,7 @@ func TestGetChooseReplacementAttorneysAddressWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{ra}})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -188,23 +152,20 @@ func TestPostChooseReplacementAttorneysAddressSkip(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			ReplacementAttorneys: actor.Attorneys{{
-				ID:         "123",
-				FirstNames: "a",
-				Email:      "a",
-				Address:    place.Address{Line1: "abc"},
-			}},
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a", Email: "a"}},
 			Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskCompleted},
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{
+			ID:         "123",
+			FirstNames: "a",
+			Email:      "a",
+			Address:    place.Address{Line1: "abc"},
+		}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -228,12 +189,6 @@ func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a"}},
-		}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			ReplacementAttorneys: actor.Attorneys{{
 				ID:         "123",
@@ -244,7 +199,9 @@ func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -268,14 +225,10 @@ func TestPostChooseReplacementAttorneysAddressManualWhenStoreErrors(t *testing.T
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
-
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -296,17 +249,6 @@ func TestPostChooseReplacementAttorneysAddressManualFromStore(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			ReplacementAttorneys: actor.Attorneys{{
-				ID:         "123",
-				FirstNames: "John",
-				Address:    place.Address{Line1: "abc"},
-			}},
-			WhoFor: "me",
-		}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			ReplacementAttorneys: actor.Attorneys{{
 				ID:         "123",
@@ -318,7 +260,14 @@ func TestPostChooseReplacementAttorneysAddressManualFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{
+			ID:         "123",
+			FirstNames: "John",
+			Address:    place.Address{Line1: "abc"},
+		}},
+		WhoFor: "me",
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -337,11 +286,6 @@ func TestPostChooseReplacementAttorneysAddressManualWhenValidationError(t *testi
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
 
 	invalidAddress := &place.Address{
 		Line2:      "b",
@@ -365,7 +309,7 @@ func TestPostChooseReplacementAttorneysAddressManualWhenValidationError(t *testi
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -383,11 +327,6 @@ func TestPostChooseReplacementAttorneysPostcodeSelect(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -404,7 +343,7 @@ func TestPostChooseReplacementAttorneysPostcodeSelect(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -424,11 +363,6 @@ func TestPostChooseReplacementAttorneysPostcodeSelectWhenValidationError(t *test
 	addresses := []place.Address{
 		{Line1: "1 Road Way", TownOrCity: "Townville"},
 	}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -452,7 +386,7 @@ func TestPostChooseReplacementAttorneysPostcodeSelectWhenValidationError(t *test
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -478,11 +412,6 @@ func TestPostChooseReplacementAttorneysPostcodeLookup(t *testing.T) {
 		On("LookupPostcode", mock.Anything, "NG1").
 		Return(addresses, nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &chooseAddressData{
@@ -499,7 +428,7 @@ func TestPostChooseReplacementAttorneysPostcodeLookup(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -519,11 +448,6 @@ func TestPostChooseReplacementAttorneysPostcodeLookupError(t *testing.T) {
 	logger := newMockLogger(t)
 	logger.
 		On("Print", expectedError)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -547,7 +471,7 @@ func TestPostChooseReplacementAttorneysPostcodeLookupError(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -573,11 +497,6 @@ func TestPostChooseReplacementAttorneysPostcodeLookupInvalidPostcodeError(t *tes
 	logger.
 		On("Print", invalidPostcodeErr)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
-
 	addressClient := newMockAddressClient(t)
 	addressClient.
 		On("LookupPostcode", mock.Anything, "XYZ").
@@ -600,7 +519,9 @@ func TestPostChooseReplacementAttorneysPostcodeLookupInvalidPostcodeError(t *tes
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -619,11 +540,6 @@ func TestPostChooseReplacementAttorneysPostcodeLookupValidPostcodeNoAddresses(t 
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 	logger := newMockLogger(t)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
 
 	addressClient := newMockAddressClient(t)
 	addressClient.
@@ -647,7 +563,9 @@ func TestPostChooseReplacementAttorneysPostcodeLookupValidPostcodeNoAddresses(t 
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(logger, template.Execute, addressClient, nil)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -662,11 +580,6 @@ func TestPostChooseReplacementAttorneysPostcodeLookupWhenValidationError(t *test
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -683,7 +596,7 @@ func TestPostChooseReplacementAttorneysPostcodeLookupWhenValidationError(t *test
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -698,14 +611,6 @@ func TestPostChooseReplacementAttorneysAddressReuse(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor:                actor.Donor{Address: place.Address{Line1: "donor lane"}},
-			ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
-		}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -722,7 +627,10 @@ func TestPostChooseReplacementAttorneysAddressReuse(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{
+		Donor:                actor.Donor{Address: place.Address{Line1: "donor lane"}},
+		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -752,16 +660,15 @@ func TestPostChooseReplacementAttorneysAddressReuseSelect(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ReplacementAttorneys: actor.Attorneys{{ID: "123"}}}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			ReplacementAttorneys: actor.Attorneys{updatedAttorney},
 			Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskInProgress},
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -777,14 +684,6 @@ func TestPostChooseReplacementAttorneysAddressReuseSelectWhenValidationError(t *
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(f.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor:                actor.Donor{Address: place.Address{Line1: "donor lane"}},
-			ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
-		}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -802,7 +701,10 @@ func TestPostChooseReplacementAttorneysAddressReuseSelectWhenValidationError(t *
 		}).
 		Return(nil)
 
-	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, donorStore)(testAppData, w, r)
+	err := ChooseReplacementAttorneysAddress(nil, template.Execute, nil, nil)(testAppData, w, r, &page.Lpa{
+		Donor:                actor.Donor{Address: place.Address{Line1: "donor lane"}},
+		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/choose_replacement_attorneys_summary.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_summary.go
@@ -17,14 +17,8 @@ type chooseReplacementAttorneysSummaryData struct {
 	Lpa    *page.Lpa
 }
 
-func ChooseReplacementAttorneysSummary(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func ChooseReplacementAttorneysSummary(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.ReplacementAttorneys) == 0 {
 			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantReplacementAttorneys)
 		}

--- a/app/internal/page/donor/do_you_want_to_notify_people.go
+++ b/app/internal/page/donor/do_you_want_to_notify_people.go
@@ -18,13 +18,8 @@ type doYouWantToNotifyPeopleData struct {
 	HowWorkTogether string
 }
 
-func DoYouWantToNotifyPeople(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func DoYouWantToNotifyPeople(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) > 0 {
 			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
 		}

--- a/app/internal/page/donor/guidance.go
+++ b/app/internal/page/donor/guidance.go
@@ -14,18 +14,11 @@ type guidanceData struct {
 	Lpa    *page.Lpa
 }
 
-func Guidance(tmpl template.Template, donorStore GetDonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
+func Guidance(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &guidanceData{
 			App: appData,
-		}
-
-		if donorStore != nil {
-			lpa, err := donorStore.Get(r.Context())
-			if err != nil {
-				return err
-			}
-			data.Lpa = lpa
+			Lpa: lpa,
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/guidance_test.go
+++ b/app/internal/page/donor/guidance_test.go
@@ -15,71 +15,28 @@ func TestGuidance(t *testing.T) {
 
 	lpa := &page.Lpa{}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &guidanceData{App: testAppData, Lpa: lpa}).
 		Return(nil)
 
-	err := Guidance(template.Execute, donorStore)(testAppData, w, r)
+	err := Guidance(template.Execute)(testAppData, w, r, lpa)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGuidanceWhenNilDataStores(t *testing.T) {
-	w := httptest.NewRecorder()
-
-	template := newMockTemplate(t)
-	template.
-		On("Execute", w, &guidanceData{App: testAppData}).
-		Return(nil)
-
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	err := Guidance(template.Execute, nil)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGuidanceWhenDonorStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	lpa := &page.Lpa{}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, expectedError)
-
-	err := Guidance(nil, donorStore)(testAppData, w, r)
-
-	assert.Equal(t, expectedError, err)
 }
 
 func TestGuidanceWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &guidanceData{App: testAppData, Lpa: &page.Lpa{}}).
 		Return(expectedError)
 
-	err := Guidance(template.Execute, donorStore)(testAppData, w, r)
+	err := Guidance(template.Execute)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/how_do_you_know_your_certificate_provider.go
+++ b/app/internal/page/donor/how_do_you_know_your_certificate_provider.go
@@ -16,13 +16,8 @@ type howDoYouKnowYourCertificateProviderData struct {
 	Form                *howDoYouKnowYourCertificateProviderForm
 }
 
-func HowDoYouKnowYourCertificateProvider(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowDoYouKnowYourCertificateProvider(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howDoYouKnowYourCertificateProviderData{
 			App:                 appData,
 			CertificateProvider: lpa.CertificateProvider,

--- a/app/internal/page/donor/how_long_have_you_known_certificate_provider.go
+++ b/app/internal/page/donor/how_long_have_you_known_certificate_provider.go
@@ -16,13 +16,8 @@ type howLongHaveYouKnownCertificateProviderData struct {
 	HowLong             string
 }
 
-func HowLongHaveYouKnownCertificateProvider(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowLongHaveYouKnownCertificateProvider(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howLongHaveYouKnownCertificateProviderData{
 			App:                 appData,
 			CertificateProvider: lpa.CertificateProvider,

--- a/app/internal/page/donor/how_should_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_attorneys_make_decisions.go
@@ -16,13 +16,8 @@ type howShouldAttorneysMakeDecisionsData struct {
 	Lpa    *page.Lpa
 }
 
-func HowShouldAttorneysMakeDecisions(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowShouldAttorneysMakeDecisions(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howShouldAttorneysMakeDecisionsData{
 			App: appData,
 			Form: &howShouldAttorneysMakeDecisionsForm{

--- a/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
@@ -15,13 +15,8 @@ type howShouldReplacementAttorneysMakeDecisionsData struct {
 	Form   *howShouldAttorneysMakeDecisionsForm
 }
 
-func HowShouldReplacementAttorneysMakeDecisions(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowShouldReplacementAttorneysMakeDecisions(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howShouldReplacementAttorneysMakeDecisionsData{
 			App: appData,
 			Form: &howShouldAttorneysMakeDecisionsForm{

--- a/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
@@ -15,13 +15,8 @@ type howShouldReplacementAttorneysStepInData struct {
 	Form              *howShouldReplacementAttorneysStepInForm
 }
 
-func HowShouldReplacementAttorneysStepIn(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowShouldReplacementAttorneysStepIn(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howShouldReplacementAttorneysStepInData{
 			App:               appData,
 			AllowSomeOtherWay: len(lpa.ReplacementAttorneys) == 1,

--- a/app/internal/page/donor/how_should_replacement_attorneys_step_in_test.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_step_in_test.go
@@ -33,13 +33,6 @@ func TestGetHowShouldReplacementAttorneysStepIn(t *testing.T) {
 			w := httptest.NewRecorder()
 			r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-			donorStore := newMockDonorStore(t)
-			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{
-					ReplacementAttorneys: tc.attorneys,
-				}, nil)
-
 			template := newMockTemplate(t)
 			template.
 				On("Execute", w, &howShouldReplacementAttorneysStepInData{
@@ -49,7 +42,9 @@ func TestGetHowShouldReplacementAttorneysStepIn(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+			err := HowShouldReplacementAttorneysStepIn(template.Execute, nil)(testAppData, w, r, &page.Lpa{
+				ReplacementAttorneys: tc.attorneys,
+			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -62,14 +57,6 @@ func TestGetHowShouldReplacementAttorneysStepInFromStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			HowShouldReplacementAttorneysStepIn:        page.SomeOtherWay,
-			HowShouldReplacementAttorneysStepInDetails: "some details",
-		}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &howShouldReplacementAttorneysStepInData{
@@ -81,28 +68,13 @@ func TestGetHowShouldReplacementAttorneysStepInFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+	err := HowShouldReplacementAttorneysStepIn(template.Execute, nil)(testAppData, w, r, &page.Lpa{
+		HowShouldReplacementAttorneysStepIn:        page.SomeOtherWay,
+		HowShouldReplacementAttorneysStepInDetails: "some details",
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetHowShouldReplacementAttorneysStepInWhenStoreError(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	template := newMockTemplate(t)
-
-	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -118,12 +90,6 @@ func TestPostHowShouldReplacementAttorneysStepIn(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			HowShouldReplacementAttorneysStepIn:        "",
-			HowShouldReplacementAttorneysStepInDetails: "",
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			HowShouldReplacementAttorneysStepIn:        page.SomeOtherWay,
 			HowShouldReplacementAttorneysStepInDetails: "some details"}).
@@ -131,7 +97,10 @@ func TestPostHowShouldReplacementAttorneysStepIn(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+		HowShouldReplacementAttorneysStepIn:        "",
+		HowShouldReplacementAttorneysStepInDetails: "",
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -212,14 +181,6 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{
-					Attorneys:                    tc.Attorneys,
-					AttorneyDecisions:            actor.AttorneyDecisions{How: tc.HowAttorneysMakeDecisions},
-					ReplacementAttorneys:         tc.ReplacementAttorneys,
-					ReplacementAttorneyDecisions: actor.AttorneyDecisions{How: tc.HowReplacementAttorneysMakeDecisions},
-				}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					Attorneys:                           tc.Attorneys,
 					AttorneyDecisions:                   actor.AttorneyDecisions{How: tc.HowAttorneysMakeDecisions},
@@ -232,7 +193,12 @@ func TestPostHowShouldReplacementAttorneysStepInRedirects(t *testing.T) {
 
 			template := newMockTemplate(t)
 
-			err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+			err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+				Attorneys:                    tc.Attorneys,
+				AttorneyDecisions:            actor.AttorneyDecisions{How: tc.HowAttorneysMakeDecisions},
+				ReplacementAttorneys:         tc.ReplacementAttorneys,
+				ReplacementAttorneyDecisions: actor.AttorneyDecisions{How: tc.HowReplacementAttorneysMakeDecisions},
+			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -283,12 +249,6 @@ func TestPostHowShouldReplacementAttorneysStepInFromStore(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{
-					HowShouldReplacementAttorneysStepIn:        tc.existingWhenStepIn,
-					HowShouldReplacementAttorneysStepInDetails: tc.existingOtherDetails,
-				}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					HowShouldReplacementAttorneysStepIn:        tc.updatedWhenStepIn,
 					HowShouldReplacementAttorneysStepInDetails: tc.updatedOtherDetails}).
@@ -296,7 +256,10 @@ func TestPostHowShouldReplacementAttorneysStepInFromStore(t *testing.T) {
 
 			template := newMockTemplate(t)
 
-			err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+			err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+				HowShouldReplacementAttorneysStepIn:        tc.existingWhenStepIn,
+				HowShouldReplacementAttorneysStepInDetails: tc.existingOtherDetails,
+			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -317,11 +280,6 @@ func TestPostHowShouldReplacementAttorneysStepInFormValidation(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &howShouldReplacementAttorneysStepInData{
@@ -331,7 +289,7 @@ func TestPostHowShouldReplacementAttorneysStepInFormValidation(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+	err := HowShouldReplacementAttorneysStepIn(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -350,12 +308,6 @@ func TestPostHowShouldReplacementAttorneysStepInWhenPutStoreError(t *testing.T) 
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			HowShouldReplacementAttorneysStepIn:        "",
-			HowShouldReplacementAttorneysStepInDetails: "",
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			HowShouldReplacementAttorneysStepIn:        page.SomeOtherWay,
 			HowShouldReplacementAttorneysStepInDetails: "some details"}).
@@ -363,7 +315,10 @@ func TestPostHowShouldReplacementAttorneysStepInWhenPutStoreError(t *testing.T) 
 
 	template := newMockTemplate(t)
 
-	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r)
+	err := HowShouldReplacementAttorneysStepIn(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+		HowShouldReplacementAttorneysStepIn:        "",
+		HowShouldReplacementAttorneysStepInDetails: "",
+	})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)

--- a/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
+++ b/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
@@ -16,13 +16,8 @@ type howWouldCertificateProviderPreferToCarryOutTheirRoleData struct {
 	Form                *howWouldCertificateProviderPreferToCarryOutTheirRoleForm
 }
 
-func HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &howWouldCertificateProviderPreferToCarryOutTheirRoleData{
 			App:                 appData,
 			CertificateProvider: lpa.CertificateProvider,

--- a/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
+++ b/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
@@ -18,11 +18,6 @@ func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRole(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &howWouldCertificateProviderPreferToCarryOutTheirRoleData{
@@ -31,7 +26,7 @@ func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRole(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, donorStore)(testAppData, w, r)
+	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -42,13 +37,6 @@ func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRoleFromStore(t *tes
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			CertificateProvider: actor.CertificateProvider{CarryOutBy: "paper"},
-		}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &howWouldCertificateProviderPreferToCarryOutTheirRoleData{
@@ -58,37 +46,18 @@ func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRoleFromStore(t *tes
 		}).
 		Return(nil)
 
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, donorStore)(testAppData, w, r)
+	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, nil)(testAppData, w, r, &page.Lpa{
+		CertificateProvider: actor.CertificateProvider{CarryOutBy: "paper"},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -98,7 +67,7 @@ func TestGetHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenTemplateErro
 		}).
 		Return(expectedError)
 
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, donorStore)(testAppData, w, r)
+	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -132,15 +101,12 @@ func TestPostHowWouldCertificateProviderPreferToCarryOutTheirRole(t *testing.T) 
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{}, nil)
-			donorStore.
 				On("Put", r.Context(), &page.Lpa{
 					CertificateProvider: actor.CertificateProvider{CarryOutBy: tc.carryOutBy, Email: tc.email},
 				}).
 				Return(nil)
 
-			err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r)
+			err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -161,13 +127,10 @@ func TestPostHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenStoreErrors
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r)
+	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -176,11 +139,6 @@ func TestPostHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenValidationE
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("nope"))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -191,7 +149,7 @@ func TestPostHowWouldCertificateProviderPreferToCarryOutTheirRoleWhenValidationE
 		}).
 		Return(nil)
 
-	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, donorStore)(testAppData, w, r)
+	err := HowWouldCertificateProviderPreferToCarryOutTheirRole(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/identity_with_one_login_callback.go
+++ b/app/internal/page/donor/identity_with_one_login_callback.go
@@ -22,13 +22,8 @@ type identityWithOneLoginCallbackData struct {
 	CouldNotConfirm bool
 }
 
-func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLoginClient, sessionStore sessions.Store, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLoginClient, sessionStore sessions.Store, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			if lpa.DonorIdentityConfirmed() {
 				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)

--- a/app/internal/page/donor/identity_with_todo.go
+++ b/app/internal/page/donor/identity_with_todo.go
@@ -16,13 +16,8 @@ type identityWithTodoData struct {
 	IdentityOption identity.Option
 }
 
-func IdentityWithTodo(tmpl template.Template, donorStore DonorStore, now func() time.Time, identityOption identity.Option) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func IdentityWithTodo(tmpl template.Template, donorStore DonorStore, now func() time.Time, identityOption identity.Option) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
 		}

--- a/app/internal/page/donor/identity_with_todo_test.go
+++ b/app/internal/page/donor/identity_with_todo_test.go
@@ -20,11 +20,6 @@ func TestGetIdentityWithTodo(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
 			DonorIdentityUserData: identity.UserData{
@@ -45,26 +40,13 @@ func TestGetIdentityWithTodo(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := IdentityWithTodo(template.Execute, donorStore, func() time.Time { return now }, identity.Passport)(testAppData, w, r)
+	err := IdentityWithTodo(template.Execute, donorStore, func() time.Time { return now }, identity.Passport)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetIdentityWithTodoWhenDonorStoreGetErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
-		}, expectedError)
-
-	err := IdentityWithTodo(nil, donorStore, nil, identity.Passport)(testAppData, w, r)
-	assert.Equal(t, expectedError, err)
 }
 
 func TestGetIdentityWithTodoWhenDonorStorePutErrors(t *testing.T) {
@@ -73,15 +55,12 @@ func TestGetIdentityWithTodoWhenDonorStorePutErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := IdentityWithTodo(nil, donorStore, time.Now, identity.Passport)(testAppData, w, r)
+	err := IdentityWithTodo(nil, donorStore, time.Now, identity.Passport)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+	})
 	assert.Equal(t, expectedError, err)
 }
 
@@ -89,21 +68,16 @@ func TestPostIdentityWithTodo(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Donor: actor.Donor{FirstNames: "a", LastName: "b"},
-			DonorIdentityUserData: identity.UserData{
-				OK:          true,
-				Provider:    identity.Passport,
-				FirstNames:  "a",
-				LastName:    "b",
-				RetrievedAt: now,
-			},
-		}, nil)
-
-	err := IdentityWithTodo(nil, donorStore, nil, identity.Passport)(testAppData, w, r)
+	err := IdentityWithTodo(nil, nil, nil, identity.Passport)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{FirstNames: "a", LastName: "b"},
+		DonorIdentityUserData: identity.UserData{
+			OK:          true,
+			Provider:    identity.Passport,
+			FirstNames:  "a",
+			LastName:    "b",
+			RetrievedAt: now,
+		},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/identity_with_yoti.go
+++ b/app/internal/page/donor/identity_with_yoti.go
@@ -16,13 +16,8 @@ type identityWithYotiData struct {
 	ScenarioID  string
 }
 
-func IdentityWithYoti(tmpl template.Template, donorStore DonorStore, sessionStore SessionStore, yotiClient YotiClient) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func IdentityWithYoti(tmpl template.Template, sessionStore SessionStore, yotiClient YotiClient) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if lpa.DonorIdentityConfirmed() || yotiClient.IsTest() {
 			return appData.Redirect(w, r, lpa, page.Paths.IdentityWithYotiCallback)
 		}

--- a/app/internal/page/donor/identity_with_yoti_callback.go
+++ b/app/internal/page/donor/identity_with_yoti_callback.go
@@ -20,13 +20,8 @@ type identityWithYotiCallbackData struct {
 	CouldNotConfirm bool
 }
 
-func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			if lpa.DonorIdentityConfirmed() {
 				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)

--- a/app/internal/page/donor/life_sustaining_treatment.go
+++ b/app/internal/page/donor/life_sustaining_treatment.go
@@ -15,13 +15,8 @@ type lifeSustainingTreatmentData struct {
 	Option string
 }
 
-func LifeSustainingTreatment(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func LifeSustainingTreatment(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &lifeSustainingTreatmentData{
 			App:    appData,
 			Option: lpa.LifeSustainingTreatmentOption,

--- a/app/internal/page/donor/life_sustaining_treatment_test.go
+++ b/app/internal/page/donor/life_sustaining_treatment_test.go
@@ -17,11 +17,6 @@ func TestGetLifeSustainingTreatment(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lifeSustainingTreatmentData{
@@ -29,7 +24,7 @@ func TestGetLifeSustainingTreatment(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LifeSustainingTreatment(template.Execute, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -40,11 +35,6 @@ func TestGetLifeSustainingTreatmentFromStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{LifeSustainingTreatmentOption: page.OptionA}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lifeSustainingTreatmentData{
@@ -53,37 +43,16 @@ func TestGetLifeSustainingTreatmentFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LifeSustainingTreatment(template.Execute, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(template.Execute, nil)(testAppData, w, r, &page.Lpa{LifeSustainingTreatmentOption: page.OptionA})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetLifeSustainingTreatmentWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetLifeSustainingTreatmentWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -92,7 +61,7 @@ func TestGetLifeSustainingTreatmentWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := LifeSustainingTreatment(template.Execute, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -110,18 +79,15 @@ func TestPostLifeSustainingTreatment(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
-		}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			LifeSustainingTreatmentOption: page.OptionA,
 			Tasks:                         page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, LifeSustainingTreatment: actor.TaskCompleted},
 		}).
 		Return(nil)
 
-	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -140,13 +106,10 @@ func TestPostLifeSustainingTreatmentWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{LifeSustainingTreatmentOption: page.OptionA, Tasks: page.Tasks{LifeSustainingTreatment: actor.TaskCompleted}}).
 		Return(expectedError)
 
-	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -156,11 +119,6 @@ func TestPostLifeSustainingTreatmentWhenValidationErrors(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lifeSustainingTreatmentData{
@@ -169,7 +127,7 @@ func TestPostLifeSustainingTreatmentWhenValidationErrors(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LifeSustainingTreatment(template.Execute, donorStore)(testAppData, w, r)
+	err := LifeSustainingTreatment(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/lpa_progress.go
+++ b/app/internal/page/donor/lpa_progress.go
@@ -18,13 +18,8 @@ type lpaProgressData struct {
 	Errors              validation.List
 }
 
-func LpaProgress(tmpl template.Template, donorStore DonorStore, certificateProviderStore CertificateProviderStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func LpaProgress(tmpl template.Template, certificateProviderStore CertificateProviderStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		ctx := page.ContextWithSessionData(r.Context(), &page.SessionData{LpaID: lpa.ID})
 
 		certificateProvider, err := certificateProviderStore.GetAny(ctx)

--- a/app/internal/page/donor/lpa_progress_test.go
+++ b/app/internal/page/donor/lpa_progress_test.go
@@ -14,11 +14,6 @@ func TestGetLpaProgress(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ID: "123"}, nil)
-
 	certificateProviderStore := newMockCertificateProviderStore(t)
 
 	ctx := page.ContextWithSessionData(r.Context(), &page.SessionData{LpaID: "123"})
@@ -36,37 +31,16 @@ func TestGetLpaProgress(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LpaProgress(template.Execute, donorStore, certificateProviderStore)(testAppData, w, r)
+	err := LpaProgress(template.Execute, certificateProviderStore)(testAppData, w, r, &page.Lpa{ID: "123"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetLpaProgressWhenDonorStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := LpaProgress(nil, donorStore, nil)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetLpaProgressWhenCertificateProviderStoreErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ID: "123"}, nil)
 
 	certificateProviderStore := newMockCertificateProviderStore(t)
 
@@ -76,7 +50,7 @@ func TestGetLpaProgressWhenCertificateProviderStoreErrors(t *testing.T) {
 		On("GetAny", ctx).
 		Return(&actor.CertificateProviderProvidedDetails{}, expectedError)
 
-	err := LpaProgress(nil, donorStore, certificateProviderStore)(testAppData, w, r)
+	err := LpaProgress(nil, certificateProviderStore)(testAppData, w, r, &page.Lpa{ID: "123"})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -86,11 +60,6 @@ func TestGetLpaProgressWhenCertificateProviderStoreErrors(t *testing.T) {
 func TestGetLpaProgressOnTemplateError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{ID: "123"}, nil)
 
 	certificateProviderStore := newMockCertificateProviderStore(t)
 
@@ -109,7 +78,7 @@ func TestGetLpaProgressOnTemplateError(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := LpaProgress(template.Execute, donorStore, certificateProviderStore)(testAppData, w, r)
+	err := LpaProgress(template.Execute, certificateProviderStore)(testAppData, w, r, &page.Lpa{ID: "123"})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)

--- a/app/internal/page/donor/lpa_type.go
+++ b/app/internal/page/donor/lpa_type.go
@@ -15,13 +15,8 @@ type lpaTypeData struct {
 	Type   string
 }
 
-func LpaType(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func LpaType(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &lpaTypeData{
 			App:  appData,
 			Type: lpa.Type,

--- a/app/internal/page/donor/lpa_type_test.go
+++ b/app/internal/page/donor/lpa_type_test.go
@@ -20,11 +20,6 @@ func TestGetLpaType(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lpaTypeData{
@@ -32,7 +27,7 @@ func TestGetLpaType(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LpaType(template.Execute, donorStore)(testAppData, w, r)
+	err := LpaType(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -43,11 +38,6 @@ func TestGetLpaTypeFromStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Type: page.LpaTypePropertyFinance}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lpaTypeData{
@@ -56,37 +46,16 @@ func TestGetLpaTypeFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LpaType(template.Execute, donorStore)(testAppData, w, r)
+	err := LpaType(template.Execute, nil)(testAppData, w, r, &page.Lpa{Type: page.LpaTypePropertyFinance})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetLpaTypeWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := LpaType(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetLpaTypeWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -95,7 +64,7 @@ func TestGetLpaTypeWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := LpaType(template.Execute, donorStore)(testAppData, w, r)
+	err := LpaType(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -113,16 +82,6 @@ func TestPostLpaType(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Donor: actor.Donor{
-			FirstNames:  "Jane",
-			LastName:    "Smith",
-			DateOfBirth: date.New("2000", "1", "2"),
-			Address:     place.Address{Postcode: "ABC123"},
-		},
-		}, nil)
-
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{Donor: actor.Donor{
 			FirstNames:  "Jane",
 			LastName:    "Smith",
@@ -134,7 +93,14 @@ func TestPostLpaType(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LpaType(nil, donorStore)(testAppData, w, r)
+	err := LpaType(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		Donor: actor.Donor{
+			FirstNames:  "Jane",
+			LastName:    "Smith",
+			DateOfBirth: date.New("2000", "1", "2"),
+			Address:     place.Address{Postcode: "ABC123"},
+		},
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -153,13 +119,10 @@ func TestPostLpaTypeWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := LpaType(nil, donorStore)(testAppData, w, r)
+	err := LpaType(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -169,11 +132,6 @@ func TestPostLpaTypeWhenValidationErrors(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &lpaTypeData{
@@ -182,7 +140,7 @@ func TestPostLpaTypeWhenValidationErrors(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := LpaType(template.Execute, donorStore)(testAppData, w, r)
+	err := LpaType(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/payment_confirmation.go
+++ b/app/internal/page/donor/payment_confirmation.go
@@ -19,13 +19,8 @@ type paymentConfirmationData struct {
 	PaymentReference string
 }
 
-func PaymentConfirmation(logger Logger, tmpl template.Template, payClient PayClient, donorStore DonorStore, sessionStore sessions.Store, shareCodeSender ShareCodeSender) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func PaymentConfirmation(logger Logger, tmpl template.Template, payClient PayClient, donorStore DonorStore, sessionStore sessions.Store, shareCodeSender ShareCodeSender) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		paymentSession, err := sesh.Payment(sessionStore, r)
 		if err != nil {
 			return err

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -161,7 +161,7 @@ func Register(
 
 	handleWithLpa(page.Paths.ChooseAttorneys, None,
 		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), donorStore, random.UuidString))
-	handleLpa(page.Paths.ChooseAttorneysAddress, CanGoBack,
+	handleWithLpa(page.Paths.ChooseAttorneysAddress, CanGoBack,
 		ChooseAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleLpa(page.Paths.ChooseAttorneysSummary, CanGoBack,
 		ChooseAttorneysSummary(logger, tmpls.Get("choose_attorneys_summary.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -221,7 +221,7 @@ func Register(
 		ChoosePeopleToNotifyAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleWithLpa(page.Paths.ChoosePeopleToNotifySummary, CanGoBack,
 		ChoosePeopleToNotifySummary(tmpls.Get("choose_people_to_notify_summary.gohtml")))
-	handleLpa(page.Paths.RemovePersonToNotify, CanGoBack,
+	handleWithLpa(page.Paths.RemovePersonToNotify, CanGoBack,
 		RemovePersonToNotify(logger, tmpls.Get("remove_person_to_notify.gohtml"), donorStore))
 
 	handleLpa(page.Paths.CheckYourLpa, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -219,8 +219,8 @@ func Register(
 		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), donorStore, random.UuidString))
 	handleWithLpa(page.Paths.ChoosePeopleToNotifyAddress, CanGoBack,
 		ChoosePeopleToNotifyAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
-	handleLpa(page.Paths.ChoosePeopleToNotifySummary, CanGoBack,
-		ChoosePeopleToNotifySummary(logger, tmpls.Get("choose_people_to_notify_summary.gohtml"), donorStore))
+	handleWithLpa(page.Paths.ChoosePeopleToNotifySummary, CanGoBack,
+		ChoosePeopleToNotifySummary(tmpls.Get("choose_people_to_notify_summary.gohtml")))
 	handleLpa(page.Paths.RemovePersonToNotify, CanGoBack,
 		RemovePersonToNotify(logger, tmpls.Get("remove_person_to_notify.gohtml"), donorStore))
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -151,7 +151,7 @@ func Register(
 		YourDetails(tmpls.Get("your_details.gohtml"), donorStore, sessionStore))
 	handleWithLpa(page.Paths.YourAddress, None,
 		YourAddress(logger, tmpls.Get("your_address.gohtml"), addressClient, donorStore))
-	handleLpa(page.Paths.WhoIsTheLpaFor, None,
+	handleWithLpa(page.Paths.WhoIsTheLpaFor, None,
 		WhoIsTheLpaFor(tmpls.Get("who_is_the_lpa_for.gohtml"), donorStore))
 	handleLpa(page.Paths.LpaType, None,
 		LpaType(tmpls.Get("lpa_type.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -182,7 +182,7 @@ func Register(
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleWithLpa(page.Paths.ChooseReplacementAttorneysSummary, CanGoBack,
 		ChooseReplacementAttorneysSummary(tmpls.Get("choose_replacement_attorneys_summary.gohtml")))
-	handleLpa(page.Paths.RemoveReplacementAttorney, CanGoBack,
+	handleWithLpa(page.Paths.RemoveReplacementAttorney, CanGoBack,
 		RemoveReplacementAttorney(logger, tmpls.Get("remove_replacement_attorney.gohtml"), donorStore))
 	handleLpa(page.Paths.HowShouldReplacementAttorneysStepIn, CanGoBack,
 		HowShouldReplacementAttorneysStepIn(tmpls.Get("how_should_replacement_attorneys_step_in.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -180,8 +180,8 @@ func Register(
 		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), donorStore, random.UuidString))
 	handleWithLpa(page.Paths.ChooseReplacementAttorneysAddress, CanGoBack,
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
-	handleLpa(page.Paths.ChooseReplacementAttorneysSummary, CanGoBack,
-		ChooseReplacementAttorneysSummary(logger, tmpls.Get("choose_replacement_attorneys_summary.gohtml"), donorStore))
+	handleWithLpa(page.Paths.ChooseReplacementAttorneysSummary, CanGoBack,
+		ChooseReplacementAttorneysSummary(tmpls.Get("choose_replacement_attorneys_summary.gohtml")))
 	handleLpa(page.Paths.RemoveReplacementAttorney, CanGoBack,
 		RemoveReplacementAttorney(logger, tmpls.Get("remove_replacement_attorney.gohtml"), donorStore))
 	handleLpa(page.Paths.HowShouldReplacementAttorneysStepIn, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -195,7 +195,7 @@ func Register(
 
 	handleWithLpa(page.Paths.WhenCanTheLpaBeUsed, None,
 		WhenCanTheLpaBeUsed(tmpls.Get("when_can_the_lpa_be_used.gohtml"), donorStore))
-	handleLpa(page.Paths.LifeSustainingTreatment, None,
+	handleWithLpa(page.Paths.LifeSustainingTreatment, None,
 		LifeSustainingTreatment(tmpls.Get("life_sustaining_treatment.gohtml"), donorStore))
 	handleLpa(page.Paths.Restrictions, None,
 		Restrictions(tmpls.Get("restrictions.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -184,7 +184,7 @@ func Register(
 		ChooseReplacementAttorneysSummary(tmpls.Get("choose_replacement_attorneys_summary.gohtml")))
 	handleWithLpa(page.Paths.RemoveReplacementAttorney, CanGoBack,
 		RemoveReplacementAttorney(logger, tmpls.Get("remove_replacement_attorney.gohtml"), donorStore))
-	handleLpa(page.Paths.HowShouldReplacementAttorneysStepIn, CanGoBack,
+	handleWithLpa(page.Paths.HowShouldReplacementAttorneysStepIn, CanGoBack,
 		HowShouldReplacementAttorneysStepIn(tmpls.Get("how_should_replacement_attorneys_step_in.gohtml"), donorStore))
 	handleLpa(page.Paths.HowShouldReplacementAttorneysMakeDecisions, CanGoBack,
 		HowShouldReplacementAttorneysMakeDecisions(tmpls.Get("how_should_replacement_attorneys_make_decisions.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -210,7 +210,7 @@ func Register(
 		CertificateProviderAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleWithLpa(page.Paths.HowDoYouKnowYourCertificateProvider, CanGoBack,
 		HowDoYouKnowYourCertificateProvider(tmpls.Get("how_do_you_know_your_certificate_provider.gohtml"), donorStore))
-	handleLpa(page.Paths.HowLongHaveYouKnownCertificateProvider, CanGoBack,
+	handleWithLpa(page.Paths.HowLongHaveYouKnownCertificateProvider, CanGoBack,
 		HowLongHaveYouKnownCertificateProvider(tmpls.Get("how_long_have_you_known_certificate_provider.gohtml"), donorStore))
 
 	handleLpa(page.Paths.DoYouWantToNotifyPeople, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -283,8 +283,8 @@ func Register(
 	handleWithLpa(page.Paths.YouHaveSubmittedYourLpa, None,
 		Guidance(tmpls.Get("you_have_submitted_your_lpa.gohtml")))
 
-	handleLpa(page.Paths.Progress, CanGoBack,
-		LpaProgress(tmpls.Get("lpa_progress.gohtml"), donorStore, certificateProviderStore))
+	handleWithLpa(page.Paths.Progress, CanGoBack,
+		LpaProgress(tmpls.Get("lpa_progress.gohtml"), certificateProviderStore))
 }
 
 type handleOpt byte

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -143,7 +143,6 @@ func Register(
 	rootMux.Handle("/lpa/", page.RouteToPrefix("/lpa/", lpaMux, notFoundHandler))
 
 	handleLpa := makeHandle(lpaMux, sessionStore, RequireSession, errorHandler)
-	// Temp - will update all the routes that need an LPA in a future PR to save on diff
 	handleWithLpa := makeLpaHandle(lpaMux, sessionStore, RequireSession, errorHandler, donorStore, uidClient, logger)
 
 	handleLpa(page.Paths.Root, None, notFoundHandler)

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -248,8 +248,8 @@ func Register(
 
 	handleWithLpa(page.Paths.YourChosenIdentityOptions, CanGoBack,
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml")))
-	handleLpa(page.Paths.IdentityWithYoti, CanGoBack,
-		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), donorStore, sessionStore, yotiClient))
+	handleWithLpa(page.Paths.IdentityWithYoti, CanGoBack,
+		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), sessionStore, yotiClient))
 	handleLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, donorStore))
 	handleLpa(page.Paths.IdentityWithOneLogin, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -232,8 +232,8 @@ func Register(
 	handleWithLpa(page.Paths.PaymentConfirmation, None,
 		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, donorStore, sessionStore, shareCodeSender))
 
-	handleLpa(page.Paths.HowToConfirmYourIdentityAndSign, None,
-		Guidance(tmpls.Get("how_to_confirm_your_identity_and_sign.gohtml"), donorStore))
+	handleWithLpa(page.Paths.HowToConfirmYourIdentityAndSign, None,
+		Guidance(tmpls.Get("how_to_confirm_your_identity_and_sign.gohtml")))
 	handleLpa(page.Paths.WhatYoullNeedToConfirmYourIdentity, None,
 		Guidance(tmpls.Get("what_youll_need_to_confirm_your_identity.gohtml"), donorStore))
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -176,7 +176,7 @@ func Register(
 
 	handleWithLpa(page.Paths.DoYouWantReplacementAttorneys, None,
 		WantReplacementAttorneys(tmpls.Get("do_you_want_replacement_attorneys.gohtml"), donorStore))
-	handleLpa(page.Paths.ChooseReplacementAttorneys, CanGoBack,
+	handleWithLpa(page.Paths.ChooseReplacementAttorneys, CanGoBack,
 		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), donorStore, random.UuidString))
 	handleLpa(page.Paths.ChooseReplacementAttorneysAddress, CanGoBack,
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -264,7 +264,7 @@ func Register(
 		page.Paths.IdentityWithDrivingLicencePhotocard:  identity.DrivingLicencePhotocard,
 		page.Paths.IdentityWithOnlineBankAccount:        identity.OnlineBankAccount,
 	} {
-		handleLpa(path, CanGoBack,
+		handleWithLpa(path, CanGoBack,
 			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), donorStore, time.Now, identityOption))
 	}
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -197,10 +197,10 @@ func Register(
 		WhenCanTheLpaBeUsed(tmpls.Get("when_can_the_lpa_be_used.gohtml"), donorStore))
 	handleWithLpa(page.Paths.LifeSustainingTreatment, None,
 		LifeSustainingTreatment(tmpls.Get("life_sustaining_treatment.gohtml"), donorStore))
-	handleLpa(page.Paths.Restrictions, None,
+	handleWithLpa(page.Paths.Restrictions, None,
 		Restrictions(tmpls.Get("restrictions.gohtml"), donorStore))
 
-	handleLpa(page.Paths.WhoDoYouWantToBeCertificateProviderGuidance, None,
+	handleWithLpa(page.Paths.WhoDoYouWantToBeCertificateProviderGuidance, None,
 		WhoDoYouWantToBeCertificateProviderGuidance(tmpls.Get("who_do_you_want_to_be_certificate_provider_guidance.gohtml"), donorStore))
 	handleLpa(page.Paths.CertificateProviderDetails, CanGoBack,
 		CertificateProviderDetails(tmpls.Get("certificate_provider_details.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -246,8 +246,8 @@ func Register(
 			SelectYourIdentityOptions(tmpls.Get("select_your_identity_options.gohtml"), donorStore, page))
 	}
 
-	handleLpa(page.Paths.YourChosenIdentityOptions, CanGoBack,
-		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml"), donorStore))
+	handleWithLpa(page.Paths.YourChosenIdentityOptions, CanGoBack,
+		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml")))
 	handleLpa(page.Paths.IdentityWithYoti, CanGoBack,
 		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), donorStore, sessionStore, yotiClient))
 	handleLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -149,7 +149,7 @@ func Register(
 	handleLpa(page.Paths.Root, None, notFoundHandler)
 	handleWithLpa(page.Paths.YourDetails, None,
 		YourDetails(tmpls.Get("your_details.gohtml"), donorStore, sessionStore))
-	handleLpa(page.Paths.YourAddress, None,
+	handleWithLpa(page.Paths.YourAddress, None,
 		YourAddress(logger, tmpls.Get("your_address.gohtml"), addressClient, donorStore))
 	handleLpa(page.Paths.WhoIsTheLpaFor, None,
 		WhoIsTheLpaFor(tmpls.Get("who_is_the_lpa_for.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -217,7 +217,7 @@ func Register(
 		DoYouWantToNotifyPeople(tmpls.Get("do_you_want_to_notify_people.gohtml"), donorStore))
 	handleWithLpa(page.Paths.ChoosePeopleToNotify, CanGoBack,
 		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), donorStore, random.UuidString))
-	handleLpa(page.Paths.ChoosePeopleToNotifyAddress, CanGoBack,
+	handleWithLpa(page.Paths.ChoosePeopleToNotifyAddress, CanGoBack,
 		ChoosePeopleToNotifyAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleLpa(page.Paths.ChoosePeopleToNotifySummary, CanGoBack,
 		ChoosePeopleToNotifySummary(logger, tmpls.Get("choose_people_to_notify_summary.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -272,7 +272,7 @@ func Register(
 		Guidance(tmpls.Get("read_your_lpa.gohtml")))
 	handleWithLpa(page.Paths.YourLegalRightsAndResponsibilities, CanGoBack,
 		Guidance(tmpls.Get("your_legal_rights_and_responsibilities.gohtml")))
-	handleLpa(page.Paths.SignYourLpa, CanGoBack,
+	handleWithLpa(page.Paths.SignYourLpa, CanGoBack,
 		SignYourLpa(tmpls.Get("sign_your_lpa.gohtml"), donorStore))
 	handleLpa(page.Paths.WitnessingYourSignature, None,
 		WitnessingYourSignature(tmpls.Get("witnessing_your_signature.gohtml"), donorStore, witnessCodeSender))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -250,7 +250,7 @@ func Register(
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml")))
 	handleWithLpa(page.Paths.IdentityWithYoti, CanGoBack,
 		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), sessionStore, yotiClient))
-	handleLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,
+	handleWithLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, donorStore))
 	handleLpa(page.Paths.IdentityWithOneLogin, CanGoBack,
 		IdentityWithOneLogin(logger, oneLoginClient, sessionStore, random.String))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -153,7 +153,7 @@ func Register(
 		YourAddress(logger, tmpls.Get("your_address.gohtml"), addressClient, donorStore))
 	handleWithLpa(page.Paths.WhoIsTheLpaFor, None,
 		WhoIsTheLpaFor(tmpls.Get("who_is_the_lpa_for.gohtml"), donorStore))
-	handleLpa(page.Paths.LpaType, None,
+	handleWithLpa(page.Paths.LpaType, None,
 		LpaType(tmpls.Get("lpa_type.gohtml"), donorStore))
 
 	handleLpa(page.Paths.TaskList, None,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -234,8 +234,8 @@ func Register(
 
 	handleWithLpa(page.Paths.HowToConfirmYourIdentityAndSign, None,
 		Guidance(tmpls.Get("how_to_confirm_your_identity_and_sign.gohtml")))
-	handleLpa(page.Paths.WhatYoullNeedToConfirmYourIdentity, None,
-		Guidance(tmpls.Get("what_youll_need_to_confirm_your_identity.gohtml"), donorStore))
+	handleWithLpa(page.Paths.WhatYoullNeedToConfirmYourIdentity, None,
+		Guidance(tmpls.Get("what_youll_need_to_confirm_your_identity.gohtml")))
 
 	for path, page := range map[string]int{
 		page.Paths.SelectYourIdentityOptions:  0,
@@ -268,10 +268,10 @@ func Register(
 			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), donorStore, time.Now, identityOption))
 	}
 
-	handleLpa(page.Paths.ReadYourLpa, None,
-		Guidance(tmpls.Get("read_your_lpa.gohtml"), donorStore))
-	handleLpa(page.Paths.YourLegalRightsAndResponsibilities, CanGoBack,
-		Guidance(tmpls.Get("your_legal_rights_and_responsibilities.gohtml"), donorStore))
+	handleWithLpa(page.Paths.ReadYourLpa, None,
+		Guidance(tmpls.Get("read_your_lpa.gohtml")))
+	handleWithLpa(page.Paths.YourLegalRightsAndResponsibilities, CanGoBack,
+		Guidance(tmpls.Get("your_legal_rights_and_responsibilities.gohtml")))
 	handleLpa(page.Paths.SignYourLpa, CanGoBack,
 		SignYourLpa(tmpls.Get("sign_your_lpa.gohtml"), donorStore))
 	handleLpa(page.Paths.WitnessingYourSignature, None,
@@ -280,8 +280,8 @@ func Register(
 		WitnessingAsCertificateProvider(tmpls.Get("witnessing_as_certificate_provider.gohtml"), donorStore, shareCodeSender, time.Now, certificateProviderStore))
 	handleLpa(page.Paths.ResendWitnessCode, CanGoBack,
 		ResendWitnessCode(tmpls.Get("resend_witness_code.gohtml"), donorStore, witnessCodeSender, time.Now))
-	handleLpa(page.Paths.YouHaveSubmittedYourLpa, None,
-		Guidance(tmpls.Get("you_have_submitted_your_lpa.gohtml"), donorStore))
+	handleWithLpa(page.Paths.YouHaveSubmittedYourLpa, None,
+		Guidance(tmpls.Get("you_have_submitted_your_lpa.gohtml")))
 
 	handleLpa(page.Paths.Progress, CanGoBack,
 		LpaProgress(tmpls.Get("lpa_progress.gohtml"), donorStore, certificateProviderStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -174,7 +174,7 @@ func Register(
 	handleWithLpa(page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_attorneys_can_continue_to_act.gohtml"), donorStore))
 
-	handleLpa(page.Paths.DoYouWantReplacementAttorneys, None,
+	handleWithLpa(page.Paths.DoYouWantReplacementAttorneys, None,
 		WantReplacementAttorneys(tmpls.Get("do_you_want_replacement_attorneys.gohtml"), donorStore))
 	handleLpa(page.Paths.ChooseReplacementAttorneys, CanGoBack,
 		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), donorStore, random.UuidString))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -213,7 +213,7 @@ func Register(
 	handleWithLpa(page.Paths.HowLongHaveYouKnownCertificateProvider, CanGoBack,
 		HowLongHaveYouKnownCertificateProvider(tmpls.Get("how_long_have_you_known_certificate_provider.gohtml"), donorStore))
 
-	handleLpa(page.Paths.DoYouWantToNotifyPeople, CanGoBack,
+	handleWithLpa(page.Paths.DoYouWantToNotifyPeople, CanGoBack,
 		DoYouWantToNotifyPeople(tmpls.Get("do_you_want_to_notify_people.gohtml"), donorStore))
 	handleLpa(page.Paths.ChoosePeopleToNotify, CanGoBack,
 		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), donorStore, random.UuidString))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -156,8 +156,8 @@ func Register(
 	handleWithLpa(page.Paths.LpaType, None,
 		LpaType(tmpls.Get("lpa_type.gohtml"), donorStore))
 
-	handleLpa(page.Paths.TaskList, None,
-		TaskList(tmpls.Get("task_list.gohtml"), donorStore))
+	handleWithLpa(page.Paths.TaskList, None,
+		TaskList(tmpls.Get("task_list.gohtml")))
 
 	handleWithLpa(page.Paths.ChooseAttorneys, None,
 		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), donorStore, random.UuidString))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -242,7 +242,7 @@ func Register(
 		page.Paths.SelectYourIdentityOptions1: 1,
 		page.Paths.SelectYourIdentityOptions2: 2,
 	} {
-		handleLpa(path, None,
+		handleWithLpa(path, None,
 			SelectYourIdentityOptions(tmpls.Get("select_your_identity_options.gohtml"), donorStore, page))
 	}
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -227,8 +227,8 @@ func Register(
 	handleWithLpa(page.Paths.CheckYourLpa, CanGoBack,
 		CheckYourLpa(tmpls.Get("check_your_lpa.gohtml"), donorStore))
 
-	handleLpa(page.Paths.AboutPayment, CanGoBack,
-		AboutPayment(logger, tmpls.Get("about_payment.gohtml"), sessionStore, payClient, appPublicUrl, random.String, donorStore))
+	handleWithLpa(page.Paths.AboutPayment, CanGoBack,
+		AboutPayment(logger, tmpls.Get("about_payment.gohtml"), sessionStore, payClient, appPublicUrl, random.String))
 	handleLpa(page.Paths.PaymentConfirmation, None,
 		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, donorStore, sessionStore, shareCodeSender))
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -215,7 +215,7 @@ func Register(
 
 	handleWithLpa(page.Paths.DoYouWantToNotifyPeople, CanGoBack,
 		DoYouWantToNotifyPeople(tmpls.Get("do_you_want_to_notify_people.gohtml"), donorStore))
-	handleLpa(page.Paths.ChoosePeopleToNotify, CanGoBack,
+	handleWithLpa(page.Paths.ChoosePeopleToNotify, CanGoBack,
 		ChoosePeopleToNotify(tmpls.Get("choose_people_to_notify.gohtml"), donorStore, random.UuidString))
 	handleLpa(page.Paths.ChoosePeopleToNotifyAddress, CanGoBack,
 		ChoosePeopleToNotifyAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -202,7 +202,7 @@ func Register(
 
 	handleWithLpa(page.Paths.WhoDoYouWantToBeCertificateProviderGuidance, None,
 		WhoDoYouWantToBeCertificateProviderGuidance(tmpls.Get("who_do_you_want_to_be_certificate_provider_guidance.gohtml"), donorStore))
-	handleLpa(page.Paths.CertificateProviderDetails, CanGoBack,
+	handleWithLpa(page.Paths.CertificateProviderDetails, CanGoBack,
 		CertificateProviderDetails(tmpls.Get("certificate_provider_details.gohtml"), donorStore))
 	handleLpa(page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole, CanGoBack,
 		HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpls.Get("how_would_certificate_provider_prefer_to_carry_out_their_role.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -188,7 +188,7 @@ func Register(
 		HowShouldReplacementAttorneysStepIn(tmpls.Get("how_should_replacement_attorneys_step_in.gohtml"), donorStore))
 	handleWithLpa(page.Paths.HowShouldReplacementAttorneysMakeDecisions, CanGoBack,
 		HowShouldReplacementAttorneysMakeDecisions(tmpls.Get("how_should_replacement_attorneys_make_decisions.gohtml"), donorStore))
-	handleLpa(page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan, CanGoBack,
+	handleWithLpa(page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_replacement_attorney_cant_act_none_can.gohtml"), donorStore))
 	handleLpa(page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -254,7 +254,7 @@ func Register(
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, donorStore))
 	handleLpa(page.Paths.IdentityWithOneLogin, CanGoBack,
 		IdentityWithOneLogin(logger, oneLoginClient, sessionStore, random.String))
-	handleLpa(page.Paths.IdentityWithOneLoginCallback, CanGoBack,
+	handleWithLpa(page.Paths.IdentityWithOneLoginCallback, CanGoBack,
 		IdentityWithOneLoginCallback(tmpls.Get("identity_with_one_login_callback.gohtml"), oneLoginClient, sessionStore, donorStore))
 
 	for path, identityOption := range map[string]identity.Option{

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -178,7 +178,7 @@ func Register(
 		WantReplacementAttorneys(tmpls.Get("do_you_want_replacement_attorneys.gohtml"), donorStore))
 	handleWithLpa(page.Paths.ChooseReplacementAttorneys, CanGoBack,
 		ChooseReplacementAttorneys(tmpls.Get("choose_replacement_attorneys.gohtml"), donorStore, random.UuidString))
-	handleLpa(page.Paths.ChooseReplacementAttorneysAddress, CanGoBack,
+	handleWithLpa(page.Paths.ChooseReplacementAttorneysAddress, CanGoBack,
 		ChooseReplacementAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleLpa(page.Paths.ChooseReplacementAttorneysSummary, CanGoBack,
 		ChooseReplacementAttorneysSummary(logger, tmpls.Get("choose_replacement_attorneys_summary.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -193,7 +193,7 @@ func Register(
 	handleWithLpa(page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.gohtml"), donorStore))
 
-	handleLpa(page.Paths.WhenCanTheLpaBeUsed, None,
+	handleWithLpa(page.Paths.WhenCanTheLpaBeUsed, None,
 		WhenCanTheLpaBeUsed(tmpls.Get("when_can_the_lpa_be_used.gohtml"), donorStore))
 	handleLpa(page.Paths.LifeSustainingTreatment, None,
 		LifeSustainingTreatment(tmpls.Get("life_sustaining_treatment.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -190,7 +190,7 @@ func Register(
 		HowShouldReplacementAttorneysMakeDecisions(tmpls.Get("how_should_replacement_attorneys_make_decisions.gohtml"), donorStore))
 	handleWithLpa(page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_replacement_attorney_cant_act_none_can.gohtml"), donorStore))
-	handleLpa(page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct, CanGoBack,
+	handleWithLpa(page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.gohtml"), donorStore))
 
 	handleLpa(page.Paths.WhenCanTheLpaBeUsed, None,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -206,7 +206,7 @@ func Register(
 		CertificateProviderDetails(tmpls.Get("certificate_provider_details.gohtml"), donorStore))
 	handleWithLpa(page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole, CanGoBack,
 		HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpls.Get("how_would_certificate_provider_prefer_to_carry_out_their_role.gohtml"), donorStore))
-	handleLpa(page.Paths.CertificateProviderAddress, CanGoBack,
+	handleWithLpa(page.Paths.CertificateProviderAddress, CanGoBack,
 		CertificateProviderAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleLpa(page.Paths.HowDoYouKnowYourCertificateProvider, CanGoBack,
 		HowDoYouKnowYourCertificateProvider(tmpls.Get("how_do_you_know_your_certificate_provider.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -208,7 +208,7 @@ func Register(
 		HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpls.Get("how_would_certificate_provider_prefer_to_carry_out_their_role.gohtml"), donorStore))
 	handleWithLpa(page.Paths.CertificateProviderAddress, CanGoBack,
 		CertificateProviderAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
-	handleLpa(page.Paths.HowDoYouKnowYourCertificateProvider, CanGoBack,
+	handleWithLpa(page.Paths.HowDoYouKnowYourCertificateProvider, CanGoBack,
 		HowDoYouKnowYourCertificateProvider(tmpls.Get("how_do_you_know_your_certificate_provider.gohtml"), donorStore))
 	handleLpa(page.Paths.HowLongHaveYouKnownCertificateProvider, CanGoBack,
 		HowLongHaveYouKnownCertificateProvider(tmpls.Get("how_long_have_you_known_certificate_provider.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -163,8 +163,8 @@ func Register(
 		ChooseAttorneys(tmpls.Get("choose_attorneys.gohtml"), donorStore, random.UuidString))
 	handleWithLpa(page.Paths.ChooseAttorneysAddress, CanGoBack,
 		ChooseAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
-	handleLpa(page.Paths.ChooseAttorneysSummary, CanGoBack,
-		ChooseAttorneysSummary(logger, tmpls.Get("choose_attorneys_summary.gohtml"), donorStore))
+	handleWithLpa(page.Paths.ChooseAttorneysSummary, CanGoBack,
+		ChooseAttorneysSummary(tmpls.Get("choose_attorneys_summary.gohtml")))
 	handleLpa(page.Paths.RemoveAttorney, CanGoBack,
 		RemoveAttorney(logger, tmpls.Get("remove_attorney.gohtml"), donorStore))
 	handleLpa(page.Paths.HowShouldAttorneysMakeDecisions, CanGoBack,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -165,7 +165,7 @@ func Register(
 		ChooseAttorneysAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))
 	handleWithLpa(page.Paths.ChooseAttorneysSummary, CanGoBack,
 		ChooseAttorneysSummary(tmpls.Get("choose_attorneys_summary.gohtml")))
-	handleLpa(page.Paths.RemoveAttorney, CanGoBack,
+	handleWithLpa(page.Paths.RemoveAttorney, CanGoBack,
 		RemoveAttorney(logger, tmpls.Get("remove_attorney.gohtml"), donorStore))
 	handleLpa(page.Paths.HowShouldAttorneysMakeDecisions, CanGoBack,
 		HowShouldAttorneysMakeDecisions(tmpls.Get("how_should_attorneys_make_decisions.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -204,7 +204,7 @@ func Register(
 		WhoDoYouWantToBeCertificateProviderGuidance(tmpls.Get("who_do_you_want_to_be_certificate_provider_guidance.gohtml"), donorStore))
 	handleWithLpa(page.Paths.CertificateProviderDetails, CanGoBack,
 		CertificateProviderDetails(tmpls.Get("certificate_provider_details.gohtml"), donorStore))
-	handleLpa(page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole, CanGoBack,
+	handleWithLpa(page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole, CanGoBack,
 		HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpls.Get("how_would_certificate_provider_prefer_to_carry_out_their_role.gohtml"), donorStore))
 	handleLpa(page.Paths.CertificateProviderAddress, CanGoBack,
 		CertificateProviderAddress(logger, tmpls.Get("choose_address.gohtml"), addressClient, donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -167,7 +167,7 @@ func Register(
 		ChooseAttorneysSummary(tmpls.Get("choose_attorneys_summary.gohtml")))
 	handleWithLpa(page.Paths.RemoveAttorney, CanGoBack,
 		RemoveAttorney(logger, tmpls.Get("remove_attorney.gohtml"), donorStore))
-	handleLpa(page.Paths.HowShouldAttorneysMakeDecisions, CanGoBack,
+	handleWithLpa(page.Paths.HowShouldAttorneysMakeDecisions, CanGoBack,
 		HowShouldAttorneysMakeDecisions(tmpls.Get("how_should_attorneys_make_decisions.gohtml"), donorStore))
 	handleLpa(page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_attorney_cant_act_none_can.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -278,8 +278,8 @@ func Register(
 		WitnessingYourSignature(tmpls.Get("witnessing_your_signature.gohtml"), witnessCodeSender))
 	handleWithLpa(page.Paths.WitnessingAsCertificateProvider, None,
 		WitnessingAsCertificateProvider(tmpls.Get("witnessing_as_certificate_provider.gohtml"), donorStore, shareCodeSender, time.Now, certificateProviderStore))
-	handleLpa(page.Paths.ResendWitnessCode, CanGoBack,
-		ResendWitnessCode(tmpls.Get("resend_witness_code.gohtml"), donorStore, witnessCodeSender, time.Now))
+	handleWithLpa(page.Paths.ResendWitnessCode, CanGoBack,
+		ResendWitnessCode(tmpls.Get("resend_witness_code.gohtml"), witnessCodeSender, time.Now))
 	handleWithLpa(page.Paths.YouHaveSubmittedYourLpa, None,
 		Guidance(tmpls.Get("you_have_submitted_your_lpa.gohtml")))
 

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -275,8 +275,8 @@ func Register(
 	handleWithLpa(page.Paths.SignYourLpa, CanGoBack,
 		SignYourLpa(tmpls.Get("sign_your_lpa.gohtml"), donorStore))
 	handleWithLpa(page.Paths.WitnessingYourSignature, None,
-		WitnessingYourSignature(tmpls.Get("witnessing_your_signature.gohtml"), donorStore, witnessCodeSender))
-	handleLpa(page.Paths.WitnessingAsCertificateProvider, None,
+		WitnessingYourSignature(tmpls.Get("witnessing_your_signature.gohtml"), witnessCodeSender))
+	handleWithLpa(page.Paths.WitnessingAsCertificateProvider, None,
 		WitnessingAsCertificateProvider(tmpls.Get("witnessing_as_certificate_provider.gohtml"), donorStore, shareCodeSender, time.Now, certificateProviderStore))
 	handleLpa(page.Paths.ResendWitnessCode, CanGoBack,
 		ResendWitnessCode(tmpls.Get("resend_witness_code.gohtml"), donorStore, witnessCodeSender, time.Now))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -186,7 +186,7 @@ func Register(
 		RemoveReplacementAttorney(logger, tmpls.Get("remove_replacement_attorney.gohtml"), donorStore))
 	handleWithLpa(page.Paths.HowShouldReplacementAttorneysStepIn, CanGoBack,
 		HowShouldReplacementAttorneysStepIn(tmpls.Get("how_should_replacement_attorneys_step_in.gohtml"), donorStore))
-	handleLpa(page.Paths.HowShouldReplacementAttorneysMakeDecisions, CanGoBack,
+	handleWithLpa(page.Paths.HowShouldReplacementAttorneysMakeDecisions, CanGoBack,
 		HowShouldReplacementAttorneysMakeDecisions(tmpls.Get("how_should_replacement_attorneys_make_decisions.gohtml"), donorStore))
 	handleLpa(page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_replacement_attorney_cant_act_none_can.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -169,7 +169,7 @@ func Register(
 		RemoveAttorney(logger, tmpls.Get("remove_attorney.gohtml"), donorStore))
 	handleWithLpa(page.Paths.HowShouldAttorneysMakeDecisions, CanGoBack,
 		HowShouldAttorneysMakeDecisions(tmpls.Get("how_should_attorneys_make_decisions.gohtml"), donorStore))
-	handleLpa(page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan, CanGoBack,
+	handleWithLpa(page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_attorney_cant_act_none_can.gohtml"), donorStore))
 	handleLpa(page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_attorneys_can_continue_to_act.gohtml"), donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -171,7 +171,7 @@ func Register(
 		HowShouldAttorneysMakeDecisions(tmpls.Get("how_should_attorneys_make_decisions.gohtml"), donorStore))
 	handleWithLpa(page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan, CanGoBack,
 		AreYouHappyIfOneAttorneyCantActNoneCan(tmpls.Get("are_you_happy_if_one_attorney_cant_act_none_can.gohtml"), donorStore))
-	handleLpa(page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct, CanGoBack,
+	handleWithLpa(page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct, CanGoBack,
 		AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpls.Get("are_you_happy_if_remaining_attorneys_can_continue_to_act.gohtml"), donorStore))
 
 	handleLpa(page.Paths.DoYouWantReplacementAttorneys, None,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -229,7 +229,7 @@ func Register(
 
 	handleWithLpa(page.Paths.AboutPayment, CanGoBack,
 		AboutPayment(logger, tmpls.Get("about_payment.gohtml"), sessionStore, payClient, appPublicUrl, random.String))
-	handleLpa(page.Paths.PaymentConfirmation, None,
+	handleWithLpa(page.Paths.PaymentConfirmation, None,
 		PaymentConfirmation(logger, tmpls.Get("payment_confirmation.gohtml"), payClient, donorStore, sessionStore, shareCodeSender))
 
 	handleLpa(page.Paths.HowToConfirmYourIdentityAndSign, None,

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -274,7 +274,7 @@ func Register(
 		Guidance(tmpls.Get("your_legal_rights_and_responsibilities.gohtml")))
 	handleWithLpa(page.Paths.SignYourLpa, CanGoBack,
 		SignYourLpa(tmpls.Get("sign_your_lpa.gohtml"), donorStore))
-	handleLpa(page.Paths.WitnessingYourSignature, None,
+	handleWithLpa(page.Paths.WitnessingYourSignature, None,
 		WitnessingYourSignature(tmpls.Get("witnessing_your_signature.gohtml"), donorStore, witnessCodeSender))
 	handleLpa(page.Paths.WitnessingAsCertificateProvider, None,
 		WitnessingAsCertificateProvider(tmpls.Get("witnessing_as_certificate_provider.gohtml"), donorStore, shareCodeSender, time.Now, certificateProviderStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -147,7 +147,7 @@ func Register(
 	handleWithLpa := makeLpaHandle(lpaMux, sessionStore, RequireSession, errorHandler, donorStore, uidClient, logger)
 
 	handleLpa(page.Paths.Root, None, notFoundHandler)
-	handleLpa(page.Paths.YourDetails, None,
+	handleWithLpa(page.Paths.YourDetails, None,
 		YourDetails(tmpls.Get("your_details.gohtml"), donorStore, sessionStore))
 	handleLpa(page.Paths.YourAddress, None,
 		YourAddress(logger, tmpls.Get("your_address.gohtml"), addressClient, donorStore))

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -224,7 +224,7 @@ func Register(
 	handleWithLpa(page.Paths.RemovePersonToNotify, CanGoBack,
 		RemovePersonToNotify(logger, tmpls.Get("remove_person_to_notify.gohtml"), donorStore))
 
-	handleLpa(page.Paths.CheckYourLpa, CanGoBack,
+	handleWithLpa(page.Paths.CheckYourLpa, CanGoBack,
 		CheckYourLpa(tmpls.Get("check_your_lpa.gohtml"), donorStore))
 
 	handleLpa(page.Paths.AboutPayment, CanGoBack,

--- a/app/internal/page/donor/remove_attorney.go
+++ b/app/internal/page/donor/remove_attorney.go
@@ -17,14 +17,8 @@ type removeAttorneyData struct {
 	Form     *removeAttorneyForm
 }
 
-func RemoveAttorney(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func RemoveAttorney(logger Logger, tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		id := r.FormValue("id")
 		attorney, found := lpa.Attorneys.Get(id)
 

--- a/app/internal/page/donor/remove_attorney_test.go
+++ b/app/internal/page/donor/remove_attorney_test.go
@@ -38,40 +38,11 @@ func TestGetRemoveAttorney(t *testing.T) {
 		}).
 		Return(nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorney}}, nil)
-
-	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
+	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorney}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetRemoveAttorneyErrorOnStore(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
-
-	logger := newMockLogger(t)
-	logger.
-		On("Print", "error getting lpa from store: err").
-		Return(nil)
-
-	template := newMockTemplate(t)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
-
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -90,12 +61,7 @@ func TestGetRemoveAttorneyAttorneyDoesNotExist(t *testing.T) {
 		},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorney}}, nil)
-
-	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
+	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorney}})
 
 	resp := w.Result()
 
@@ -161,13 +127,10 @@ func TestPostRemoveAttorney(t *testing.T) {
 
 			donorStore := newMockDonorStore(t)
 			donorStore.
-				On("Get", r.Context()).
-				Return(tc.lpa, nil)
-			donorStore.
 				On("Put", r.Context(), tc.updatedLpa).
 				Return(nil)
 
-			err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
+			err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r, tc.lpa)
 
 			resp := w.Result()
 
@@ -202,12 +165,7 @@ func TestPostRemoveAttorneyWithFormValueNo(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}}, nil)
-
-	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
+	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
 
 	resp := w.Result()
 
@@ -246,13 +204,10 @@ func TestPostRemoveAttorneyErrorOnPutStore(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r)
+	err := RemoveAttorney(logger, template.Execute, donorStore)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
 
 	resp := w.Result()
 
@@ -274,11 +229,6 @@ func TestRemoveAttorneyFormValidation(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress}}, nil)
-
 	validationError := validation.With("remove-attorney", validation.SelectError{Label: "yesToRemoveAttorney"})
 
 	template := newMockTemplate(t)
@@ -288,7 +238,7 @@ func TestRemoveAttorneyFormValidation(t *testing.T) {
 		})).
 		Return(nil)
 
-	err := RemoveAttorney(nil, template.Execute, donorStore)(testAppData, w, r)
+	err := RemoveAttorney(nil, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress}})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/remove_person_to_notify.go
+++ b/app/internal/page/donor/remove_person_to_notify.go
@@ -17,14 +17,8 @@ type removePersonToNotifyData struct {
 	Form           *removePersonToNotifyForm
 }
 
-func RemovePersonToNotify(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func RemovePersonToNotify(logger Logger, tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		id := r.FormValue("id")
 		person, found := lpa.PeopleToNotify.Get(id)
 

--- a/app/internal/page/donor/remove_replacement_attorney.go
+++ b/app/internal/page/donor/remove_replacement_attorney.go
@@ -17,14 +17,8 @@ type removeReplacementAttorneyData struct {
 	Form     *removeAttorneyForm
 }
 
-func RemoveReplacementAttorney(logger Logger, tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			logger.Print(fmt.Sprintf("error getting lpa from store: %s", err.Error()))
-			return err
-		}
-
+func RemoveReplacementAttorney(logger Logger, tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		id := r.FormValue("id")
 		attorney, found := lpa.ReplacementAttorneys.Get(id)
 

--- a/app/internal/page/donor/resend_witness_code.go
+++ b/app/internal/page/donor/resend_witness_code.go
@@ -14,13 +14,8 @@ type resendWitnessCodeData struct {
 	Errors validation.List
 }
 
-func ResendWitnessCode(tmpl template.Template, donorStore DonorStore, witnessCodeSender WitnessCodeSender, now func() time.Time) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func ResendWitnessCode(tmpl template.Template, witnessCodeSender WitnessCodeSender, now func() time.Time) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &resendWitnessCodeData{
 			App: appData,
 		}

--- a/app/internal/page/donor/restrictions.go
+++ b/app/internal/page/donor/restrictions.go
@@ -15,13 +15,8 @@ type restrictionsData struct {
 	Lpa    *page.Lpa
 }
 
-func Restrictions(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func Restrictions(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &restrictionsData{
 			App: appData,
 			Lpa: lpa,

--- a/app/internal/page/donor/select_your_identity_options.go
+++ b/app/internal/page/donor/select_your_identity_options.go
@@ -17,13 +17,8 @@ type selectYourIdentityOptionsData struct {
 	Page   int
 }
 
-func SelectYourIdentityOptions(tmpl template.Template, donorStore DonorStore, pageIndex int) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func SelectYourIdentityOptions(tmpl template.Template, donorStore DonorStore, pageIndex int) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &selectYourIdentityOptionsData{
 			App:  appData,
 			Page: pageIndex,

--- a/app/internal/page/donor/select_your_identity_options_test.go
+++ b/app/internal/page/donor/select_your_identity_options_test.go
@@ -20,11 +20,6 @@ func TestGetSelectYourIdentityOptions(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &selectYourIdentityOptionsData{
@@ -34,37 +29,16 @@ func TestGetSelectYourIdentityOptions(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SelectYourIdentityOptions(template.Execute, donorStore, 2)(testAppData, w, r)
+	err := SelectYourIdentityOptions(template.Execute, nil, 2)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetSelectYourIdentityOptionsWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r)
-
-	assert.Equal(t, expectedError, err)
-}
-
 func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			DonorIdentityOption: identity.Passport,
-		}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -74,7 +48,9 @@ func TestGetSelectYourIdentityOptionsFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SelectYourIdentityOptions(template.Execute, donorStore, 0)(testAppData, w, r)
+	err := SelectYourIdentityOptions(template.Execute, nil, 0)(testAppData, w, r, &page.Lpa{
+		DonorIdentityOption: identity.Passport,
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -85,17 +61,12 @@ func TestGetSelectYourIdentityOptionsWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.Anything).
 		Return(expectedError)
 
-	err := SelectYourIdentityOptions(template.Execute, donorStore, 0)(testAppData, w, r)
+	err := SelectYourIdentityOptions(template.Execute, nil, 0)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -113,9 +84,6 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{
 			DonorIdentityOption: identity.Passport,
 			Tasks: page.Tasks{
@@ -124,7 +92,7 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r)
+	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -147,12 +115,7 @@ func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-			donorStore := newMockDonorStore(t)
-			donorStore.
-				On("Get", r.Context()).
-				Return(&page.Lpa{}, nil)
-
-			err := SelectYourIdentityOptions(nil, donorStore, pageIndex)(testAppData, w, r)
+			err := SelectYourIdentityOptions(nil, nil, pageIndex)(testAppData, w, r, &page.Lpa{})
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -173,13 +136,10 @@ func TestPostSelectYourIdentityOptionsWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r)
+	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -188,11 +148,6 @@ func TestPostSelectYourIdentityOptionsWhenValidationErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -203,7 +158,7 @@ func TestPostSelectYourIdentityOptionsWhenValidationErrors(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SelectYourIdentityOptions(template.Execute, donorStore, 0)(testAppData, w, r)
+	err := SelectYourIdentityOptions(template.Execute, nil, 0)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/sign_your_lpa.go
+++ b/app/internal/page/donor/sign_your_lpa.go
@@ -23,13 +23,8 @@ const (
 	WantToApplyForLpa = "want-to-apply"
 )
 
-func SignYourLpa(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func SignYourLpa(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &signYourLpaData{
 			App: appData,
 			Lpa: lpa,
@@ -54,7 +49,7 @@ func SignYourLpa(tmpl template.Template, donorStore DonorStore) page.Handler {
 				lpa.Tasks.ConfirmYourIdentityAndSign = actor.TaskCompleted
 			}
 
-			if err = donorStore.Put(r.Context(), lpa); err != nil {
+			if err := donorStore.Put(r.Context(), lpa); err != nil {
 				return err
 			}
 

--- a/app/internal/page/donor/task_list.go
+++ b/app/internal/page/donor/task_list.go
@@ -28,13 +28,8 @@ type taskListSection struct {
 	Items   []taskListItem
 }
 
-func TaskList(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func TaskList(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		signTaskPage := page.Paths.HowToConfirmYourIdentityAndSign
 		if lpa.DonorIdentityConfirmed() {
 			signTaskPage = page.Paths.ReadYourLpa

--- a/app/internal/page/donor/task_list_test.go
+++ b/app/internal/page/donor/task_list_test.go
@@ -90,11 +90,6 @@ func TestGetTaskList(t *testing.T) {
 			w := httptest.NewRecorder()
 			r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-			donorStore := newMockDonorStore(t)
-			donorStore.
-				On("Get", r.Context()).
-				Return(tc.lpa, nil)
-
 			template := newMockTemplate(t)
 			template.
 				On("Execute", w, &taskListData{
@@ -130,7 +125,7 @@ func TestGetTaskList(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := TaskList(template.Execute, donorStore)(testAppData, w, r)
+			err := TaskList(template.Execute)(testAppData, w, r, tc.lpa)
 			resp := w.Result()
 
 			assert.Nil(t, err)
@@ -139,35 +134,16 @@ func TestGetTaskList(t *testing.T) {
 	}
 }
 
-func TestGetTaskListWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := TaskList(nil, donorStore)(testAppData, w, r)
-
-	assert.Equal(t, expectedError, err)
-}
-
 func TestGetTaskListWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.Anything).
 		Return(expectedError)
 
-	err := TaskList(template.Execute, donorStore)(testAppData, w, r)
+	err := TaskList(template.Execute)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)

--- a/app/internal/page/donor/want_replacement_attorneys.go
+++ b/app/internal/page/donor/want_replacement_attorneys.go
@@ -16,13 +16,8 @@ type wantReplacementAttorneysData struct {
 	Lpa    *page.Lpa
 }
 
-func WantReplacementAttorneys(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WantReplacementAttorneys(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &wantReplacementAttorneysData{
 			App:  appData,
 			Want: lpa.WantReplacementAttorneys,

--- a/app/internal/page/donor/when_can_the_lpa_be_used.go
+++ b/app/internal/page/donor/when_can_the_lpa_be_used.go
@@ -16,13 +16,8 @@ type whenCanTheLpaBeUsedData struct {
 	Lpa    *page.Lpa
 }
 
-func WhenCanTheLpaBeUsed(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WhenCanTheLpaBeUsed(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &whenCanTheLpaBeUsedData{
 			App:  appData,
 			When: lpa.WhenCanTheLpaBeUsed,

--- a/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance.go
+++ b/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance.go
@@ -15,13 +15,8 @@ type whoDoYouWantToBeCertificateProviderGuidanceData struct {
 	Lpa    *page.Lpa
 }
 
-func WhoDoYouWantToBeCertificateProviderGuidance(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WhoDoYouWantToBeCertificateProviderGuidance(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &whoDoYouWantToBeCertificateProviderGuidanceData{
 			App: appData,
 			Lpa: lpa,

--- a/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance_test.go
+++ b/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance_test.go
@@ -36,11 +36,6 @@ func TestGetWhoDoYouWantToBeCertificateProviderGuidance(t *testing.T) {
 			w := httptest.NewRecorder()
 			r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-			donorStore := newMockDonorStore(t)
-			donorStore.
-				On("Get", r.Context()).
-				Return(tc.data, nil)
-
 			template := newMockTemplate(t)
 			template.
 				On("Execute", w, &whoDoYouWantToBeCertificateProviderGuidanceData{
@@ -49,47 +44,25 @@ func TestGetWhoDoYouWantToBeCertificateProviderGuidance(t *testing.T) {
 				}).
 				Return(nil)
 
-			err := WhoDoYouWantToBeCertificateProviderGuidance(template.Execute, donorStore)(testAppData, w, r)
+			err := WhoDoYouWantToBeCertificateProviderGuidance(template.Execute, nil)(testAppData, w, r, tc.data)
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
-
 		})
 	}
-}
-
-func TestGetWhoDoYouWantToBeCertificateProviderGuidanceWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestGetWhoDoYouWantToBeCertificateProviderGuidanceWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.Anything).
 		Return(expectedError)
 
-	err := WhoDoYouWantToBeCertificateProviderGuidance(template.Execute, donorStore)(testAppData, w, r)
+	err := WhoDoYouWantToBeCertificateProviderGuidance(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -103,13 +76,10 @@ func TestPostWhoDoYouWantToBeCertificateProviderGuidance(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{Tasks: page.Tasks{CertificateProvider: actor.TaskInProgress}}).
 		Return(nil)
 
-	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r)
+	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -124,13 +94,10 @@ func TestPostWhoDoYouWantToBeCertificateProviderGuidanceWhenStoreErrors(t *testi
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), mock.Anything).
 		Return(expectedError)
 
-	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r)
+	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/who_is_the_lpa_for.go
+++ b/app/internal/page/donor/who_is_the_lpa_for.go
@@ -14,13 +14,8 @@ type whoIsTheLpaForData struct {
 	WhoFor string
 }
 
-func WhoIsTheLpaFor(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WhoIsTheLpaFor(tmpl template.Template, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &whoIsTheLpaForData{
 			App:    appData,
 			WhoFor: lpa.WhoFor,

--- a/app/internal/page/donor/who_is_the_lpa_for_test.go
+++ b/app/internal/page/donor/who_is_the_lpa_for_test.go
@@ -16,11 +16,6 @@ func TestGetWhoIsTheLpaFor(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &whoIsTheLpaForData{
@@ -28,37 +23,16 @@ func TestGetWhoIsTheLpaFor(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := WhoIsTheLpaFor(template.Execute, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetWhoIsTheLpaForWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r)
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestGetWhoIsTheLpaForFromStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{WhoFor: "me"}, nil)
 
 	template := newMockTemplate(t)
 	template.
@@ -68,7 +42,7 @@ func TestGetWhoIsTheLpaForFromStore(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := WhoIsTheLpaFor(template.Execute, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(template.Execute, nil)(testAppData, w, r, &page.Lpa{WhoFor: "me"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -79,11 +53,6 @@ func TestGetWhoIsTheLpaForWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &whoIsTheLpaForData{
@@ -91,7 +60,7 @@ func TestGetWhoIsTheLpaForWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	err := WhoIsTheLpaFor(template.Execute, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -109,13 +78,10 @@ func TestPostWhoIsTheLpaFor(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{WhoFor: "me"}).
 		Return(nil)
 
-	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -134,13 +100,10 @@ func TestPostWhoIsTheLpaForWhenStoreErrors(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-	donorStore.
 		On("Put", r.Context(), &page.Lpa{WhoFor: "me"}).
 		Return(expectedError)
 
-	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r, &page.Lpa{})
 
 	assert.Equal(t, expectedError, err)
 }
@@ -150,11 +113,6 @@ func TestPostWhoIsTheLpaForWhenValidationErrors(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &whoIsTheLpaForData{
@@ -163,7 +121,7 @@ func TestPostWhoIsTheLpaForWhenValidationErrors(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := WhoIsTheLpaFor(template.Execute, donorStore)(testAppData, w, r)
+	err := WhoIsTheLpaFor(template.Execute, nil)(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/witnessing_as_certificate_provider.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider.go
@@ -19,13 +19,8 @@ type witnessingAsCertificateProviderData struct {
 	Lpa    *page.Lpa
 }
 
-func WitnessingAsCertificateProvider(tmpl template.Template, donorStore DonorStore, shareCodeSender ShareCodeSender, now func() time.Time, certificateProviderStore CertificateProviderStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WitnessingAsCertificateProvider(tmpl template.Template, donorStore DonorStore, shareCodeSender ShareCodeSender, now func() time.Time, certificateProviderStore CertificateProviderStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &witnessingAsCertificateProviderData{
 			App:  appData,
 			Lpa:  lpa,

--- a/app/internal/page/donor/witnessing_your_signature.go
+++ b/app/internal/page/donor/witnessing_your_signature.go
@@ -14,13 +14,8 @@ type witnessingYourSignatureData struct {
 	Lpa    *page.Lpa
 }
 
-func WitnessingYourSignature(tmpl template.Template, donorStore DonorStore, witnessCodeSender WitnessCodeSender) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func WitnessingYourSignature(tmpl template.Template, witnessCodeSender WitnessCodeSender) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			if err := witnessCodeSender.Send(r.Context(), lpa, appData.Localizer); err != nil {
 				return err

--- a/app/internal/page/donor/witnessing_your_signature_test.go
+++ b/app/internal/page/donor/witnessing_your_signature_test.go
@@ -21,35 +21,16 @@ func TestGetWitnessingYourSignature(t *testing.T) {
 
 	lpa := &page.Lpa{CertificateProvider: actor.CertificateProvider{Mobile: "07535111111"}}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &witnessingYourSignatureData{App: testAppData, Lpa: lpa}).
 		Return(nil)
 
-	err := WitnessingYourSignature(template.Execute, donorStore, nil)(testAppData, w, r)
+	err := WitnessingYourSignature(template.Execute, nil)(testAppData, w, r, lpa)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestGetWitnessingYourSignatureWhenDonorStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := WitnessingYourSignature(nil, donorStore, nil)(testAppData, w, r)
-
-	assert.Equal(t, expectedError, err)
 }
 
 func TestGetWitnessingYourSignatureWhenTemplateErrors(t *testing.T) {
@@ -58,17 +39,12 @@ func TestGetWitnessingYourSignatureWhenTemplateErrors(t *testing.T) {
 
 	lpa := &page.Lpa{CertificateProvider: actor.CertificateProvider{Mobile: "07535111111"}}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &witnessingYourSignatureData{App: testAppData, Lpa: lpa}).
 		Return(expectedError)
 
-	err := WitnessingYourSignature(template.Execute, donorStore, nil)(testAppData, w, r)
+	err := WitnessingYourSignature(template.Execute, nil)(testAppData, w, r, lpa)
 
 	assert.Equal(t, expectedError, err)
 }
@@ -82,17 +58,12 @@ func TestPostWitnessingYourSignature(t *testing.T) {
 		CertificateProvider:   actor.CertificateProvider{Mobile: "07535111111"},
 	}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-
 	witnessCodeSender := newMockWitnessCodeSender(t)
 	witnessCodeSender.
 		On("Send", r.Context(), lpa, mock.Anything).
 		Return(nil)
 
-	err := WitnessingYourSignature(nil, donorStore, witnessCodeSender)(testAppData, w, r)
+	err := WitnessingYourSignature(nil, witnessCodeSender)(testAppData, w, r, lpa)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -106,17 +77,12 @@ func TestPostWitnessingYourSignatureWhenWitnessCodeSenderErrors(t *testing.T) {
 
 	lpa := &page.Lpa{CertificateProvider: actor.CertificateProvider{Mobile: "07535111111"}}
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(lpa, nil)
-
 	witnessCodeSender := newMockWitnessCodeSender(t)
 	witnessCodeSender.
 		On("Send", mock.Anything, mock.Anything, mock.Anything).
 		Return(expectedError)
 
-	err := WitnessingYourSignature(nil, donorStore, witnessCodeSender)(testAppData, w, r)
+	err := WitnessingYourSignature(nil, witnessCodeSender)(testAppData, w, r, lpa)
 
 	assert.Equal(t, expectedError, err)
 }

--- a/app/internal/page/donor/your_address.go
+++ b/app/internal/page/donor/your_address.go
@@ -9,13 +9,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 )
 
-func YourAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func YourAddress(logger Logger, tmpl template.Template, addressClient AddressClient, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &chooseAddressData{
 			App:  appData,
 			Form: &form.AddressForm{},

--- a/app/internal/page/donor/your_chosen_identity_options.go
+++ b/app/internal/page/donor/your_chosen_identity_options.go
@@ -17,13 +17,8 @@ type yourChosenIdentityOptionsData struct {
 	You            actor.Donor
 }
 
-func YourChosenIdentityOptions(tmpl template.Template, donorStore DonorStore) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func YourChosenIdentityOptions(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			return appData.Redirect(w, r, lpa, identityOptionPath(appData.Paths, lpa.DonorIdentityOption))
 		}

--- a/app/internal/page/donor/your_chosen_identity_options_test.go
+++ b/app/internal/page/donor/your_chosen_identity_options_test.go
@@ -15,13 +15,6 @@ func TestGetYourChosenIdentityOptions(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			DonorIdentityOption: identity.Passport,
-		}, nil)
-
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, &yourChosenIdentityOptionsData{
@@ -30,44 +23,27 @@ func TestGetYourChosenIdentityOptions(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := YourChosenIdentityOptions(template.Execute, donorStore)(testAppData, w, r)
+	err := YourChosenIdentityOptions(template.Execute)(testAppData, w, r, &page.Lpa{
+		DonorIdentityOption: identity.Passport,
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGetYourChosenIdentityOptionsWhenStoreErrors(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{}, expectedError)
-
-	err := YourChosenIdentityOptions(nil, donorStore)(testAppData, w, r)
-
-	assert.Equal(t, expectedError, err)
-}
-
 func TestGetYourChosenIdentityOptionsWhenTemplateErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			DonorIdentityOption: identity.Passport,
-		}, nil)
 
 	template := newMockTemplate(t)
 	template.
 		On("Execute", w, mock.Anything).
 		Return(expectedError)
 
-	err := YourChosenIdentityOptions(template.Execute, donorStore)(testAppData, w, r)
+	err := YourChosenIdentityOptions(template.Execute)(testAppData, w, r, &page.Lpa{
+		DonorIdentityOption: identity.Passport,
+	})
 	resp := w.Result()
 
 	assert.Equal(t, expectedError, err)
@@ -78,14 +54,9 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	donorStore := newMockDonorStore(t)
-	donorStore.
-		On("Get", r.Context()).
-		Return(&page.Lpa{
-			DonorIdentityOption: identity.Passport,
-		}, nil)
-
-	err := YourChosenIdentityOptions(nil, donorStore)(testAppData, w, r)
+	err := YourChosenIdentityOptions(nil)(testAppData, w, r, &page.Lpa{
+		DonorIdentityOption: identity.Passport,
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/your_details.go
+++ b/app/internal/page/donor/your_details.go
@@ -22,13 +22,8 @@ type yourDetailsData struct {
 	NameWarning *actor.SameNameWarning
 }
 
-func YourDetails(tmpl template.Template, donorStore DonorStore, sessionStore sessions.Store) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
-		lpa, err := donorStore.Get(r.Context())
-		if err != nil {
-			return err
-		}
-
+func YourDetails(tmpl template.Template, donorStore DonorStore, sessionStore sessions.Store) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		data := &yourDetailsData{
 			App: appData,
 			Form: &yourDetailsForm{


### PR DESCRIPTION
# Purpose

Following #522 we extended the pattern introduced in `attorney` to have a base handler that calls `donorStore.Get()` and passes the LPA to the sub-handler. This allows the removal of boilerplate calls at the start of sub-handlers and removes duplicated tests.

Fixes MLPAB-1054
