### PR TITLE
MLPAB-1072 - Fix issues with app insights

### DIFF
--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -2,5 +2,6 @@ resource "aws_applicationinsights_application" "environment" {
   resource_group_name = aws_resourcegroups_group.environment.name
   auto_config_enabled = true
   cwe_monitor_enabled = true
-  provider            = aws.region
+  # ops_center_enabled  = false
+  provider = aws.region
 }

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,7 +1,11 @@
 resource "aws_applicationinsights_application" "environment" {
   resource_group_name = aws_resourcegroups_group.environment.name
-  auto_config_enabled = true
+  auto_config_enabled = false # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
   cwe_monitor_enabled = true
-  # ops_center_enabled  = false
+  ops_center_enabled  = false
+  depends_on = [
+    aws_ecs_cluster.main,
+    module.app,
+  ]
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Application Insights fail to be provisioned by the terraform aws provider, causing the deploy job to fail

Fixes MLPAB-1072

## Approach

- turn of auto configure as unsupported states cause a problem

## Learning

there's a bug reported on the aws provider https://github.com/hashicorp/terraform-provider-aws/issues/27277