### PR TITLE
MLPAB-894 Formattable paths

### DIFF
--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -82,7 +82,7 @@ func App(
 
 	rootMux := http.NewServeMux()
 
-	rootMux.Handle(paths.TestingStart, page.TestingStart(sessionStore, donorStore, random.String, shareCodeSender, localizer, certificateProviderStore, attorneyStore, logger, time.Now))
+	rootMux.Handle(paths.TestingStart.String(), page.TestingStart(sessionStore, donorStore, random.String, shareCodeSender, localizer, certificateProviderStore, attorneyStore, logger, time.Now))
 
 	handleRoot := makeHandle(rootMux, errorHandler, sessionStore)
 
@@ -186,18 +186,18 @@ const (
 	RequireSession
 )
 
-func makeHandle(mux *http.ServeMux, errorHandler page.ErrorHandler, store sesh.Store) func(string, handleOpt, page.Handler) {
-	return func(path string, opt handleOpt, h page.Handler) {
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+func makeHandle(mux *http.ServeMux, errorHandler page.ErrorHandler, store sesh.Store) func(page.Path, handleOpt, page.Handler) {
+	return func(path page.Path, opt handleOpt, h page.Handler) {
+		mux.HandleFunc(path.String(), func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			appData := page.AppDataFromContext(ctx)
-			appData.Page = path
+			appData.Page = path.Format()
 
 			if opt&RequireSession != 0 {
 				loginSession, err := sesh.Login(store, r)
 				if err != nil {
-					http.Redirect(w, r, page.Paths.Start, http.StatusFound)
+					http.Redirect(w, r, page.Paths.Start.Format(), http.StatusFound)
 					return
 				}
 

--- a/app/internal/app/app_test.go
+++ b/app/internal/app/app_test.go
@@ -124,7 +124,7 @@ func TestMakeHandleRequireSessionMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleRequireSessionError(t *testing.T) {
@@ -144,7 +144,7 @@ func TestMakeHandleRequireSessionError(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleWhenError(t *testing.T) {

--- a/app/internal/app/dashboard_store.go
+++ b/app/internal/app/dashboard_store.go
@@ -41,6 +41,10 @@ func (s *dashboardStore) GetAll(ctx context.Context) (donor, attorney, certifica
 		keyMap[key.PK] = actorType
 	}
 
+	if len(searchKeys) == 0 {
+		return nil, nil, nil, nil
+	}
+
 	var result []struct {
 		PK   string
 		Data *page.Lpa

--- a/app/internal/app/dashboard_store_test.go
+++ b/app/internal/app/dashboard_store_test.go
@@ -49,3 +49,19 @@ func TestDashboardStoreGetAll(t *testing.T) {
 	assert.Equal(t, []*page.Lpa{lpa789}, attorney)
 	assert.Equal(t, []*page.Lpa{lpa456}, certificateProvider)
 }
+
+func TestDashboardStoreGetAllWhenNone(t *testing.T) {
+	ctx := page.ContextWithSessionData(context.Background(), &page.SessionData{SessionID: "an-id"})
+
+	dataStore := newMockDataStore(t)
+	dataStore.ExpectGetAllByGsi(ctx, "ActorIndex", "#SUB#an-id",
+		[]map[string]any{}, nil)
+
+	dashboardStore := &dashboardStore{dataStore: dataStore}
+
+	donor, attorney, certificateProvider, err := dashboardStore.GetAll(ctx)
+	assert.Nil(t, err)
+	assert.Nil(t, donor)
+	assert.Nil(t, attorney)
+	assert.Nil(t, certificateProvider)
+}

--- a/app/internal/page/app_data.go
+++ b/app/internal/page/app_data.go
@@ -40,7 +40,7 @@ func (d AppData) Redirect(w http.ResponseWriter, r *http.Request, lpa *Lpa, url 
 	if lpa == nil || lpa.CanGoTo(url) {
 		http.Redirect(w, r, d.BuildUrl(url), http.StatusFound)
 	} else {
-		http.Redirect(w, r, d.BuildUrl(Paths.TaskList), http.StatusFound)
+		http.Redirect(w, r, d.BuildUrl(Paths.TaskList.Format(d.LpaID)), http.StatusFound)
 	}
 
 	return nil
@@ -48,23 +48,7 @@ func (d AppData) Redirect(w http.ResponseWriter, r *http.Request, lpa *Lpa, url 
 
 func (d AppData) BuildUrl(url string) string {
 	if d.Lang == localize.Cy {
-		return "/" + localize.Cy.String() + d.BuildUrlWithoutLang(url)
-	}
-
-	return d.BuildUrlWithoutLang(url)
-}
-
-func (d AppData) BuildUrlWithoutLang(url string) string {
-	if IsAttorneyPath(url) {
-		return "/attorney/" + d.LpaID + url
-	}
-
-	if IsCertificateProviderPath(url) {
-		return "/certificate-provider/" + d.LpaID + url
-	}
-
-	if IsLpaPath(url) {
-		return "/lpa/" + d.LpaID + url
+		return "/" + localize.Cy.String() + url
 	}
 
 	return url

--- a/app/internal/page/attorney/check_your_name.go
+++ b/app/internal/page/attorney/check_your_name.go
@@ -32,7 +32,7 @@ func CheckYourName(tmpl template.Template, donorStore DonorStore, attorneyStore 
 
 		attorney, ok := attorneys.Get(appData.AttorneyID)
 		if !ok {
-			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start)
+			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start.Format())
 		}
 
 		data := &checkYourNameData{
@@ -71,8 +71,7 @@ func CheckYourName(tmpl template.Template, donorStore DonorStore, attorneyStore 
 					return err
 				}
 
-				appData.Redirect(w, r, lpa, page.Paths.Attorney.ReadTheLpa)
-				return nil
+				return appData.Redirect(w, r, lpa, page.Paths.Attorney.ReadTheLpa.Format(attorneyProvidedDetails.LpaID))
 			}
 		}
 

--- a/app/internal/page/attorney/check_your_name_test.go
+++ b/app/internal/page/attorney/check_your_name_test.go
@@ -107,7 +107,7 @@ func TestGetCheckYourNameWhenAttorneyDoesNotExist(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -171,6 +171,7 @@ func TestPostCheckYourName(t *testing.T) {
 				Attorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "yes",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
 			},
@@ -181,6 +182,7 @@ func TestPostCheckYourName(t *testing.T) {
 				ReplacementAttorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "yes",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
 			},
@@ -208,12 +210,12 @@ func TestPostCheckYourName(t *testing.T) {
 				On("Put", r.Context(), tc.updatedAttorney).
 				Return(nil)
 
-			err := CheckYourName(nil, donorStore, attorneyStore, nil)(tc.appData, w, r, &actor.AttorneyProvidedDetails{})
+			err := CheckYourName(nil, donorStore, attorneyStore, nil)(tc.appData, w, r, &actor.AttorneyProvidedDetails{LpaID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.ReadTheLpa, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -231,6 +233,7 @@ func TestPostCheckYourNameWithCorrectedName(t *testing.T) {
 				Attorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
@@ -243,6 +246,7 @@ func TestPostCheckYourNameWithCorrectedName(t *testing.T) {
 				ReplacementAttorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
@@ -284,12 +288,12 @@ func TestPostCheckYourNameWithCorrectedName(t *testing.T) {
 				}).
 				Return("", nil)
 
-			err := CheckYourName(nil, donorStore, attorneyStore, notifyClient)(tc.appData, w, r, &actor.AttorneyProvidedDetails{})
+			err := CheckYourName(nil, donorStore, attorneyStore, notifyClient)(tc.appData, w, r, &actor.AttorneyProvidedDetails{LpaID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.ReadTheLpa, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -308,10 +312,12 @@ func TestPostCheckYourNameWithUnchangedCorrectedName(t *testing.T) {
 				Attorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			attorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
@@ -324,10 +330,12 @@ func TestPostCheckYourNameWithUnchangedCorrectedName(t *testing.T) {
 				ReplacementAttorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			attorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:         "lpa-id",
 				IsNameCorrect: "no",
 				CorrectedName: "Bobby Smith",
 				Tasks:         actor.AttorneyTasks{ConfirmYourDetails: actor.TaskCompleted},
@@ -362,7 +370,7 @@ func TestPostCheckYourNameWithUnchangedCorrectedName(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.ReadTheLpa, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/enter_reference_number.go
+++ b/app/internal/page/attorney/enter_reference_number.go
@@ -63,7 +63,7 @@ func EnterReferenceNumber(tmpl template.Template, shareCodeStore ShareCodeStore,
 				}
 
 				appData.LpaID = shareCode.LpaID
-				return appData.Redirect(w, r, nil, page.Paths.Attorney.CodeOfConduct)
+				return appData.Redirect(w, r, nil, page.Paths.Attorney.CodeOfConduct.Format(shareCode.LpaID))
 			}
 		}
 

--- a/app/internal/page/attorney/enter_reference_number_test.go
+++ b/app/internal/page/attorney/enter_reference_number_test.go
@@ -129,7 +129,7 @@ func TestPostEnterReferenceNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.CodeOfConduct, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.CodeOfConduct.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/mobile_number.go
+++ b/app/internal/page/attorney/mobile_number.go
@@ -44,7 +44,7 @@ func MobileNumber(tmpl template.Template, attorneyStore AttorneyStore) Handler {
 					return err
 				}
 
-				return appData.Redirect(w, r, nil, page.Paths.Attorney.CheckYourName)
+				return appData.Redirect(w, r, nil, page.Paths.Attorney.CheckYourName.Format(attorneyProvidedDetails.LpaID))
 			}
 		}
 

--- a/app/internal/page/attorney/mobile_number_test.go
+++ b/app/internal/page/attorney/mobile_number_test.go
@@ -112,8 +112,9 @@ func TestPostMobileNumber(t *testing.T) {
 			form: url.Values{
 				"mobile": {"07535111222"},
 			},
-			attorney: &actor.AttorneyProvidedDetails{},
+			attorney: &actor.AttorneyProvidedDetails{LpaID: "lpa-id"},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:  "lpa-id",
 				Mobile: "07535111222",
 				Tasks: actor.AttorneyTasks{
 					ConfirmYourDetails: actor.TaskInProgress,
@@ -124,11 +125,13 @@ func TestPostMobileNumber(t *testing.T) {
 		"attorney empty": {
 			appData: testAppData,
 			attorney: &actor.AttorneyProvidedDetails{
+				LpaID: "lpa-id",
 				Tasks: actor.AttorneyTasks{
 					ConfirmYourDetails: actor.TaskCompleted,
 				},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID: "lpa-id",
 				Tasks: actor.AttorneyTasks{
 					ConfirmYourDetails: actor.TaskCompleted,
 				},
@@ -138,8 +141,9 @@ func TestPostMobileNumber(t *testing.T) {
 			form: url.Values{
 				"mobile": {"07535111222"},
 			},
-			attorney: &actor.AttorneyProvidedDetails{},
+			attorney: &actor.AttorneyProvidedDetails{LpaID: "lpa-id"},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:  "lpa-id",
 				Mobile: "07535111222",
 				Tasks: actor.AttorneyTasks{
 					ConfirmYourDetails: actor.TaskInProgress,
@@ -149,8 +153,9 @@ func TestPostMobileNumber(t *testing.T) {
 		},
 		"replacement attorney empty": {
 			appData:  testReplacementAppData,
-			attorney: &actor.AttorneyProvidedDetails{},
+			attorney: &actor.AttorneyProvidedDetails{LpaID: "lpa-id"},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID: "lpa-id",
 				Tasks: actor.AttorneyTasks{
 					ConfirmYourDetails: actor.TaskInProgress,
 				},
@@ -174,7 +179,7 @@ func TestPostMobileNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.CheckYourName, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.CheckYourName.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/read_the_lpa.go
+++ b/app/internal/page/attorney/read_the_lpa.go
@@ -30,7 +30,7 @@ func ReadTheLpa(tmpl template.Template, donorStore DonorStore, attorneyStore Att
 
 		attorney, ok := attorneys.Get(appData.AttorneyID)
 		if !ok {
-			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start)
+			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start.Format())
 		}
 
 		data := &readTheLpaData{
@@ -46,7 +46,7 @@ func ReadTheLpa(tmpl template.Template, donorStore DonorStore, attorneyStore Att
 				return err
 			}
 
-			return appData.Redirect(w, r, lpa, page.Paths.Attorney.RightsAndResponsibilities)
+			return appData.Redirect(w, r, lpa, page.Paths.Attorney.RightsAndResponsibilities.Format(attorneyProvidedDetails.LpaID))
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/attorney/read_the_lpa_test.go
+++ b/app/internal/page/attorney/read_the_lpa_test.go
@@ -90,7 +90,7 @@ func TestGetReadTheLpaWhenAttorneyNotFound(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestGetReadTheLpaWhenTemplateError(t *testing.T) {
@@ -130,18 +130,19 @@ func TestPostReadTheLpaWithAttorney(t *testing.T) {
 	attorneyStore := newMockAttorneyStore(t)
 	attorneyStore.
 		On("Put", r.Context(), &actor.AttorneyProvidedDetails{
+			LpaID: "lpa-id",
 			Tasks: actor.AttorneyTasks{
 				ReadTheLpa: actor.TaskCompleted,
 			},
 		}).
 		Return(nil)
 
-	err := ReadTheLpa(nil, donorStore, attorneyStore)(testAppData, w, r, &actor.AttorneyProvidedDetails{})
+	err := ReadTheLpa(nil, donorStore, attorneyStore)(testAppData, w, r, &actor.AttorneyProvidedDetails{LpaID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.RightsAndResponsibilities, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.RightsAndResponsibilities.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostReadTheLpaWithAttorneyOnDonorStoreError(t *testing.T) {

--- a/app/internal/page/attorney/register_test.go
+++ b/app/internal/page/attorney/register_test.go
@@ -124,7 +124,7 @@ func TestMakeHandleSessionError(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleSessionMissing(t *testing.T) {
@@ -144,7 +144,7 @@ func TestMakeHandleSessionMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleLpaMissing(t *testing.T) {
@@ -164,7 +164,7 @@ func TestMakeHandleLpaMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleNoSessionRequired(t *testing.T) {
@@ -211,7 +211,7 @@ func TestMakeAttorneyHandleExistingSessionData(t *testing.T) {
 		assert.Equal(t, expectedDetails, details)
 
 		assert.Equal(t, page.AppData{
-			Page:       "/path",
+			Page:       "/attorney/lpa-id/path",
 			CanGoBack:  true,
 			SessionID:  "cmFuZG9t",
 			LpaID:      "lpa-id",
@@ -269,7 +269,7 @@ func TestMakeAttorneyHandleExistingLpaData(t *testing.T) {
 			handle("/path", CanGoBack, func(appData page.AppData, hw http.ResponseWriter, hr *http.Request, details *actor.AttorneyProvidedDetails) error {
 				assert.Equal(t, tc.details, details)
 				assert.Equal(t, page.AppData{
-					Page:       "/path",
+					Page:       "/attorney/lpa-id/path",
 					CanGoBack:  true,
 					LpaID:      "lpa-id",
 					SessionID:  "cmFuZG9t",
@@ -366,7 +366,7 @@ func TestMakeAttorneyHandleSessionError(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeAttorneyHandleSessionMissing(t *testing.T) {
@@ -388,7 +388,7 @@ func TestMakeAttorneyHandleSessionMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeAttorneyHandleLpaMissing(t *testing.T) {
@@ -410,5 +410,5 @@ func TestMakeAttorneyHandleLpaMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 }

--- a/app/internal/page/attorney/sign.go
+++ b/app/internal/page/attorney/sign.go
@@ -46,7 +46,7 @@ func Sign(tmpl template.Template, donorStore DonorStore, certificateProviderStor
 		}
 
 		if ok, _ := canSign(r.Context(), certificateProviderStore, lpa); !ok {
-			return appData.Redirect(w, r, lpa, page.Paths.Attorney.TaskList)
+			return appData.Redirect(w, r, lpa, page.Paths.Attorney.TaskList.Format(attorneyProvidedDetails.LpaID))
 		}
 
 		attorneys := lpa.Attorneys
@@ -56,7 +56,7 @@ func Sign(tmpl template.Template, donorStore DonorStore, certificateProviderStor
 
 		attorney, ok := attorneys.Get(appData.AttorneyID)
 		if !ok {
-			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start)
+			return appData.Redirect(w, r, lpa, page.Paths.Attorney.Start.Format())
 		}
 
 		data := &signData{
@@ -81,7 +81,7 @@ func Sign(tmpl template.Template, donorStore DonorStore, certificateProviderStor
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.Attorney.WhatHappensNext)
+				return appData.Redirect(w, r, lpa, page.Paths.Attorney.WhatHappensNext.Format(attorneyProvidedDetails.LpaID))
 			}
 		}
 

--- a/app/internal/page/attorney/sign_test.go
+++ b/app/internal/page/attorney/sign_test.go
@@ -156,12 +156,12 @@ func TestGetSignCantSignYet(t *testing.T) {
 				On("GetAny", mock.Anything).
 				Return(tc.certificateProvider, nil)
 
-			err := Sign(nil, donorStore, certificateProviderStore, nil)(tc.appData, w, r, nil)
+			err := Sign(nil, donorStore, certificateProviderStore, nil)(tc.appData, w, r, &actor.AttorneyProvidedDetails{LpaID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.TaskList, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -213,7 +213,7 @@ func TestGetSignWhenAttorneyDoesNotExist(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.Attorney.Start, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.Start.Format(), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -282,6 +282,7 @@ func TestPostSign(t *testing.T) {
 				Attorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:     "lpa-id",
 				Confirmed: true,
 				Tasks:     actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
 			},
@@ -293,6 +294,7 @@ func TestPostSign(t *testing.T) {
 				ReplacementAttorneys: actor.Attorneys{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
+				LpaID:     "lpa-id",
 				Confirmed: true,
 				Tasks:     actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
 			},
@@ -327,12 +329,12 @@ func TestPostSign(t *testing.T) {
 					Certificate: actor.Certificate{Agreed: time.Now()},
 				}, nil)
 
-			err := Sign(nil, donorStore, certificateProviderStore, attorneyStore)(tc.appData, w, r, &actor.AttorneyProvidedDetails{})
+			err := Sign(nil, donorStore, certificateProviderStore, attorneyStore)(tc.appData, w, r, &actor.AttorneyProvidedDetails{LpaID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/attorney/lpa-id"+page.Paths.Attorney.WhatHappensNext, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.Attorney.WhatHappensNext.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/attorney/task_list.go
+++ b/app/internal/page/attorney/task_list.go
@@ -39,7 +39,7 @@ func TaskList(tmpl template.Template, donorStore DonorStore, certificateProvider
 				return err
 			}
 			if ok {
-				signPath = page.Paths.Attorney.Sign
+				signPath = page.Paths.Attorney.Sign.Format(lpa.ID)
 			}
 		}
 
@@ -49,12 +49,12 @@ func TaskList(tmpl template.Template, donorStore DonorStore, certificateProvider
 			Items: []taskListItem{
 				{
 					Name:  "confirmYourDetails",
-					Path:  page.Paths.Attorney.MobileNumber,
+					Path:  page.Paths.Attorney.MobileNumber.Format(lpa.ID),
 					State: tasks.ConfirmYourDetails,
 				},
 				{
 					Name:  "readTheLpa",
-					Path:  page.Paths.Attorney.ReadTheLpa,
+					Path:  page.Paths.Attorney.ReadTheLpa.Format(lpa.ID),
 					State: tasks.ReadTheLpa,
 				},
 				{

--- a/app/internal/page/attorney/task_list_test.go
+++ b/app/internal/page/attorney/task_list_test.go
@@ -82,7 +82,7 @@ func TestGetTaskList(t *testing.T) {
 			appData:                  testAppData,
 			expected: func(items []taskListItem) []taskListItem {
 				items[1].State = actor.TaskCompleted
-				items[2].Path = page.Paths.Attorney.Sign
+				items[2].Path = page.Paths.Attorney.Sign.Format("lpa-id")
 
 				return items
 			},
@@ -105,7 +105,7 @@ func TestGetTaskList(t *testing.T) {
 				items[0].State = actor.TaskCompleted
 				items[1].State = actor.TaskCompleted
 				items[2].State = actor.TaskCompleted
-				items[2].Path = page.Paths.Attorney.Sign
+				items[2].Path = page.Paths.Attorney.Sign.Format("lpa-id")
 
 				return items
 			},
@@ -128,7 +128,7 @@ func TestGetTaskList(t *testing.T) {
 				items[0].State = actor.TaskCompleted
 				items[1].State = actor.TaskCompleted
 				items[2].State = actor.TaskCompleted
-				items[2].Path = page.Paths.Attorney.Sign
+				items[2].Path = page.Paths.Attorney.Sign.Format("lpa-id")
 
 				return items
 			},
@@ -151,8 +151,8 @@ func TestGetTaskList(t *testing.T) {
 					App: tc.appData,
 					Lpa: tc.lpa,
 					Items: tc.expected([]taskListItem{
-						{Name: "confirmYourDetails", Path: page.Paths.Attorney.MobileNumber},
-						{Name: "readTheLpa", Path: page.Paths.Attorney.ReadTheLpa},
+						{Name: "confirmYourDetails", Path: page.Paths.Attorney.MobileNumber.Format("lpa-id")},
+						{Name: "readTheLpa", Path: page.Paths.Attorney.ReadTheLpa.Format("lpa-id")},
 						{Name: "signTheLpa"},
 					}),
 				}).

--- a/app/internal/page/auth_redirect_test.go
+++ b/app/internal/page/auth_redirect_test.go
@@ -20,29 +20,29 @@ func TestAuthRedirect(t *testing.T) {
 				State:    "my-state",
 				Nonce:    "my-nonce",
 				Locale:   "en",
-				Redirect: Paths.LoginCallback,
+				Redirect: Paths.LoginCallback.Format(),
 			},
-			redirect: Paths.LoginCallback,
+			redirect: Paths.LoginCallback.Format(),
 		},
 		"login with nested route": {
 			session: &sesh.OneLoginSession{
 				State:    "my-state",
 				Nonce:    "my-nonce",
 				Locale:   "en",
-				Redirect: Paths.IdentityWithOneLoginCallback,
+				Redirect: Paths.IdentityWithOneLoginCallback.Format("123"),
 				LpaID:    "123",
 			},
-			redirect: "/lpa/123" + Paths.IdentityWithOneLoginCallback,
+			redirect: Paths.IdentityWithOneLoginCallback.Format("123"),
 		},
 		"welsh": {
 			session: &sesh.OneLoginSession{
 				State:    "my-state",
 				Nonce:    "my-nonce",
 				Locale:   "cy",
-				Redirect: Paths.IdentityWithOneLoginCallback,
+				Redirect: Paths.IdentityWithOneLoginCallback.Format("123"),
 				LpaID:    "123",
 			},
-			redirect: "/cy/lpa/123" + Paths.IdentityWithOneLoginCallback,
+			redirect: "/cy" + Paths.IdentityWithOneLoginCallback.Format("123"),
 		},
 	}
 
@@ -142,7 +142,7 @@ func TestAuthRedirectStateIncorrect(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{
 			Values: map[any]any{
-				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Redirect: Paths.LoginCallback},
+				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Redirect: Paths.LoginCallback.Format()},
 			},
 		}, nil)
 

--- a/app/internal/page/certificateprovider/check_your_name.go
+++ b/app/internal/page/certificateprovider/check_your_name.go
@@ -64,7 +64,7 @@ func CheckYourName(tmpl template.Template, donorStore DonorStore, notifyClient N
 					}
 				}
 
-				appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.EnterDateOfBirth)
+				appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.EnterDateOfBirth.Format(certificateProvider.LpaID))
 				return nil
 			}
 		}

--- a/app/internal/page/certificateprovider/check_your_name_test.go
+++ b/app/internal/page/certificateprovider/check_your_name_test.go
@@ -146,10 +146,10 @@ func TestPostEnterYourName(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	certificateProviderStore.
-		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{FirstNames: "Bob", LastName: "Smith"}).
+		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{LpaID: "lpa-id", FirstNames: "Bob", LastName: "Smith"}).
 		Return(nil)
 
 	err := CheckYourName(nil, donorStore, nil, certificateProviderStore)(testAppData, w, r)
@@ -157,7 +157,7 @@ func TestPostEnterYourName(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.EnterDateOfBirth.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostEnterYourNameIsCorrectOnStoreError(t *testing.T) {
@@ -217,9 +217,9 @@ func TestPostEnterYourNameWithCorrectedName(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 	certificateProviderStore.
-		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{DeclaredFullName: "Bobby Smith"}).
+		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{LpaID: "lpa-id", DeclaredFullName: "Bobby Smith"}).
 		Return(nil)
 
 	notifyClient := newMockNotifyClient(t)
@@ -239,7 +239,7 @@ func TestPostEnterYourNameWithCorrectedName(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.EnterDateOfBirth.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostEnterYourNameWithCorrectedNameWhenStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/enter_date_of_birth.go
+++ b/app/internal/page/certificateprovider/enter_date_of_birth.go
@@ -64,7 +64,7 @@ func EnterDateOfBirth(tmpl template.Template, donorStore DonorStore, certificate
 					redirect = page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity
 				}
 
-				return appData.Redirect(w, r, lpa, redirect)
+				return appData.Redirect(w, r, lpa, redirect.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/enter_date_of_birth_test.go
+++ b/app/internal/page/certificateprovider/enter_date_of_birth_test.go
@@ -168,6 +168,7 @@ func TestPostEnterDateOfBirth(t *testing.T) {
 				"date-of-birth-year":  {validBirthYear},
 			},
 			cp: &actor.CertificateProviderProvidedDetails{
+				LpaID:       "lpa-id",
 				DateOfBirth: date.New(validBirthYear, "1", "2"),
 			},
 		},
@@ -179,6 +180,7 @@ func TestPostEnterDateOfBirth(t *testing.T) {
 				"ignore-dob-warning":  {"dateOfBirthIsOver100"},
 			},
 			cp: &actor.CertificateProviderProvidedDetails{
+				LpaID:       "lpa-id",
 				DateOfBirth: date.New("1900", "1", "2"),
 			},
 		},
@@ -199,7 +201,7 @@ func TestPostEnterDateOfBirth(t *testing.T) {
 			certificateProviderStore := newMockCertificateProviderStore(t)
 			certificateProviderStore.
 				On("Get", r.Context()).
-				Return(&actor.CertificateProviderProvidedDetails{}, nil)
+				Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 			certificateProviderStore.
 				On("Put", r.Context(), tc.cp).
 				Return(nil)
@@ -209,7 +211,7 @@ func TestPostEnterDateOfBirth(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterMobileNumber, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.CertificateProvider.EnterMobileNumber.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -236,9 +238,10 @@ func TestPostEnterDateOfBirthWhenCPHasAlreadyWitnessed(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 	certificateProviderStore.
 		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{
+			LpaID:       "lpa-id",
 			DateOfBirth: date.New("1983", "1", "2"),
 		}).
 		Return(nil)
@@ -248,7 +251,7 @@ func TestPostEnterDateOfBirthWhenCPHasAlreadyWitnessed(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostEnterDateOfBirthWhenInputRequired(t *testing.T) {

--- a/app/internal/page/certificateprovider/enter_mobile_number.go
+++ b/app/internal/page/certificateprovider/enter_mobile_number.go
@@ -51,7 +51,7 @@ func EnterMobileNumber(tmpl template.Template, donorStore DonorStore, certificat
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity)
+				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/enter_mobile_number_test.go
+++ b/app/internal/page/certificateprovider/enter_mobile_number_test.go
@@ -172,9 +172,9 @@ func TestPostEnterMobileNumber(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 	certificateProviderStore.
-		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{Mobile: "07535111222"}).
+		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{LpaID: "lpa-id", Mobile: "07535111222"}).
 		Return(nil)
 
 	err := EnterMobileNumber(nil, donorStore, certificateProviderStore)(testAppData, w, r)
@@ -182,7 +182,7 @@ func TestPostEnterMobileNumber(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity.Format("lpa-id"), resp.Header.Get("Location"))
 
 }
 

--- a/app/internal/page/certificateprovider/enter_reference_number.go
+++ b/app/internal/page/certificateprovider/enter_reference_number.go
@@ -54,8 +54,7 @@ func EnterReferenceNumber(tmpl template.Template, shareCodeStore ShareCodeStore,
 					return err
 				}
 
-				appData.Redirect(w, r, nil, page.Paths.CertificateProvider.WhoIsEligible)
-				return nil
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.WhoIsEligible.Format())
 			}
 		}
 

--- a/app/internal/page/certificateprovider/enter_reference_number_test.go
+++ b/app/internal/page/certificateprovider/enter_reference_number_test.go
@@ -109,7 +109,7 @@ func TestPostEnterReferenceNumber(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, page.Paths.CertificateProvider.WhoIsEligible, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.CertificateProvider.WhoIsEligible.Format(), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/certificateprovider/identity_with_one_login.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login.go
@@ -24,7 +24,7 @@ func IdentityWithOneLogin(logger Logger, oneLoginClient OneLoginClient, store se
 			State:    state,
 			Nonce:    nonce,
 			Locale:   locale,
-			Redirect: page.Paths.CertificateProvider.IdentityWithOneLoginCallback,
+			Redirect: page.Paths.CertificateProvider.IdentityWithOneLoginCallback.Format(appData.LpaID),
 		}); err != nil {
 			logger.Print(err)
 			return nil

--- a/app/internal/page/certificateprovider/identity_with_one_login_callback.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_callback.go
@@ -30,9 +30,9 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 
 		if r.Method == http.MethodPost {
 			if certificateProvider.CertificateProviderIdentityConfirmed() {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa.Format(certificateProvider.LpaID))
 			} else {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_callback_test.go
@@ -323,6 +323,7 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 	certificateProviderStore.
 		On("Get", r.Context()).
 		Return(&actor.CertificateProviderProvidedDetails{
+			LpaID:            "lpa-id",
 			IdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 		}, nil)
 
@@ -331,7 +332,7 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithOneLoginCallbackNotConfirmed(t *testing.T) {
@@ -341,12 +342,12 @@ func TestPostIdentityWithOneLoginCallbackNotConfirmed(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	err := IdentityWithOneLoginCallback(nil, nil, nil, certificateProviderStore)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.SelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_one_login_test.go
+++ b/app/internal/page/certificateprovider/identity_with_one_login_test.go
@@ -34,14 +34,14 @@ func TestIdentityWithOneLogin(t *testing.T) {
 		Secure:   true,
 	}
 	session.Values = map[any]any{
-		"one-login": &sesh.OneLoginSession{State: "i am random", Nonce: "i am random", Locale: "cy", Redirect: page.Paths.CertificateProvider.IdentityWithOneLoginCallback},
+		"one-login": &sesh.OneLoginSession{State: "i am random", Nonce: "i am random", Locale: "cy", Redirect: page.Paths.CertificateProvider.IdentityWithOneLoginCallback.Format("lpa-id")},
 	}
 
 	sessionStore.
 		On("Save", r, w, session).
 		Return(nil)
 
-	err := IdentityWithOneLogin(nil, client, sessionStore, func(int) string { return "i am random" })(page.AppData{Lang: localize.Cy}, w, r)
+	err := IdentityWithOneLogin(nil, client, sessionStore, func(int) string { return "i am random" })(page.AppData{LpaID: "lpa-id", Lang: localize.Cy}, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/certificateprovider/identity_with_todo.go
+++ b/app/internal/page/certificateprovider/identity_with_todo.go
@@ -24,7 +24,7 @@ func IdentityWithTodo(tmpl template.Template, now func() time.Time, identityOpti
 		}
 
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
+			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa.Format(certificateProvider.LpaID))
 		}
 
 		certificateProvider.IdentityUserData = identity.UserData{

--- a/app/internal/page/certificateprovider/identity_with_todo_test.go
+++ b/app/internal/page/certificateprovider/identity_with_todo_test.go
@@ -87,12 +87,12 @@ func TestPostIdentityWithTodo(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	err := IdentityWithTodo(nil, nil, identity.Passport, certificateProviderStore)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_yoti.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti.go
@@ -24,7 +24,7 @@ func IdentityWithYoti(tmpl template.Template, sessionStore SessionStore, yotiCli
 		}
 
 		if certificateProvider.CertificateProviderIdentityConfirmed() || yotiClient.IsTest() {
-			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.IdentityWithYotiCallback)
+			return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.IdentityWithYotiCallback.Format(certificateProvider.LpaID))
 		}
 
 		if err := sesh.SetYoti(sessionStore, r, w, &sesh.YotiSession{

--- a/app/internal/page/certificateprovider/identity_with_yoti_callback.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_callback.go
@@ -29,9 +29,9 @@ func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, cer
 
 		if r.Method == http.MethodPost {
 			if certificateProvider.CertificateProviderIdentityConfirmed() {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.ReadTheLpa.Format(certificateProvider.LpaID))
 			} else {
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/identity_with_yoti_callback_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_callback_test.go
@@ -212,6 +212,7 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 	certificateProviderStore.
 		On("Get", r.Context()).
 		Return(&actor.CertificateProviderProvidedDetails{
+			LpaID:            "lpa-id",
 			IdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID},
 		}, nil)
 
@@ -220,7 +221,7 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.ReadTheLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.ReadTheLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
@@ -230,12 +231,12 @@ func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	err := IdentityWithYotiCallback(nil, nil, certificateProviderStore)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.SelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/certificateprovider/identity_with_yoti_test.go
+++ b/app/internal/page/certificateprovider/identity_with_yoti_test.go
@@ -99,7 +99,7 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.IdentityWithYotiCallback.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenTest(t *testing.T) {
@@ -109,7 +109,7 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("IsTest").Return(true)
@@ -119,7 +119,7 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.IdentityWithYotiCallback.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenCertificateProviderStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/login.go
+++ b/app/internal/page/certificateprovider/login.go
@@ -30,7 +30,7 @@ func Login(logger Logger, oneLoginClient OneLoginClient, store sesh.Store, rando
 			State:     state,
 			Nonce:     nonce,
 			Locale:    locale,
-			Redirect:  page.Paths.CertificateProvider.LoginCallback,
+			Redirect:  page.Paths.CertificateProvider.LoginCallback.Format(),
 			LpaID:     sc.LpaID,
 			SessionID: sc.SessionID,
 		}); err != nil {

--- a/app/internal/page/certificateprovider/login_callback.go
+++ b/app/internal/page/certificateprovider/login_callback.go
@@ -49,6 +49,6 @@ func LoginCallback(oneLoginClient OneLoginClient, sessionStore sesh.Store, certi
 		}
 
 		appData.LpaID = oneLoginSession.LpaID
-		return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.EnterDateOfBirth)
+		return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.EnterDateOfBirth.Format(oneLoginSession.LpaID))
 	}
 }

--- a/app/internal/page/certificateprovider/login_callback_test.go
+++ b/app/internal/page/certificateprovider/login_callback_test.go
@@ -78,7 +78,7 @@ func TestLoginCallback(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.EnterDateOfBirth.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestLoginCallbackWhenCertificateProviderExists(t *testing.T) {
@@ -144,7 +144,7 @@ func TestLoginCallbackWhenCertificateProviderExists(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.EnterDateOfBirth, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.EnterDateOfBirth.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestLoginCallbackSessionMissing(t *testing.T) {

--- a/app/internal/page/certificateprovider/login_test.go
+++ b/app/internal/page/certificateprovider/login_test.go
@@ -51,7 +51,7 @@ func TestCertificateProviderLogin(t *testing.T) {
 			Nonce:    "i am random",
 			Locale:   "cy",
 			LpaID:    "lpa-id",
-			Redirect: page.Paths.CertificateProvider.LoginCallback,
+			Redirect: page.Paths.CertificateProvider.LoginCallback.Format(),
 		},
 	}
 
@@ -105,7 +105,7 @@ func TestCertificateProviderLoginDefaultLocale(t *testing.T) {
 			Nonce:    "i am random",
 			Locale:   "en",
 			LpaID:    "lpa-id",
-			Redirect: page.Paths.CertificateProvider.LoginCallback,
+			Redirect: page.Paths.CertificateProvider.LoginCallback.Format(),
 		},
 	}
 

--- a/app/internal/page/certificateprovider/provide_certificate.go
+++ b/app/internal/page/certificateprovider/provide_certificate.go
@@ -30,7 +30,7 @@ func ProvideCertificate(tmpl template.Template, donorStore DonorStore, now func(
 		}
 
 		if lpa.Submitted.IsZero() {
-			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderStart)
+			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderStart.Format())
 		}
 
 		data := &provideCertificateData{
@@ -52,7 +52,7 @@ func ProvideCertificate(tmpl template.Template, donorStore DonorStore, now func(
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.CertificateProvided)
+				return appData.Redirect(w, r, lpa, page.Paths.CertificateProvider.CertificateProvided.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/provide_certificate_test.go
+++ b/app/internal/page/certificateprovider/provide_certificate_test.go
@@ -57,14 +57,14 @@ func TestGetProvideCertificateRedirectsToStartOnLpaNotSubmitted(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 	err := ProvideCertificate(nil, donorStore, nil, certificateProviderStore)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.CertificateProviderStart, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProviderStart.Format(), resp.Header.Get("Location"))
 }
 
 func TestGetProvideCertificateWhenDonorStoreErrors(t *testing.T) {
@@ -123,9 +123,10 @@ func TestPostProvideCertificate(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 	certificateProviderStore.
 		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{
+			LpaID: "lpa-id",
 			Certificate: actor.Certificate{
 				AgreeToStatement: true,
 				Agreed:           now,
@@ -138,7 +139,7 @@ func TestPostProvideCertificate(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.CertificateProvided, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.CertificateProvided.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostProvideCertificateOnStoreError(t *testing.T) {

--- a/app/internal/page/certificateprovider/register.go
+++ b/app/internal/page/certificateprovider/register.go
@@ -89,107 +89,113 @@ func Register(
 ) {
 	handleRoot := makeHandle(rootMux, sessionStore, errorHandler)
 
-	handleRoot(page.Paths.CertificateProvider.EnterReferenceNumber, None,
+	handleRoot(page.Paths.CertificateProvider.EnterReferenceNumber,
 		EnterReferenceNumber(tmpls.Get("certificate_provider_enter_reference_number.gohtml"), shareCodeStore, sessionStore))
-	handleRoot(page.Paths.CertificateProvider.WhoIsEligible, None,
+	handleRoot(page.Paths.CertificateProvider.WhoIsEligible,
 		WhoIsEligible(tmpls.Get("certificate_provider_who_is_eligible.gohtml"), sessionStore))
-	handleRoot(page.Paths.CertificateProvider.Login, None,
+	handleRoot(page.Paths.CertificateProvider.Login,
 		Login(logger, oneLoginClient, sessionStore, random.String))
-	handleRoot(page.Paths.CertificateProvider.LoginCallback, None,
+	handleRoot(page.Paths.CertificateProvider.LoginCallback,
 		LoginCallback(oneLoginClient, sessionStore, certificateProviderStore))
 
 	certificateProviderMux := http.NewServeMux()
 	rootMux.Handle("/certificate-provider/", page.RouteToPrefix("/certificate-provider/", certificateProviderMux, notFoundHandler))
-	handleCertificateProvider := makeHandle(certificateProviderMux, sessionStore, errorHandler)
+	handleCertificateProvider := makeCertificateProviderHandle(certificateProviderMux, sessionStore, errorHandler)
 
-	handleCertificateProvider(page.Paths.CertificateProvider.CheckYourName, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.CheckYourName,
 		CheckYourName(tmpls.Get("certificate_provider_check_your_name.gohtml"), donorStore, notifyClient, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.EnterDateOfBirth, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.EnterDateOfBirth,
 		EnterDateOfBirth(tmpls.Get("certificate_provider_enter_date_of_birth.gohtml"), donorStore, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.EnterMobileNumber, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.EnterMobileNumber,
 		EnterMobileNumber(tmpls.Get("certificate_provider_enter_mobile_number.gohtml"), donorStore, certificateProviderStore))
 
-	handleCertificateProvider(page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity,
 		Guidance(tmpls.Get("certificate_provider_what_youll_need_to_confirm_your_identity.gohtml"), donorStore, nil))
 
-	for path, page := range map[string]int{
+	for path, page := range map[page.CertificateProviderPath]int{
 		page.Paths.CertificateProvider.SelectYourIdentityOptions:  0,
 		page.Paths.CertificateProvider.SelectYourIdentityOptions1: 1,
 		page.Paths.CertificateProvider.SelectYourIdentityOptions2: 2,
 	} {
-		handleCertificateProvider(path, RequireSession,
+		handleCertificateProvider(path,
 			SelectYourIdentityOptions(tmpls.Get("select_your_identity_options.gohtml"), page, certificateProviderStore))
 	}
 
-	handleCertificateProvider(page.Paths.CertificateProvider.YourChosenIdentityOptions, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.YourChosenIdentityOptions,
 		YourChosenIdentityOptions(tmpls.Get("your_chosen_identity_options.gohtml"), certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithYoti, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithYoti,
 		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), sessionStore, yotiClient, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithYotiCallback, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithYotiCallback,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithOneLogin, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithOneLogin,
 		IdentityWithOneLogin(logger, oneLoginClient, sessionStore, random.String))
-	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithOneLoginCallback, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.IdentityWithOneLoginCallback,
 		IdentityWithOneLoginCallback(tmpls.Get("identity_with_one_login_callback.gohtml"), oneLoginClient, sessionStore, certificateProviderStore))
 
-	for path, identityOption := range map[string]identity.Option{
+	for path, identityOption := range map[page.CertificateProviderPath]identity.Option{
 		page.Paths.CertificateProvider.IdentityWithPassport:                 identity.Passport,
 		page.Paths.CertificateProvider.IdentityWithBiometricResidencePermit: identity.BiometricResidencePermit,
 		page.Paths.CertificateProvider.IdentityWithDrivingLicencePaper:      identity.DrivingLicencePaper,
 		page.Paths.CertificateProvider.IdentityWithDrivingLicencePhotocard:  identity.DrivingLicencePhotocard,
 		page.Paths.CertificateProvider.IdentityWithOnlineBankAccount:        identity.OnlineBankAccount,
 	} {
-		handleCertificateProvider(path, RequireSession,
+		handleCertificateProvider(path,
 			IdentityWithTodo(tmpls.Get("identity_with_todo.gohtml"), time.Now, identityOption, certificateProviderStore))
 	}
 
-	handleCertificateProvider(page.Paths.CertificateProvider.ReadTheLpa, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.ReadTheLpa,
 		Guidance(tmpls.Get("certificate_provider_read_the_lpa.gohtml"), donorStore, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.WhatHappensNext, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.WhatHappensNext,
 		Guidance(tmpls.Get("certificate_provider_what_happens_next.gohtml"), donorStore, nil))
-	handleCertificateProvider(page.Paths.CertificateProvider.ProvideCertificate, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.ProvideCertificate,
 		ProvideCertificate(tmpls.Get("provide_certificate.gohtml"), donorStore, time.Now, certificateProviderStore))
-	handleCertificateProvider(page.Paths.CertificateProvider.CertificateProvided, RequireSession,
+	handleCertificateProvider(page.Paths.CertificateProvider.CertificateProvided,
 		Guidance(tmpls.Get("certificate_provided.gohtml"), donorStore, nil))
 }
 
-type handleOpt byte
-
-const (
-	None handleOpt = 1 << iota
-	RequireSession
-	CanGoBack
-)
-
-func makeHandle(mux *http.ServeMux, store sesh.Store, errorHandler page.ErrorHandler) func(string, handleOpt, page.Handler) {
-	return func(path string, opt handleOpt, h page.Handler) {
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+func makeHandle(mux *http.ServeMux, store sesh.Store, errorHandler page.ErrorHandler) func(page.Path, page.Handler) {
+	return func(path page.Path, h page.Handler) {
+		mux.HandleFunc(path.String(), func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			appData := page.AppDataFromContext(ctx)
-			appData.Page = path
-			appData.CanGoBack = opt&CanGoBack != 0
+			appData.ActorType = actor.TypeCertificateProvider
+			appData.Page = path.Format()
+
+			if err := h(appData, w, r.WithContext(page.ContextWithAppData(ctx, appData))); err != nil {
+				errorHandler(w, r, err)
+			}
+		})
+	}
+}
+
+func makeCertificateProviderHandle(mux *http.ServeMux, store sesh.Store, errorHandler page.ErrorHandler) func(page.CertificateProviderPath, page.Handler) {
+	return func(path page.CertificateProviderPath, h page.Handler) {
+		mux.HandleFunc(path.String(), func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			appData := page.AppDataFromContext(ctx)
 			appData.ActorType = actor.TypeCertificateProvider
 
-			if opt&RequireSession != 0 {
-				session, err := sesh.Login(store, r)
-				if err != nil {
-					http.Redirect(w, r, page.Paths.CertificateProviderStart, http.StatusFound)
-					return
-				}
-
-				appData.SessionID = base64.StdEncoding.EncodeToString([]byte(session.Sub))
-
-				sessionData, err := page.SessionDataFromContext(ctx)
-				if err == nil {
-					sessionData.SessionID = appData.SessionID
-					ctx = page.ContextWithSessionData(ctx, sessionData)
-
-					appData.LpaID = sessionData.LpaID
-				} else {
-					ctx = page.ContextWithSessionData(ctx, &page.SessionData{SessionID: appData.SessionID, LpaID: appData.LpaID})
-				}
+			session, err := sesh.Login(store, r)
+			if err != nil {
+				http.Redirect(w, r, page.Paths.CertificateProviderStart.Format(), http.StatusFound)
+				return
 			}
+
+			appData.SessionID = base64.StdEncoding.EncodeToString([]byte(session.Sub))
+
+			sessionData, err := page.SessionDataFromContext(ctx)
+			if err == nil {
+				sessionData.SessionID = appData.SessionID
+				ctx = page.ContextWithSessionData(ctx, sessionData)
+
+				appData.LpaID = sessionData.LpaID
+			} else {
+				ctx = page.ContextWithSessionData(ctx, &page.SessionData{SessionID: appData.SessionID, LpaID: appData.LpaID})
+			}
+
+			appData.Page = path.Format(appData.LpaID)
 
 			if err := h(appData, w, r.WithContext(page.ContextWithAppData(ctx, appData))); err != nil {
 				errorHandler(w, r, err)

--- a/app/internal/page/certificateprovider/select_your_identity_options.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options.go
@@ -38,12 +38,12 @@ func SelectYourIdentityOptions(tmpl template.Template, pageIndex int, certificat
 			if data.Form.None {
 				switch pageIndex {
 				case 0:
-					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1)
+					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format(certificateProvider.LpaID))
 				case 1:
-					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions2)
+					return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.SelectYourIdentityOptions2.Format(certificateProvider.LpaID))
 				default:
 					// will go to vouching flow when that is built
-					return appData.Redirect(w, r, nil, page.Paths.CertificateProviderStart)
+					return appData.Redirect(w, r, nil, page.Paths.CertificateProviderStart.Format())
 				}
 			}
 
@@ -54,7 +54,7 @@ func SelectYourIdentityOptions(tmpl template.Template, pageIndex int, certificat
 					return err
 				}
 
-				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.YourChosenIdentityOptions)
+				return appData.Redirect(w, r, nil, page.Paths.CertificateProvider.YourChosenIdentityOptions.Format(certificateProvider.LpaID))
 			}
 		}
 

--- a/app/internal/page/certificateprovider/select_your_identity_options_test.go
+++ b/app/internal/page/certificateprovider/select_your_identity_options_test.go
@@ -112,9 +112,10 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 	certificateProviderStore.
 		On("Put", r.Context(), &actor.CertificateProviderProvidedDetails{
+			LpaID:          "lpa-id",
 			IdentityOption: identity.Passport,
 		}).
 		Return(nil)
@@ -124,14 +125,14 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.YourChosenIdentityOptions, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.YourChosenIdentityOptions.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
 	for pageIndex, nextPath := range map[int]string{
-		0: "/certificate-provider/lpa-id" + page.Paths.CertificateProvider.SelectYourIdentityOptions1,
-		1: "/certificate-provider/lpa-id" + page.Paths.CertificateProvider.SelectYourIdentityOptions2,
-		2: page.Paths.CertificateProviderStart,
+		0: page.Paths.CertificateProvider.SelectYourIdentityOptions1.Format("lpa-id"),
+		1: page.Paths.CertificateProvider.SelectYourIdentityOptions2.Format("lpa-id"),
+		2: page.Paths.CertificateProviderStart.Format(),
 	} {
 		t.Run(fmt.Sprintf("Page%d", pageIndex), func(t *testing.T) {
 			form := url.Values{
@@ -145,7 +146,7 @@ func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
 			certificateProviderStore := newMockCertificateProviderStore(t)
 			certificateProviderStore.
 				On("Get", r.Context()).
-				Return(&actor.CertificateProviderProvidedDetails{}, nil)
+				Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id"}, nil)
 
 			err := SelectYourIdentityOptions(nil, pageIndex, certificateProviderStore)(testAppData, w, r)
 			resp := w.Result()

--- a/app/internal/page/certificateprovider/your_chosen_identity_options.go
+++ b/app/internal/page/certificateprovider/your_chosen_identity_options.go
@@ -23,7 +23,7 @@ func YourChosenIdentityOptions(tmpl template.Template, certificateProviderStore 
 		}
 
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, nil, identityOptionPath(appData.Paths, certificateProvider.IdentityOption))
+			return appData.Redirect(w, r, nil, identityOptionPath(appData.Paths, certificateProvider.IdentityOption).Format(certificateProvider.LpaID))
 		}
 
 		data := &yourChosenIdentityOptionsData{
@@ -35,7 +35,7 @@ func YourChosenIdentityOptions(tmpl template.Template, certificateProviderStore 
 	}
 }
 
-func identityOptionPath(paths page.AppPaths, identityOption identity.Option) string {
+func identityOptionPath(paths page.AppPaths, identityOption identity.Option) interface{ Format(string) string } {
 	switch identityOption {
 	case identity.OneLogin:
 		return paths.CertificateProvider.IdentityWithOneLogin

--- a/app/internal/page/certificateprovider/your_chosen_identity_options_test.go
+++ b/app/internal/page/certificateprovider/your_chosen_identity_options_test.go
@@ -78,12 +78,12 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 	certificateProviderStore := newMockCertificateProviderStore(t)
 	certificateProviderStore.
 		On("Get", r.Context()).
-		Return(&actor.CertificateProviderProvidedDetails{IdentityOption: identity.Passport}, nil)
+		Return(&actor.CertificateProviderProvidedDetails{LpaID: "lpa-id", IdentityOption: identity.Passport}, nil)
 
 	err := YourChosenIdentityOptions(nil, certificateProviderStore)(testAppData, w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/certificate-provider/lpa-id"+page.Paths.CertificateProvider.IdentityWithPassport, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProvider.IdentityWithPassport.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/cookie_consent.go
+++ b/app/internal/page/cookie_consent.go
@@ -20,7 +20,7 @@ func CookieConsent(paths AppPaths) http.HandlerFunc {
 
 		redirectURL := r.PostFormValue("cookies-redirect")
 		if len(redirectURL) <= 1 || redirectURL[0] != '/' || redirectURL[1] == '/' || redirectURL[1] == '\\' {
-			redirectURL = paths.Start
+			redirectURL = paths.Start.String()
 		}
 
 		http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/app/internal/page/cookie_consent_test.go
+++ b/app/internal/page/cookie_consent_test.go
@@ -20,7 +20,7 @@ func TestCookieConsent(t *testing.T) {
 			resp := w.Result()
 
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, Paths.Start, resp.Header.Get("Location"))
+			assert.Equal(t, Paths.Start.Format(), resp.Header.Get("Location"))
 
 			cookies := resp.Cookies()
 			if assert.Len(t, cookies, 1) {
@@ -66,7 +66,7 @@ func TestCookieConsentBadRedirect(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, Paths.Start.Format(), resp.Header.Get("Location"))
 
 	cookies := resp.Cookies()
 	if assert.Len(t, cookies, 1) {

--- a/app/internal/page/dashboard.go
+++ b/app/internal/page/dashboard.go
@@ -30,7 +30,7 @@ func Dashboard(tmpl template.Template, donorStore DonorStore, dashboardStore Das
 				return err
 			}
 
-			return appData.Redirect(w, r, lpa, Paths.YourDetails)
+			return appData.Redirect(w, r, lpa, Paths.YourDetails.Format(lpa.ID))
 		}
 
 		donorLpas, attorneyLpas, certificateProviderLpas, err := dashboardStore.GetAll(r.Context())

--- a/app/internal/page/dashboard_test.go
+++ b/app/internal/page/dashboard_test.go
@@ -114,7 +114,7 @@ func TestPostDashboard(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+Paths.YourDetails, resp.Header.Get("Location"))
+	assert.Equal(t, Paths.YourDetails.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostDashboardWhenDonorStoreError(t *testing.T) {

--- a/app/internal/page/data.go
+++ b/app/internal/page/data.go
@@ -185,7 +185,19 @@ func (l *Lpa) AttorneysAndCpSigningDeadline() time.Time {
 
 func (l *Lpa) CanGoTo(url string) bool {
 	path, _, _ := strings.Cut(url, "?")
+	if path == "" {
+		return false
+	}
 
+	if strings.HasPrefix(path, "/lpa/") {
+		_, lpaPath, _ := strings.Cut(strings.TrimPrefix(path, "/lpa/"), "/")
+		return l.canGoToLpaPath("/" + lpaPath)
+	}
+
+	return true
+}
+
+func (l *Lpa) canGoToLpaPath(path string) bool {
 	section1Completed := l.Tasks.YourDetails.Completed() &&
 		l.Tasks.ChooseAttorneys.Completed() &&
 		l.Tasks.ChooseReplacementAttorneys.Completed() &&
@@ -196,12 +208,12 @@ func (l *Lpa) CanGoTo(url string) bool {
 		l.Tasks.CheckYourLpa.Completed()
 
 	switch path {
-	case Paths.ReadYourLpa, Paths.SignYourLpa, Paths.WitnessingYourSignature, Paths.WitnessingAsCertificateProvider, Paths.YouHaveSubmittedYourLpa:
+	case Paths.ReadYourLpa.String(), Paths.SignYourLpa.String(), Paths.WitnessingYourSignature.String(), Paths.WitnessingAsCertificateProvider.String(), Paths.YouHaveSubmittedYourLpa.String():
 		return l.DonorIdentityConfirmed()
-	case Paths.WhenCanTheLpaBeUsed, Paths.LifeSustainingTreatment, Paths.Restrictions, Paths.WhoDoYouWantToBeCertificateProviderGuidance, Paths.DoYouWantToNotifyPeople, Paths.DoYouWantReplacementAttorneys:
+	case Paths.WhenCanTheLpaBeUsed.String(), Paths.LifeSustainingTreatment.String(), Paths.Restrictions.String(), Paths.WhoDoYouWantToBeCertificateProviderGuidance.String(), Paths.DoYouWantToNotifyPeople.String(), Paths.DoYouWantReplacementAttorneys.String():
 		return l.Tasks.YourDetails.Completed() &&
 			l.Tasks.ChooseAttorneys.Completed()
-	case Paths.CheckYourLpa:
+	case Paths.CheckYourLpa.String():
 		return l.Tasks.YourDetails.Completed() &&
 			l.Tasks.ChooseAttorneys.Completed() &&
 			l.Tasks.ChooseReplacementAttorneys.Completed() &&
@@ -209,9 +221,9 @@ func (l *Lpa) CanGoTo(url string) bool {
 			l.Tasks.Restrictions.Completed() &&
 			l.Tasks.CertificateProvider.Completed() &&
 			l.Tasks.PeopleToNotify.Completed()
-	case Paths.AboutPayment:
+	case Paths.AboutPayment.String():
 		return section1Completed
-	case Paths.SelectYourIdentityOptions, Paths.HowToConfirmYourIdentityAndSign:
+	case Paths.SelectYourIdentityOptions.String(), Paths.HowToConfirmYourIdentityAndSign.String():
 		return section1Completed && l.Tasks.PayForLpa.Completed()
 	case "":
 		return false

--- a/app/internal/page/data_test.go
+++ b/app/internal/page/data_test.go
@@ -115,8 +115,8 @@ func TestCanGoTo(t *testing.T) {
 			expected: true,
 		},
 		"about payment without task": {
-			lpa:      &Lpa{},
-			url:      Paths.AboutPayment,
+			lpa:      &Lpa{ID: "123"},
+			url:      Paths.AboutPayment.Format("123"),
 			expected: false,
 		},
 		"about payment with tasks": {
@@ -133,12 +133,12 @@ func TestCanGoTo(t *testing.T) {
 					CheckYourLpa:               actor.TaskCompleted,
 				},
 			},
-			url:      Paths.AboutPayment,
+			url:      Paths.AboutPayment.Format("123"),
 			expected: true,
 		},
 		"select your identity options without task": {
 			lpa:      &Lpa{},
-			url:      Paths.SelectYourIdentityOptions,
+			url:      Paths.SelectYourIdentityOptions.Format("123"),
 			expected: false,
 		},
 		"select your identity options with tasks": {
@@ -156,7 +156,7 @@ func TestCanGoTo(t *testing.T) {
 					PayForLpa:                  actor.TaskCompleted,
 				},
 			},
-			url:      Paths.SelectYourIdentityOptions,
+			url:      Paths.SelectYourIdentityOptions.Format("123"),
 			expected: true,
 		},
 	}

--- a/app/internal/page/donor/about_payment.go
+++ b/app/internal/page/donor/about_payment.go
@@ -32,7 +32,7 @@ func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.S
 				Amount:      page.CostOfLpaPence,
 				Reference:   randomString(12),
 				Description: "Property and Finance LPA",
-				ReturnUrl:   appPublicUrl + appData.BuildUrl(page.Paths.PaymentConfirmation),
+				ReturnUrl:   appPublicUrl + appData.BuildUrl(page.Paths.PaymentConfirmation.Format(lpa.ID)),
 				Email:       lpa.Donor.Email,
 				Language:    appData.Lang.String(),
 			}
@@ -53,7 +53,7 @@ func AboutPayment(logger Logger, tmpl template.Template, sessionStore sessions.S
 			if strings.HasPrefix(nextUrl, pay.PaymentPublicServiceUrl) {
 				http.Redirect(w, r, nextUrl, http.StatusFound)
 			} else {
-				appData.Redirect(w, r, lpa, page.Paths.PaymentConfirmation)
+				appData.Redirect(w, r, lpa, page.Paths.PaymentConfirmation.Format(lpa.ID))
 			}
 
 		}

--- a/app/internal/page/donor/about_payment_test.go
+++ b/app/internal/page/donor/about_payment_test.go
@@ -72,7 +72,7 @@ func TestPostAboutPayment(t *testing.T) {
 			},
 			"Fake return URL": {
 				nextUrl:  "/lpa/lpa-id/something-else",
-				redirect: "/lpa/lpa-id" + page.Paths.PaymentConfirmation,
+				redirect: page.Paths.PaymentConfirmation.Format("lpa-id"),
 			},
 		}
 
@@ -122,7 +122,7 @@ func TestPostAboutPayment(t *testing.T) {
 						},
 					}, nil)
 
-				err := AboutPayment(nil, template.Execute, sessionStore, payClient, publicUrl, random)(testAppData, w, r, &page.Lpa{Donor: actor.Donor{Email: "a@b.com"}, CertificateProvider: actor.CertificateProvider{}})
+				err := AboutPayment(nil, template.Execute, sessionStore, payClient, publicUrl, random)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Donor: actor.Donor{Email: "a@b.com"}, CertificateProvider: actor.CertificateProvider{}})
 				resp := w.Result()
 
 				assert.Nil(t, err)

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can.go
@@ -36,9 +36,9 @@ func AreYouHappyIfOneAttorneyCantActNoneCan(tmpl template.Template, donorStore D
 				}
 
 				if form.Happy == "yes" {
-					return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 				} else {
-					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct)
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct.Format(lpa.ID))
 				}
 			}
 		}

--- a/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
+++ b/app/internal/page/donor/are_you_happy_if_one_attorney_cant_act_none_can_test.go
@@ -51,7 +51,7 @@ func TestGetAreYouHappyIfOneAttorneyCantActNoneCanWhenTemplateErrors(t *testing.
 }
 
 func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
-	testcases := map[string]string{
+	testcases := map[string]page.LpaPath{
 		"yes": page.Paths.TaskList,
 		"no":  page.Paths.AreYouHappyIfRemainingAttorneysCanContinueToAct,
 	}
@@ -69,16 +69,17 @@ func TestPostAreYouHappyIfOneAttorneyCantActNoneCan(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                "lpa-id",
 					AttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: happy},
 				}).
 				Return(nil)
 
-			err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{})
+			err := AreYouHappyIfOneAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+redirect, resp.Header.Get("Location"))
+			assert.Equal(t, redirect.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
+++ b/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can.go
@@ -35,9 +35,9 @@ func AreYouHappyIfOneReplacementAttorneyCantActNoneCan(tmpl template.Template, d
 				}
 
 				if form.Happy == "yes" {
-					return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 				} else {
-					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct)
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct.Format(lpa.ID))
 				}
 			}
 		}

--- a/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can_test.go
+++ b/app/internal/page/donor/are_you_happy_if_one_replacement_attorney_cant_act_none_can_test.go
@@ -54,11 +54,12 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 	testcases := map[string]struct {
 		happy    string
 		lpa      *page.Lpa
-		redirect string
+		redirect page.LpaPath
 	}{
 		"yes": {
 			happy: "yes",
 			lpa: &page.Lpa{
+				ID:                           "lpa-id",
 				ReplacementAttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: "yes"},
 				Tasks:                        page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 			},
@@ -67,6 +68,7 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 		"no": {
 			happy: "no",
 			lpa: &page.Lpa{
+				ID:                           "lpa-id",
 				ReplacementAttorneyDecisions: actor.AttorneyDecisions{HappyIfOneCannotActNoneCan: "no"},
 				Tasks:                        page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 			},
@@ -90,13 +92,14 @@ func TestPostAreYouHappyIfOneReplacementAttorneyCantActNoneCan(t *testing.T) {
 				Return(nil)
 
 			err := AreYouHappyIfOneReplacementAttorneyCantActNoneCan(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				ID:    "lpa-id",
 				Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+tc.redirect, resp.Header.Get("Location"))
+			assert.Equal(t, tc.redirect.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act.go
@@ -35,7 +35,7 @@ func AreYouHappyIfRemainingAttorneysCanContinueToAct(tmpl template.Template, don
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_attorneys_can_continue_to_act_test.go
@@ -64,16 +64,17 @@ func TestPostAreYouHappyIfRemainingAttorneysCanContinueToAct(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                "lpa-id",
 					AttorneyDecisions: actor.AttorneyDecisions{HappyIfRemainingCanContinueToAct: happy},
 				}).
 				Return(nil)
 
-			err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{})
+			err := AreYouHappyIfRemainingAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act.go
@@ -34,7 +34,7 @@ func AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(tmpl template.Te
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act_test.go
+++ b/app/internal/page/donor/are_you_happy_if_remaining_replacement_attorneys_can_continue_to_act_test.go
@@ -64,19 +64,21 @@ func TestPostAreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(t *testi
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                           "lpa-id",
 					ReplacementAttorneyDecisions: actor.AttorneyDecisions{HappyIfRemainingCanContinueToAct: happy},
 					Tasks:                        page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 				}).
 				Return(nil)
 
 			err := AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				ID:    "lpa-id",
 				Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 			})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/certificate_provider_address.go
+++ b/app/internal/page/donor/certificate_provider_address.go
@@ -40,7 +40,7 @@ func CertificateProviderAddress(logger Logger, tmpl template.Template, addressCl
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.HowDoYouKnowYourCertificateProvider)
+					return appData.Redirect(w, r, lpa, page.Paths.HowDoYouKnowYourCertificateProvider.Format(lpa.ID))
 				}
 
 			case "postcode-select":
@@ -66,7 +66,7 @@ func CertificateProviderAddress(logger Logger, tmpl template.Template, addressCl
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.HowDoYouKnowYourCertificateProvider)
+					return appData.Redirect(w, r, lpa, page.Paths.HowDoYouKnowYourCertificateProvider.Format(lpa.ID))
 				} else {
 					data.Addresses = lpa.ActorAddresses()
 				}

--- a/app/internal/page/donor/certificate_provider_address_test.go
+++ b/app/internal/page/donor/certificate_provider_address_test.go
@@ -137,16 +137,17 @@ func TestPostCertificateProviderAddressManual(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                  "lpa-id",
 			CertificateProvider: actor.CertificateProvider{Address: testAddress},
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.HowDoYouKnowYourCertificateProvider, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.HowDoYouKnowYourCertificateProvider.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostCertificateProviderAddressManualWhenStoreErrors(t *testing.T) {
@@ -192,6 +193,7 @@ func TestPostCertificateProviderAddressManualFromStore(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			CertificateProvider: actor.CertificateProvider{
 				FirstNames: "John",
 				Address:    testAddress,
@@ -201,6 +203,7 @@ func TestPostCertificateProviderAddressManualFromStore(t *testing.T) {
 		Return(nil)
 
 	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		CertificateProvider: actor.CertificateProvider{
 			FirstNames: "John",
 			Address:    place.Address{Line1: "abc"},
@@ -211,7 +214,7 @@ func TestPostCertificateProviderAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.HowDoYouKnowYourCertificateProvider, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.HowDoYouKnowYourCertificateProvider.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostCertificateProviderAddressManualWhenValidationError(t *testing.T) {
@@ -565,6 +568,7 @@ func TestPostCertificateProviderAddressReuseSelect(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			CertificateProvider: actor.CertificateProvider{
 				Address: place.Address{
 					Line1:      "a",
@@ -577,12 +581,12 @@ func TestPostCertificateProviderAddressReuseSelect(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
+	err := CertificateProviderAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.HowDoYouKnowYourCertificateProvider, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.HowDoYouKnowYourCertificateProvider.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostCertificateProviderAddressReuseSelectWhenValidationError(t *testing.T) {

--- a/app/internal/page/donor/certificate_provider_details.go
+++ b/app/internal/page/donor/certificate_provider_details.go
@@ -57,7 +57,7 @@ func CertificateProviderDetails(tmpl template.Template, donorStore DonorStore) H
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole)
+				return appData.Redirect(w, r, lpa, page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/certificate_provider_details_test.go
+++ b/app/internal/page/donor/certificate_provider_details_test.go
@@ -131,6 +131,7 @@ func TestPostCertificateProviderDetails(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID: "lpa-id",
 					Donor: actor.Donor{
 						FirstNames: "Jane",
 						LastName:   "Doe",
@@ -140,6 +141,7 @@ func TestPostCertificateProviderDetails(t *testing.T) {
 				Return(nil)
 
 			err := CertificateProviderDetails(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				ID: "lpa-id",
 				Donor: actor.Donor{
 					FirstNames: "Jane",
 					LastName:   "Doe",
@@ -149,7 +151,7 @@ func TestPostCertificateProviderDetails(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.HowWouldCertificateProviderPreferToCarryOutTheirRole.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/check_your_lpa.go
+++ b/app/internal/page/donor/check_your_lpa.go
@@ -42,7 +42,7 @@ func CheckYourLpa(tmpl template.Template, donorStore DonorStore) Handler {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.AboutPayment)
+				return appData.Redirect(w, r, lpa, page.Paths.AboutPayment.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/check_your_lpa_test.go
+++ b/app/internal/page/donor/check_your_lpa_test.go
@@ -73,6 +73,7 @@ func TestPostCheckYourLpa(t *testing.T) {
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 	lpa := &page.Lpa{
+		ID:           "lpa-id",
 		Checked:      false,
 		HappyToShare: false,
 		Tasks:        page.Tasks{CheckYourLpa: actor.TaskInProgress},
@@ -81,6 +82,7 @@ func TestPostCheckYourLpa(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:           "lpa-id",
 			Checked:      true,
 			HappyToShare: true,
 			Tasks:        page.Tasks{CheckYourLpa: actor.TaskCompleted},
@@ -92,7 +94,7 @@ func TestPostCheckYourLpa(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostCheckYourLpaWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/choose_attorneys.go
+++ b/app/internal/page/donor/choose_attorneys.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -27,7 +26,7 @@ func ChooseAttorneys(tmpl template.Template, donorStore DonorStore, uuidString f
 		attorney, attorneyFound := lpa.Attorneys.Get(r.URL.Query().Get("id"))
 
 		if r.Method == http.MethodGet && len(lpa.Attorneys) > 0 && attorneyFound == false && addAnother == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 		}
 
 		data := &chooseAttorneysData{
@@ -88,7 +87,7 @@ func ChooseAttorneys(tmpl template.Template, donorStore DonorStore, uuidString f
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?id=%s", appData.Paths.ChooseAttorneysAddress, attorney.ID))
+				return appData.Redirect(w, r, lpa, appData.Paths.ChooseAttorneysAddress.Format(lpa.ID)+"?id="+attorney.ID)
 			}
 		}
 

--- a/app/internal/page/donor/choose_attorneys_address.go
+++ b/app/internal/page/donor/choose_attorneys_address.go
@@ -15,7 +15,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 		attorney, found := lpa.Attorneys.Get(attorneyId)
 
 		if found == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneys)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneys.Format(lpa.ID))
 		}
 
 		data := &chooseAddressData{
@@ -51,7 +51,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+				return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 
 			case "manual":
 				if data.Errors.None() {
@@ -59,7 +59,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 				}
 
 			case "postcode-select":
@@ -85,7 +85,7 @@ func ChooseAttorneysAddress(logger Logger, tmpl template.Template, addressClient
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 				} else {
 					data.Addresses = lpa.ActorAddresses()
 				}

--- a/app/internal/page/donor/choose_attorneys_address_test.go
+++ b/app/internal/page/donor/choose_attorneys_address_test.go
@@ -149,12 +149,14 @@ func TestPostChooseAttorneysAddressSkip(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:        "lpa-id",
 			Attorneys: actor.Attorneys{{ID: "123", FirstNames: "a", Email: "a"}},
 			Tasks:     page.Tasks{ChooseAttorneys: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := ChooseAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Attorneys: actor.Attorneys{{
 			ID:         "123",
 			FirstNames: "a",
@@ -166,7 +168,7 @@ func TestPostChooseAttorneysAddressSkip(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseAttorneysAddressSkipWhenStoreErrors(t *testing.T) {
@@ -215,6 +217,7 @@ func TestPostChooseAttorneysAddressManual(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:    "lpa-id",
 			Tasks: page.Tasks{ChooseAttorneys: actor.TaskCompleted},
 			Attorneys: actor.Attorneys{{
 				ID:         "123",
@@ -225,6 +228,7 @@ func TestPostChooseAttorneysAddressManual(t *testing.T) {
 		Return(nil)
 
 	err := ChooseAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Attorneys: actor.Attorneys{{
 			ID:         "123",
 			FirstNames: "a",
@@ -235,7 +239,7 @@ func TestPostChooseAttorneysAddressManual(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseAttorneysAddressManualWhenStoreErrors(t *testing.T) {
@@ -284,6 +288,7 @@ func TestPostChooseAttorneysAddressManualFromStore(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:    "lpa-id",
 			Tasks: page.Tasks{ChooseAttorneys: actor.TaskCompleted},
 			Attorneys: actor.Attorneys{{
 				ID:         "123",
@@ -295,6 +300,7 @@ func TestPostChooseAttorneysAddressManualFromStore(t *testing.T) {
 		Return(nil)
 
 	err := ChooseAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Attorneys: actor.Attorneys{{
 			ID:         "123",
 			FirstNames: "John",
@@ -306,7 +312,7 @@ func TestPostChooseAttorneysAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseAttorneysAddressManualWhenValidationError(t *testing.T) {
@@ -710,19 +716,21 @@ func TestPostChooseAttorneysAddressReuseSelect(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:        "lpa-id",
 			Attorneys: actor.Attorneys{updatedAttorney},
 			Tasks:     page.Tasks{ChooseAttorneys: actor.TaskInProgress},
 		}).
 		Return(nil)
 
 	err := ChooseAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:        "lpa-id",
 		Attorneys: actor.Attorneys{{ID: "123"}},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseAttorneysAddressReuseSelectWhenValidationError(t *testing.T) {
@@ -767,15 +775,15 @@ func TestPostChooseAttorneysManuallyFromAnotherPage(t *testing.T) {
 	}{
 		"with from value": {
 			"/?from=/test&id=123",
-			"/lpa/lpa-id/test",
+			"/test",
 		},
 		"without from value": {
 			"/?from=&id=123",
-			"/lpa/lpa-id" + page.Paths.ChooseAttorneysSummary,
+			page.Paths.ChooseAttorneysSummary.Format("lpa-id"),
 		},
 		"missing from key": {
 			"/?id=123",
-			"/lpa/lpa-id" + page.Paths.ChooseAttorneysSummary,
+			page.Paths.ChooseAttorneysSummary.Format("lpa-id"),
 		},
 	}
 
@@ -793,6 +801,7 @@ func TestPostChooseAttorneysManuallyFromAnotherPage(t *testing.T) {
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 			lpa := &page.Lpa{
+				ID: "lpa-id",
 				Attorneys: actor.Attorneys{
 					{
 						ID: "123",

--- a/app/internal/page/donor/choose_attorneys_summary.go
+++ b/app/internal/page/donor/choose_attorneys_summary.go
@@ -19,7 +19,7 @@ type chooseAttorneysSummaryData struct {
 func ChooseAttorneysSummary(tmpl template.Template) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.Attorneys) == 0 {
-			return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys))
+			return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys.Format(lpa.ID)))
 		}
 
 		data := &chooseAttorneysSummaryData{
@@ -33,14 +33,14 @@ func ChooseAttorneysSummary(tmpl template.Template) Handler {
 			data.Errors = data.Form.Validate()
 
 			if data.Errors.None() {
-				redirectUrl := appData.Paths.TaskList
+				redirectUrl := appData.Paths.TaskList.Format(lpa.ID)
 
 				if len(lpa.Attorneys) > 1 {
-					redirectUrl = appData.Paths.HowShouldAttorneysMakeDecisions
+					redirectUrl = appData.Paths.HowShouldAttorneysMakeDecisions.Format(lpa.ID)
 				}
 
 				if data.Form.AddAttorney == "yes" {
-					redirectUrl = fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys)
+					redirectUrl = fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseAttorneys.Format(lpa.ID))
 				}
 
 				return appData.Redirect(w, r, lpa, redirectUrl)

--- a/app/internal/page/donor/choose_attorneys_summary_test.go
+++ b/app/internal/page/donor/choose_attorneys_summary_test.go
@@ -38,12 +38,12 @@ func TestGetChooseAttorneysSummaryWhenNoAttorneys(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	err := ChooseAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{})
+	err := ChooseAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneys+"?addAnother=1", resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneys.Format("lpa-id")+"?addAnother=1", resp.Header.Get("Location"))
 }
 
 func TestPostChooseAttorneysSummaryAddAttorney(t *testing.T) {
@@ -54,17 +54,17 @@ func TestPostChooseAttorneysSummaryAddAttorney(t *testing.T) {
 	}{
 		"add attorney": {
 			addMoreFormValue: "yes",
-			expectedUrl:      "/lpa/lpa-id" + page.Paths.ChooseAttorneys + "?addAnother=1",
+			expectedUrl:      page.Paths.ChooseAttorneys.Format("lpa-id") + "?addAnother=1",
 			Attorneys:        actor.Attorneys{},
 		},
 		"do not add attorney - with single attorney": {
 			addMoreFormValue: "no",
-			expectedUrl:      "/lpa/lpa-id" + page.Paths.TaskList,
+			expectedUrl:      page.Paths.TaskList.Format("lpa-id"),
 			Attorneys:        actor.Attorneys{{ID: "123"}},
 		},
 		"do not add attorney - with multiple attorneys": {
 			addMoreFormValue: "no",
-			expectedUrl:      "/lpa/lpa-id" + page.Paths.HowShouldAttorneysMakeDecisions,
+			expectedUrl:      page.Paths.HowShouldAttorneysMakeDecisions.Format("lpa-id"),
 			Attorneys:        actor.Attorneys{{ID: "123"}, {ID: "456"}},
 		},
 	}
@@ -79,7 +79,7 @@ func TestPostChooseAttorneysSummaryAddAttorney(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-			err := ChooseAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{Attorneys: tc.Attorneys})
+			err := ChooseAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Attorneys: tc.Attorneys})
 			resp := w.Result()
 
 			assert.Nil(t, err)

--- a/app/internal/page/donor/choose_attorneys_test.go
+++ b/app/internal/page/donor/choose_attorneys_test.go
@@ -45,6 +45,7 @@ func TestGetChooseAttorneysFromStore(t *testing.T) {
 	template := newMockTemplate(t)
 
 	err := ChooseAttorneys(template.Execute, nil, mockUuidString)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Attorneys: actor.Attorneys{
 			{FirstNames: "John", ID: "1"},
 		},
@@ -53,7 +54,7 @@ func TestGetChooseAttorneysFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetChooseAttorneysWhenTemplateErrors(t *testing.T) {
@@ -147,6 +148,7 @@ func TestPostChooseAttorneysAttorneyDoesNotExist(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID: "lpa-id",
 					Donor: actor.Donor{
 						FirstNames: "Jane",
 						LastName:   "Doe",
@@ -157,6 +159,7 @@ func TestPostChooseAttorneysAttorneyDoesNotExist(t *testing.T) {
 				Return(nil)
 
 			err := ChooseAttorneys(nil, donorStore, mockUuidString)(testAppData, w, r, &page.Lpa{
+				ID: "lpa-id",
 				Donor: actor.Donor{
 					FirstNames: "Jane",
 					LastName:   "Doe",
@@ -166,7 +169,7 @@ func TestPostChooseAttorneysAttorneyDoesNotExist(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysAddress+"?id=123", resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.ChooseAttorneysAddress.Format("lpa-id")+"?id=123", resp.Header.Get("Location"))
 		})
 	}
 }
@@ -245,6 +248,7 @@ func TestPostChooseAttorneysAttorneyExists(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:        "lpa-id",
 					Donor:     actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					Attorneys: actor.Attorneys{tc.attorney},
 					Tasks:     page.Tasks{ChooseAttorneys: actor.TaskCompleted},
@@ -252,6 +256,7 @@ func TestPostChooseAttorneysAttorneyExists(t *testing.T) {
 				Return(nil)
 
 			err := ChooseAttorneys(nil, donorStore, mockUuidString)(testAppData, w, r, &page.Lpa{
+				ID:    "lpa-id",
 				Donor: actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 				Attorneys: actor.Attorneys{
 					{
@@ -265,7 +270,7 @@ func TestPostChooseAttorneysAttorneyExists(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysAddress+"?id=123", resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.ChooseAttorneysAddress.Format("lpa-id")+"?id=123", resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/choose_people_to_notify.go
+++ b/app/internal/page/donor/choose_people_to_notify.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -21,14 +20,14 @@ type choosePeopleToNotifyData struct {
 func ChoosePeopleToNotify(tmpl template.Template, donorStore DonorStore, uuidString func() string) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) > 4 {
-			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 		}
 
 		addAnother := r.FormValue("addAnother") == "1"
 		personToNotify, personFound := lpa.PeopleToNotify.Get(r.URL.Query().Get("id"))
 
 		if r.Method == http.MethodGet && len(lpa.PeopleToNotify) > 0 && personFound == false && addAnother == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 		}
 
 		data := &choosePeopleToNotifyData{
@@ -73,13 +72,15 @@ func ChoosePeopleToNotify(tmpl template.Template, donorStore DonorStore, uuidStr
 					lpa.PeopleToNotify.Put(personToNotify)
 				}
 
-				lpa.Tasks.PeopleToNotify = actor.TaskInProgress
+				if !lpa.Tasks.PeopleToNotify.Completed() {
+					lpa.Tasks.PeopleToNotify = actor.TaskInProgress
+				}
 
 				if err := donorStore.Put(r.Context(), lpa); err != nil {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?id=%s", appData.Paths.ChoosePeopleToNotifyAddress, personToNotify.ID))
+				return appData.Redirect(w, r, lpa, appData.Paths.ChoosePeopleToNotifyAddress.Format(lpa.ID)+"?id="+personToNotify.ID)
 			}
 		}
 

--- a/app/internal/page/donor/choose_people_to_notify_address.go
+++ b/app/internal/page/donor/choose_people_to_notify_address.go
@@ -16,7 +16,7 @@ func ChoosePeopleToNotifyAddress(logger Logger, tmpl template.Template, addressC
 		personToNotify, found := lpa.PeopleToNotify.Get(personId)
 
 		if found == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotify)
+			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotify.Format(lpa.ID))
 		}
 
 		data := &chooseAddressData{
@@ -51,7 +51,7 @@ func ChoosePeopleToNotifyAddress(logger Logger, tmpl template.Template, addressC
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 				}
 
 			case "postcode-select":
@@ -77,7 +77,7 @@ func ChoosePeopleToNotifyAddress(logger Logger, tmpl template.Template, addressC
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 				} else {
 					data.Addresses = lpa.ActorAddresses()
 				}

--- a/app/internal/page/donor/choose_people_to_notify_address_test.go
+++ b/app/internal/page/donor/choose_people_to_notify_address_test.go
@@ -141,12 +141,14 @@ func TestPostChoosePeopleToNotifyAddressManual(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:             "lpa-id",
 			PeopleToNotify: actor.PeopleToNotify{{ID: "123", Address: testAddress}},
 			Tasks:          page.Tasks{PeopleToNotify: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := ChoosePeopleToNotifyAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:             "lpa-id",
 		PeopleToNotify: actor.PeopleToNotify{{ID: "123"}},
 		Tasks:          page.Tasks{PeopleToNotify: actor.TaskInProgress},
 	})
@@ -154,7 +156,7 @@ func TestPostChoosePeopleToNotifyAddressManual(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifyAddressManualWhenStoreErrors(t *testing.T) {
@@ -202,6 +204,7 @@ func TestPostChoosePeopleToNotifyAddressManualFromStore(t *testing.T) {
 
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			PeopleToNotify: actor.PeopleToNotify{actor.PersonToNotify{
 				ID:         "123",
 				FirstNames: "John",
@@ -212,6 +215,7 @@ func TestPostChoosePeopleToNotifyAddressManualFromStore(t *testing.T) {
 		Return(nil)
 
 	err := ChoosePeopleToNotifyAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		PeopleToNotify: actor.PeopleToNotify{actor.PersonToNotify{
 			ID:         "123",
 			FirstNames: "John",
@@ -224,7 +228,7 @@ func TestPostChoosePeopleToNotifyAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifyPostcodeSelect(t *testing.T) {
@@ -560,6 +564,7 @@ func TestPostChoosePeopleToNotifyAddressReuseSelect(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			PeopleToNotify: actor.PeopleToNotify{{
 				ID: "123",
 				Address: place.Address{
@@ -574,12 +579,12 @@ func TestPostChoosePeopleToNotifyAddressReuseSelect(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := ChoosePeopleToNotifyAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{PeopleToNotify: actor.PeopleToNotify{{ID: "123"}}})
+	err := ChoosePeopleToNotifyAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifyAddressReuseSelectWhenValidationError(t *testing.T) {

--- a/app/internal/page/donor/choose_people_to_notify_summary.go
+++ b/app/internal/page/donor/choose_people_to_notify_summary.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -19,7 +18,7 @@ type choosePeopleToNotifySummaryData struct {
 func ChoosePeopleToNotifySummary(tmpl template.Template) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) == 0 {
-			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople)
+			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople.Format(lpa.ID))
 		}
 
 		data := &choosePeopleToNotifySummaryData{
@@ -33,10 +32,10 @@ func ChoosePeopleToNotifySummary(tmpl template.Template) Handler {
 			data.Errors = data.Form.Validate()
 
 			if data.Errors.None() {
-				redirectUrl := fmt.Sprintf("%s?addAnother=1", appData.Paths.ChoosePeopleToNotify)
+				redirectUrl := appData.Paths.ChoosePeopleToNotify.Format(lpa.ID) + "?addAnother=1"
 
 				if data.Form.AddPersonToNotify == "no" {
-					redirectUrl = appData.Paths.TaskList
+					redirectUrl = appData.Paths.TaskList.Format(lpa.ID)
 				}
 
 				return appData.Redirect(w, r, lpa, redirectUrl)

--- a/app/internal/page/donor/choose_people_to_notify_summary_test.go
+++ b/app/internal/page/donor/choose_people_to_notify_summary_test.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -42,6 +41,7 @@ func TestGetChoosePeopleToNotifySummaryWhenNoPeopleToNotify(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
 	err := ChoosePeopleToNotifySummary(nil)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Tasks: page.Tasks{
 			YourDetails:                actor.TaskCompleted,
 			ChooseAttorneys:            actor.TaskCompleted,
@@ -56,7 +56,7 @@ func TestGetChoosePeopleToNotifySummaryWhenNoPeopleToNotify(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.DoYouWantToNotifyPeople, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.DoYouWantToNotifyPeople.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifySummaryAddPersonToNotify(t *testing.T) {
@@ -68,12 +68,12 @@ func TestPostChoosePeopleToNotifySummaryAddPersonToNotify(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	err := ChoosePeopleToNotifySummary(nil)(testAppData, w, r, &page.Lpa{PeopleToNotify: actor.PeopleToNotify{{ID: "123"}}})
+	err := ChoosePeopleToNotifySummary(nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{{ID: "123"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, fmt.Sprintf("/lpa/lpa-id%s?addAnother=1", page.Paths.ChoosePeopleToNotify), resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotify.Format("lpa-id")+"?addAnother=1", resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifySummaryNoFurtherPeopleToNotify(t *testing.T) {
@@ -86,6 +86,7 @@ func TestPostChoosePeopleToNotifySummaryNoFurtherPeopleToNotify(t *testing.T) {
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 	err := ChoosePeopleToNotifySummary(nil)(testAppData, w, r, &page.Lpa{
+		ID:             "lpa-id",
 		PeopleToNotify: actor.PeopleToNotify{{ID: "123"}},
 		Tasks: page.Tasks{
 			YourDetails:                actor.TaskCompleted,
@@ -101,7 +102,7 @@ func TestPostChoosePeopleToNotifySummaryNoFurtherPeopleToNotify(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChoosePeopleToNotifySummaryFormValidation(t *testing.T) {

--- a/app/internal/page/donor/choose_replacement_attorneys.go
+++ b/app/internal/page/donor/choose_replacement_attorneys.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -25,7 +24,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, donorStore DonorStore, u
 		attorney, attorneyFound := lpa.ReplacementAttorneys.Get(r.URL.Query().Get("id"))
 
 		if r.Method == http.MethodGet && len(lpa.ReplacementAttorneys) > 0 && attorneyFound == false && addAnother == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 		}
 
 		data := &chooseReplacementAttorneysData{
@@ -84,7 +83,7 @@ func ChooseReplacementAttorneys(tmpl template.Template, donorStore DonorStore, u
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, fmt.Sprintf("%s?id=%s", appData.Paths.ChooseReplacementAttorneysAddress, attorney.ID))
+				return appData.Redirect(w, r, lpa, appData.Paths.ChooseReplacementAttorneysAddress.Format(lpa.ID)+"?id="+attorney.ID)
 			}
 		}
 

--- a/app/internal/page/donor/choose_replacement_attorneys_address.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address.go
@@ -46,7 +46,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+				return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 
 			case "manual":
 				if data.Errors.None() {
@@ -54,7 +54,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 				}
 
 			case "postcode-select":
@@ -80,7 +80,7 @@ func ChooseReplacementAttorneysAddress(logger Logger, tmpl template.Template, ad
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+					return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 				} else {
 					data.Addresses = lpa.ActorAddresses()
 				}

--- a/app/internal/page/donor/choose_replacement_attorneys_address_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_address_test.go
@@ -153,12 +153,14 @@ func TestPostChooseReplacementAttorneysAddressSkip(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                   "lpa-id",
 			ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a", Email: "a"}},
 			Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		ReplacementAttorneys: actor.Attorneys{{
 			ID:         "123",
 			FirstNames: "a",
@@ -170,7 +172,7 @@ func TestPostChooseReplacementAttorneysAddressSkip(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
@@ -190,6 +192,7 @@ func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			ReplacementAttorneys: actor.Attorneys{{
 				ID:         "123",
 				FirstNames: "a",
@@ -200,13 +203,14 @@ func TestPostChooseReplacementAttorneysAddressManual(t *testing.T) {
 		Return(nil)
 
 	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:                   "lpa-id",
 		ReplacementAttorneys: actor.Attorneys{{ID: "123", FirstNames: "a"}},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysAddressManualWhenStoreErrors(t *testing.T) {
@@ -250,6 +254,7 @@ func TestPostChooseReplacementAttorneysAddressManualFromStore(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			ReplacementAttorneys: actor.Attorneys{{
 				ID:         "123",
 				FirstNames: "John",
@@ -261,6 +266,7 @@ func TestPostChooseReplacementAttorneysAddressManualFromStore(t *testing.T) {
 		Return(nil)
 
 	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		ReplacementAttorneys: actor.Attorneys{{
 			ID:         "123",
 			FirstNames: "John",
@@ -272,7 +278,7 @@ func TestPostChooseReplacementAttorneysAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysAddressManualWhenValidationError(t *testing.T) {
@@ -661,19 +667,21 @@ func TestPostChooseReplacementAttorneysAddressReuseSelect(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                   "lpa-id",
 			ReplacementAttorneys: actor.Attorneys{updatedAttorney},
 			Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskInProgress},
 		}).
 		Return(nil)
 
 	err := ChooseReplacementAttorneysAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:                   "lpa-id",
 		ReplacementAttorneys: actor.Attorneys{{ID: "123"}},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysAddressReuseSelectWhenValidationError(t *testing.T) {

--- a/app/internal/page/donor/choose_replacement_attorneys_summary.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_summary.go
@@ -1,7 +1,6 @@
 package donor
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -20,7 +19,7 @@ type chooseReplacementAttorneysSummaryData struct {
 func ChooseReplacementAttorneysSummary(tmpl template.Template) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.ReplacementAttorneys) == 0 {
-			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantReplacementAttorneys)
+			return appData.Redirect(w, r, lpa, page.Paths.DoYouWantReplacementAttorneys.Format(lpa.ID))
 		}
 
 		data := &chooseReplacementAttorneysSummaryData{
@@ -37,13 +36,13 @@ func ChooseReplacementAttorneysSummary(tmpl template.Template) Handler {
 				var redirectUrl string
 
 				if data.Form.AddAttorney == "yes" {
-					redirectUrl = fmt.Sprintf("%s?addAnother=1", appData.Paths.ChooseReplacementAttorneys)
+					redirectUrl = appData.Paths.ChooseReplacementAttorneys.Format(lpa.ID) + "?addAnother=1"
 				} else if len(lpa.ReplacementAttorneys) > 1 && (len(lpa.Attorneys) == 1 || lpa.AttorneyDecisions.How == actor.JointlyForSomeSeverallyForOthers || lpa.AttorneyDecisions.How == actor.Jointly) {
-					redirectUrl = appData.Paths.HowShouldReplacementAttorneysMakeDecisions
+					redirectUrl = appData.Paths.HowShouldReplacementAttorneysMakeDecisions.Format(lpa.ID)
 				} else if lpa.AttorneyDecisions.How == actor.JointlyAndSeverally {
-					redirectUrl = appData.Paths.HowShouldReplacementAttorneysStepIn
+					redirectUrl = appData.Paths.HowShouldReplacementAttorneysStepIn.Format(lpa.ID)
 				} else {
-					redirectUrl = page.Paths.TaskList
+					redirectUrl = page.Paths.TaskList.Format(lpa.ID)
 				}
 
 				return appData.Redirect(w, r, lpa, redirectUrl)

--- a/app/internal/page/donor/choose_replacement_attorneys_summary_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_summary_test.go
@@ -43,13 +43,14 @@ func TestGetChooseReplacementAttorneysSummaryWhenNoReplacementAttorneys(t *testi
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
 	err := ChooseReplacementAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{
+		ID:    "lpa-id",
 		Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.DoYouWantReplacementAttorneys, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.DoYouWantReplacementAttorneys.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysSummaryAddAttorney(t *testing.T) {
@@ -61,12 +62,12 @@ func TestPostChooseReplacementAttorneysSummaryAddAttorney(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-	err := ChooseReplacementAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{}}})
+	err := ChooseReplacementAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", ReplacementAttorneys: actor.Attorneys{{}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneys+"?addAnother=1", resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneys.Format("lpa-id")+"?addAnother=1", resp.Header.Get("Location"))
 }
 
 func TestPostChooseReplacementAttorneysSummaryDoNotAddAttorney(t *testing.T) {
@@ -74,7 +75,7 @@ func TestPostChooseReplacementAttorneysSummaryDoNotAddAttorney(t *testing.T) {
 	attorney2 := actor.Attorney{FirstNames: "x", LastName: "y", Address: place.Address{Line1: "z"}, DateOfBirth: date.New("2000", "1", "1")}
 
 	testcases := map[string]struct {
-		redirectUrl          string
+		redirectUrl          page.LpaPath
 		attorneys            actor.Attorneys
 		replacementAttorneys actor.Attorneys
 		howAttorneysAct      string
@@ -131,6 +132,7 @@ func TestPostChooseReplacementAttorneysSummaryDoNotAddAttorney(t *testing.T) {
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 			err := ChooseReplacementAttorneysSummary(nil)(testAppData, w, r, &page.Lpa{
+				ID:                   "lpa-id",
 				ReplacementAttorneys: tc.replacementAttorneys,
 				AttorneyDecisions: actor.AttorneyDecisions{
 					How:     tc.howAttorneysAct,
@@ -146,7 +148,7 @@ func TestPostChooseReplacementAttorneysSummaryDoNotAddAttorney(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+tc.redirectUrl, resp.Header.Get("Location"))
+			assert.Equal(t, tc.redirectUrl.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/choose_replacement_attorneys_test.go
+++ b/app/internal/page/donor/choose_replacement_attorneys_test.go
@@ -43,12 +43,12 @@ func TestGetChooseReplacementAttorneysFromStore(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := ChooseReplacementAttorneys(template.Execute, nil, mockUuidString)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{{FirstNames: "John", ID: "1"}}})
+	err := ChooseReplacementAttorneys(template.Execute, nil, mockUuidString)(testAppData, w, r, &page.Lpa{ID: "lpa-id", ReplacementAttorneys: actor.Attorneys{{FirstNames: "John", ID: "1"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetChooseReplacementAttorneysWhenTemplateErrors(t *testing.T) {
@@ -141,18 +141,19 @@ func TestPostChooseReplacementAttorneysAttorneyDoesNotExists(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                   "lpa-id",
 					Donor:                actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					ReplacementAttorneys: actor.Attorneys{tc.attorney},
 					Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskCompleted},
 				}).
 				Return(nil)
 
-			err := ChooseReplacementAttorneys(nil, donorStore, mockUuidString)(testAppData, w, r, &page.Lpa{Donor: actor.Donor{FirstNames: "Jane", LastName: "Doe"}})
+			err := ChooseReplacementAttorneys(nil, donorStore, mockUuidString)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Donor: actor.Donor{FirstNames: "Jane", LastName: "Doe"}})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysAddress+"?id=123", resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.ChooseReplacementAttorneysAddress.Format("lpa-id")+"?id=123", resp.Header.Get("Location"))
 		})
 	}
 }
@@ -231,6 +232,7 @@ func TestPostChooseReplacementAttorneysAttorneyExists(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                   "lpa-id",
 					Donor:                actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 					ReplacementAttorneys: actor.Attorneys{tc.attorney},
 					Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskCompleted},
@@ -238,6 +240,7 @@ func TestPostChooseReplacementAttorneysAttorneyExists(t *testing.T) {
 				Return(nil)
 
 			err := ChooseReplacementAttorneys(nil, donorStore, mockUuidString)(testAppData, w, r, &page.Lpa{
+				ID:    "lpa-id",
 				Donor: actor.Donor{FirstNames: "Jane", LastName: "Doe"},
 				ReplacementAttorneys: actor.Attorneys{
 					{
@@ -251,7 +254,7 @@ func TestPostChooseReplacementAttorneysAttorneyExists(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysAddress+"?id=123", resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.ChooseReplacementAttorneysAddress.Format("lpa-id")+"?id=123", resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/do_you_want_to_notify_people.go
+++ b/app/internal/page/donor/do_you_want_to_notify_people.go
@@ -21,7 +21,7 @@ type doYouWantToNotifyPeopleData struct {
 func DoYouWantToNotifyPeople(tmpl template.Template, donorStore DonorStore) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if len(lpa.PeopleToNotify) > 0 {
-			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 		}
 
 		data := &doYouWantToNotifyPeopleData{
@@ -47,10 +47,10 @@ func DoYouWantToNotifyPeople(tmpl template.Template, donorStore DonorStore) Hand
 				lpa.DoYouWantToNotifyPeople = data.Form.WantToNotify
 				lpa.Tasks.PeopleToNotify = actor.TaskInProgress
 
-				redirectPath := appData.Paths.ChoosePeopleToNotify
+				redirectPath := appData.Paths.ChoosePeopleToNotify.Format(lpa.ID)
 
 				if data.Form.WantToNotify == "no" {
-					redirectPath = appData.Paths.TaskList
+					redirectPath = appData.Paths.TaskList.Format(lpa.ID)
 					lpa.Tasks.PeopleToNotify = actor.TaskCompleted
 				}
 

--- a/app/internal/page/donor/how_do_you_know_your_certificate_provider.go
+++ b/app/internal/page/donor/how_do_you_know_your_certificate_provider.go
@@ -53,10 +53,10 @@ func HowDoYouKnowYourCertificateProvider(tmpl template.Template, donorStore Dono
 				}
 
 				if requireLength {
-					return appData.Redirect(w, r, lpa, page.Paths.HowLongHaveYouKnownCertificateProvider)
+					return appData.Redirect(w, r, lpa, page.Paths.HowLongHaveYouKnownCertificateProvider.Format(lpa.ID))
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople)
+				return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/how_do_you_know_your_certificate_provider_test.go
+++ b/app/internal/page/donor/how_do_you_know_your_certificate_provider_test.go
@@ -80,7 +80,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 		form                       url.Values
 		certificateProviderDetails actor.CertificateProvider
 		taskState                  actor.TaskState
-		redirect                   string
+		redirect                   page.LpaPath
 	}{
 		"legal-professional": {
 			form: url.Values{"how": {"legal-professional"}},
@@ -89,7 +89,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				Relationship: "legal-professional",
 			},
 			taskState: actor.TaskCompleted,
-			redirect:  "/lpa/lpa-id" + page.Paths.DoYouWantToNotifyPeople,
+			redirect:  page.Paths.DoYouWantToNotifyPeople,
 		},
 		"health-professional": {
 			form: url.Values{"how": {"health-professional"}},
@@ -98,7 +98,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				Relationship: "health-professional",
 			},
 			taskState: actor.TaskCompleted,
-			redirect:  "/lpa/lpa-id" + page.Paths.DoYouWantToNotifyPeople,
+			redirect:  page.Paths.DoYouWantToNotifyPeople,
 		},
 		"other": {
 			form: url.Values{"how": {"other"}, "description": {"This"}},
@@ -109,7 +109,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength:      "gte-2-years",
 			},
 			taskState: actor.TaskInProgress,
-			redirect:  "/lpa/lpa-id" + page.Paths.HowLongHaveYouKnownCertificateProvider,
+			redirect:  page.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - friend": {
 			form: url.Values{"how": {"friend"}},
@@ -119,7 +119,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: actor.TaskInProgress,
-			redirect:  "/lpa/lpa-id" + page.Paths.HowLongHaveYouKnownCertificateProvider,
+			redirect:  page.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - neighbour": {
 			form: url.Values{"how": {"neighbour"}},
@@ -129,7 +129,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: actor.TaskInProgress,
-			redirect:  "/lpa/lpa-id" + page.Paths.HowLongHaveYouKnownCertificateProvider,
+			redirect:  page.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 		"lay - colleague": {
 			form: url.Values{"how": {"colleague"}},
@@ -139,7 +139,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				RelationshipLength: "gte-2-years",
 			},
 			taskState: actor.TaskInProgress,
-			redirect:  "/lpa/lpa-id" + page.Paths.HowLongHaveYouKnownCertificateProvider,
+			redirect:  page.Paths.HowLongHaveYouKnownCertificateProvider,
 		},
 	}
 
@@ -152,6 +152,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                  "lpa-id",
 					CertificateProvider: tc.certificateProviderDetails,
 					Tasks: page.Tasks{
 						YourDetails:         actor.TaskCompleted,
@@ -162,6 +163,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 				Return(nil)
 
 			err := HowDoYouKnowYourCertificateProvider(nil, donorStore)(testAppData, w, r, &page.Lpa{
+				ID:                  "lpa-id",
 				CertificateProvider: actor.CertificateProvider{FirstNames: "John", Relationship: "what", RelationshipLength: "gte-2-years"},
 				Tasks: page.Tasks{
 					YourDetails:     actor.TaskCompleted,
@@ -172,7 +174,7 @@ func TestPostHowDoYouKnowYourCertificateProvider(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, tc.redirect, resp.Header.Get("Location"))
+			assert.Equal(t, tc.redirect.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/how_long_have_you_known_certificate_provider.go
+++ b/app/internal/page/donor/how_long_have_you_known_certificate_provider.go
@@ -35,7 +35,7 @@ func HowLongHaveYouKnownCertificateProvider(tmpl template.Template, donorStore D
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople)
+				return appData.Redirect(w, r, lpa, page.Paths.DoYouWantToNotifyPeople.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/how_long_have_you_known_certificate_provider_test.go
+++ b/app/internal/page/donor/how_long_have_you_known_certificate_provider_test.go
@@ -86,6 +86,7 @@ func TestPostHowLongHaveYouKnownCertificateProvider(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                  "lpa-id",
 			Attorneys:           actor.Attorneys{{FirstNames: "a", LastName: "b", Address: place.Address{Line1: "c"}, DateOfBirth: date.New("1990", "1", "1")}},
 			AttorneyDecisions:   actor.AttorneyDecisions{How: actor.Jointly},
 			CertificateProvider: actor.CertificateProvider{RelationshipLength: "gte-2-years"},
@@ -94,6 +95,7 @@ func TestPostHowLongHaveYouKnownCertificateProvider(t *testing.T) {
 		Return(nil)
 
 	err := HowLongHaveYouKnownCertificateProvider(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:                "lpa-id",
 		Attorneys:         actor.Attorneys{{FirstNames: "a", LastName: "b", Address: place.Address{Line1: "c"}, DateOfBirth: date.New("1990", "1", "1")}},
 		AttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 		Tasks:             page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
@@ -102,7 +104,7 @@ func TestPostHowLongHaveYouKnownCertificateProvider(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.DoYouWantToNotifyPeople, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.DoYouWantToNotifyPeople.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostHowLongHaveYouKnownCertificateProviderWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/how_should_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_attorneys_make_decisions.go
@@ -44,9 +44,9 @@ func HowShouldAttorneysMakeDecisions(tmpl template.Template, donorStore DonorSto
 				}
 
 				if lpa.AttorneyDecisions.RequiresHappiness(len(lpa.Attorneys)) {
-					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan)
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan.Format(lpa.ID))
 				} else {
-					return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 				}
 			}
 		}

--- a/app/internal/page/donor/how_should_attorneys_make_decisions_test.go
+++ b/app/internal/page/donor/how_should_attorneys_make_decisions_test.go
@@ -93,6 +93,7 @@ func TestPostHowShouldAttorneysMakeDecisions(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                "lpa-id",
 			Attorneys:         actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}},
 			AttorneyDecisions: actor.AttorneyDecisions{How: actor.JointlyAndSeverally},
 			Tasks:             page.Tasks{ChooseAttorneys: actor.TaskCompleted},
@@ -101,12 +102,12 @@ func TestPostHowShouldAttorneysMakeDecisions(t *testing.T) {
 
 	template := newMockTemplate(t)
 
-	err := HowShouldAttorneysMakeDecisions(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}}})
+	err := HowShouldAttorneysMakeDecisions(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Attorneys: actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostHowShouldAttorneysMakeDecisionsFromStore(t *testing.T) {
@@ -150,6 +151,7 @@ func TestPostHowShouldAttorneysMakeDecisionsFromStore(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                "lpa-id",
 					Attorneys:         actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}},
 					AttorneyDecisions: actor.AttorneyDecisions{Details: tc.updatedDetails, How: tc.updatedType},
 					Tasks:             page.Tasks{ChooseAttorneys: actor.TaskInProgress},
@@ -159,6 +161,7 @@ func TestPostHowShouldAttorneysMakeDecisionsFromStore(t *testing.T) {
 			template := newMockTemplate(t)
 
 			err := HowShouldAttorneysMakeDecisions(template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+				ID:                "lpa-id",
 				Attorneys:         actor.Attorneys{{FirstNames: "a", Email: "a"}, {FirstNames: "b", Email: "b"}},
 				AttorneyDecisions: actor.AttorneyDecisions{Details: tc.existingDetails, How: tc.existingType},
 			})
@@ -166,7 +169,7 @@ func TestPostHowShouldAttorneysMakeDecisionsFromStore(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.AreYouHappyIfOneAttorneyCantActNoneCan.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_make_decisions.go
@@ -41,9 +41,9 @@ func HowShouldReplacementAttorneysMakeDecisions(tmpl template.Template, donorSto
 				}
 
 				if lpa.ReplacementAttorneyDecisions.RequiresHappiness(len(lpa.ReplacementAttorneys)) {
-					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan)
+					return appData.Redirect(w, r, lpa, page.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan.Format(lpa.ID))
 				} else {
-					return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 				}
 			}
 		}

--- a/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
+++ b/app/internal/page/donor/how_should_replacement_attorneys_step_in.go
@@ -46,11 +46,11 @@ func HowShouldReplacementAttorneysStepIn(tmpl template.Template, donorStore Dono
 				}
 
 				if len(lpa.ReplacementAttorneys) > 1 && lpa.HowShouldReplacementAttorneysStepIn == page.AllCanNoLongerAct {
-					return appData.Redirect(w, r, lpa, appData.Paths.HowShouldReplacementAttorneysMakeDecisions)
+					return appData.Redirect(w, r, lpa, appData.Paths.HowShouldReplacementAttorneysMakeDecisions.Format(lpa.ID))
 				} else if lpa.ReplacementAttorneyDecisions.RequiresHappiness(len(lpa.ReplacementAttorneys)) {
-					return appData.Redirect(w, r, lpa, appData.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan)
+					return appData.Redirect(w, r, lpa, appData.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan.Format(lpa.ID))
 				} else {
-					return appData.Redirect(w, r, lpa, appData.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, appData.Paths.TaskList.Format(lpa.ID))
 				}
 			}
 		}

--- a/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
+++ b/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
@@ -39,7 +39,7 @@ func HowWouldCertificateProviderPreferToCarryOutTheirRole(tmpl template.Template
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderAddress)
+				return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderAddress.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
+++ b/app/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
@@ -102,16 +102,17 @@ func TestPostHowWouldCertificateProviderPreferToCarryOutTheirRole(t *testing.T) 
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                  "lpa-id",
 					CertificateProvider: actor.CertificateProvider{CarryOutBy: tc.carryOutBy, Email: tc.email},
 				}).
 				Return(nil)
 
-			err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r, &page.Lpa{})
+			err := HowWouldCertificateProviderPreferToCarryOutTheirRole(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.CertificateProviderAddress, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.CertificateProviderAddress.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/identity_with_one_login.go
+++ b/app/internal/page/donor/identity_with_one_login.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/app/internal/sesh"
 )
 
-func IdentityWithOneLogin(logger Logger, oneLoginClient OneLoginClient, store sesh.Store, randomString func(int) string) page.Handler {
-	return func(appData page.AppData, w http.ResponseWriter, r *http.Request) error {
+func IdentityWithOneLogin(logger Logger, oneLoginClient OneLoginClient, store sesh.Store, randomString func(int) string) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		locale := ""
 		if appData.Lang == localize.Cy {
 			locale = "cy"
@@ -24,8 +24,8 @@ func IdentityWithOneLogin(logger Logger, oneLoginClient OneLoginClient, store se
 			State:    state,
 			Nonce:    nonce,
 			Locale:   locale,
-			LpaID:    appData.LpaID,
-			Redirect: page.Paths.IdentityWithOneLoginCallback,
+			LpaID:    lpa.ID,
+			Redirect: page.Paths.IdentityWithOneLoginCallback.Format(lpa.ID),
 		}); err != nil {
 			logger.Print(err)
 			return nil

--- a/app/internal/page/donor/identity_with_one_login_callback.go
+++ b/app/internal/page/donor/identity_with_one_login_callback.go
@@ -26,9 +26,9 @@ func IdentityWithOneLoginCallback(tmpl template.Template, oneLoginClient OneLogi
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			if lpa.DonorIdentityConfirmed() {
-				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
+				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa.Format(lpa.ID))
 			} else {
-				return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1)
+				return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/identity_with_one_login_callback_test.go
+++ b/app/internal/page/donor/identity_with_one_login_callback_test.go
@@ -272,23 +272,24 @@ func TestPostIdentityWithOneLoginCallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	err := IdentityWithOneLoginCallback(nil, nil, nil, nil)(testAppData, w, r, &page.Lpa{
+		ID:                    "lpa-id",
 		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ReadYourLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ReadYourLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithOneLoginCallbackNotConfirmed(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	err := IdentityWithOneLoginCallback(nil, nil, nil, nil)(testAppData, w, r, &page.Lpa{})
+	err := IdentityWithOneLoginCallback(nil, nil, nil, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.SelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.SelectYourIdentityOptions1.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/identity_with_one_login_test.go
+++ b/app/internal/page/donor/identity_with_one_login_test.go
@@ -34,14 +34,14 @@ func TestIdentityWithOneLogin(t *testing.T) {
 		Secure:   true,
 	}
 	session.Values = map[any]any{
-		"one-login": &sesh.OneLoginSession{State: "i am random", Nonce: "i am random", Locale: "cy", Redirect: page.Paths.IdentityWithOneLoginCallback, LpaID: "123"},
+		"one-login": &sesh.OneLoginSession{State: "i am random", Nonce: "i am random", Locale: "cy", Redirect: page.Paths.IdentityWithOneLoginCallback.Format("lpa-id"), LpaID: "lpa-id"},
 	}
 
 	sessionStore.
 		On("Save", r, w, session).
 		Return(nil)
 
-	err := IdentityWithOneLogin(nil, client, sessionStore, func(int) string { return "i am random" })(page.AppData{Lang: localize.Cy, LpaID: "123"}, w, r)
+	err := IdentityWithOneLogin(nil, client, sessionStore, func(int) string { return "i am random" })(page.AppData{Lang: localize.Cy}, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -67,7 +67,7 @@ func TestIdentityWithOneLoginWhenStoreSaveError(t *testing.T) {
 		On("Save", r, w, mock.Anything).
 		Return(expectedError)
 
-	err := IdentityWithOneLogin(logger, client, sessionStore, func(int) string { return "i am random" })(testAppData, w, r)
+	err := IdentityWithOneLogin(logger, client, sessionStore, func(int) string { return "i am random" })(testAppData, w, r, &page.Lpa{})
 	resp := w.Result()
 
 	assert.Nil(t, err)

--- a/app/internal/page/donor/identity_with_todo.go
+++ b/app/internal/page/donor/identity_with_todo.go
@@ -19,7 +19,7 @@ type identityWithTodoData struct {
 func IdentityWithTodo(tmpl template.Template, donorStore DonorStore, now func() time.Time, identityOption identity.Option) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
+			return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa.Format(lpa.ID))
 		}
 
 		lpa.DonorIdentityUserData = identity.UserData{

--- a/app/internal/page/donor/identity_with_todo_test.go
+++ b/app/internal/page/donor/identity_with_todo_test.go
@@ -69,6 +69,7 @@ func TestPostIdentityWithTodo(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	err := IdentityWithTodo(nil, nil, nil, identity.Passport)(testAppData, w, r, &page.Lpa{
+		ID:    "lpa-id",
 		Donor: actor.Donor{FirstNames: "a", LastName: "b"},
 		DonorIdentityUserData: identity.UserData{
 			OK:          true,
@@ -82,5 +83,5 @@ func TestPostIdentityWithTodo(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ReadYourLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ReadYourLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/identity_with_yoti.go
+++ b/app/internal/page/donor/identity_with_yoti.go
@@ -19,7 +19,7 @@ type identityWithYotiData struct {
 func IdentityWithYoti(tmpl template.Template, sessionStore SessionStore, yotiClient YotiClient) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if lpa.DonorIdentityConfirmed() || yotiClient.IsTest() {
-			return appData.Redirect(w, r, lpa, page.Paths.IdentityWithYotiCallback)
+			return appData.Redirect(w, r, lpa, page.Paths.IdentityWithYotiCallback.Format(lpa.ID))
 		}
 
 		if err := sesh.SetYoti(sessionStore, r, w, &sesh.YotiSession{

--- a/app/internal/page/donor/identity_with_yoti_callback.go
+++ b/app/internal/page/donor/identity_with_yoti_callback.go
@@ -24,9 +24,9 @@ func IdentityWithYotiCallback(tmpl template.Template, yotiClient YotiClient, don
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
 			if lpa.DonorIdentityConfirmed() {
-				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa)
+				return appData.Redirect(w, r, lpa, page.Paths.ReadYourLpa.Format(lpa.ID))
 			} else {
-				return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1)
+				return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/identity_with_yoti_callback_test.go
+++ b/app/internal/page/donor/identity_with_yoti_callback_test.go
@@ -175,6 +175,7 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	err := IdentityWithYotiCallback(nil, nil, nil)(testAppData, w, r, &page.Lpa{
+		ID:                    "lpa-id",
 		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID},
 		DonorIdentityOption:   identity.EasyID,
 	})
@@ -182,17 +183,17 @@ func TestPostIdentityWithYotiCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ReadYourLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ReadYourLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostIdentityWithYotiCallbackNotConfirmed(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
-	err := IdentityWithYotiCallback(nil, nil, nil)(testAppData, w, r, &page.Lpa{})
+	err := IdentityWithYotiCallback(nil, nil, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.SelectYourIdentityOptions1, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.SelectYourIdentityOptions1.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/identity_with_yoti_test.go
+++ b/app/internal/page/donor/identity_with_yoti_test.go
@@ -75,12 +75,12 @@ func TestGetIdentityWithYotiWhenAlreadyProvided(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	err := IdentityWithYoti(nil, nil, nil)(testAppData, w, r, &page.Lpa{DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID}})
+	err := IdentityWithYoti(nil, nil, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.EasyID}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.IdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.IdentityWithYotiCallback.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenTest(t *testing.T) {
@@ -90,12 +90,12 @@ func TestGetIdentityWithYotiWhenTest(t *testing.T) {
 	yotiClient := newMockYotiClient(t)
 	yotiClient.On("IsTest").Return(true)
 
-	err := IdentityWithYoti(nil, nil, yotiClient)(testAppData, w, r, &page.Lpa{})
+	err := IdentityWithYoti(nil, nil, yotiClient)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.IdentityWithYotiCallback, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.IdentityWithYotiCallback.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestGetIdentityWithYotiWhenTemplateError(t *testing.T) {

--- a/app/internal/page/donor/life_sustaining_treatment.go
+++ b/app/internal/page/donor/life_sustaining_treatment.go
@@ -33,7 +33,7 @@ func LifeSustainingTreatment(tmpl template.Template, donorStore DonorStore) Hand
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/life_sustaining_treatment_test.go
+++ b/app/internal/page/donor/life_sustaining_treatment_test.go
@@ -80,19 +80,21 @@ func TestPostLifeSustainingTreatment(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                            "lpa-id",
 			LifeSustainingTreatmentOption: page.OptionA,
 			Tasks:                         page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, LifeSustainingTreatment: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := LifeSustainingTreatment(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:    "lpa-id",
 		Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostLifeSustainingTreatmentWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/lpa_type.go
+++ b/app/internal/page/donor/lpa_type.go
@@ -34,7 +34,7 @@ func LpaType(tmpl template.Template, donorStore DonorStore) Handler {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/lpa_type_test.go
+++ b/app/internal/page/donor/lpa_type_test.go
@@ -82,18 +82,21 @@ func TestPostLpaType(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Put", r.Context(), &page.Lpa{Donor: actor.Donor{
-			FirstNames:  "Jane",
-			LastName:    "Smith",
-			DateOfBirth: date.New("2000", "1", "2"),
-			Address:     place.Address{Postcode: "ABC123"},
-		},
+		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
+			Donor: actor.Donor{
+				FirstNames:  "Jane",
+				LastName:    "Smith",
+				DateOfBirth: date.New("2000", "1", "2"),
+				Address:     place.Address{Postcode: "ABC123"},
+			},
 			Type:  page.LpaTypePropertyFinance,
 			Tasks: page.Tasks{YourDetails: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := LpaType(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Donor: actor.Donor{
 			FirstNames:  "Jane",
 			LastName:    "Smith",
@@ -105,7 +108,7 @@ func TestPostLpaType(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostLpaTypeWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -233,7 +233,7 @@ func Register(
 	handleWithLpa(page.Paths.WhatYoullNeedToConfirmYourIdentity, None,
 		Guidance(tmpls.Get("what_youll_need_to_confirm_your_identity.gohtml")))
 
-	for path, page := range map[string]int{
+	for path, page := range map[page.LpaPath]int{
 		page.Paths.SelectYourIdentityOptions:  0,
 		page.Paths.SelectYourIdentityOptions1: 1,
 		page.Paths.SelectYourIdentityOptions2: 2,
@@ -248,12 +248,12 @@ func Register(
 		IdentityWithYoti(tmpls.Get("identity_with_yoti.gohtml"), sessionStore, yotiClient))
 	handleWithLpa(page.Paths.IdentityWithYotiCallback, CanGoBack,
 		IdentityWithYotiCallback(tmpls.Get("identity_with_yoti_callback.gohtml"), yotiClient, donorStore))
-	handleLpa(page.Paths.IdentityWithOneLogin, CanGoBack,
+	handleWithLpa(page.Paths.IdentityWithOneLogin, CanGoBack,
 		IdentityWithOneLogin(logger, oneLoginClient, sessionStore, random.String))
 	handleWithLpa(page.Paths.IdentityWithOneLoginCallback, CanGoBack,
 		IdentityWithOneLoginCallback(tmpls.Get("identity_with_one_login_callback.gohtml"), oneLoginClient, sessionStore, donorStore))
 
-	for path, identityOption := range map[string]identity.Option{
+	for path, identityOption := range map[page.LpaPath]identity.Option{
 		page.Paths.IdentityWithPassport:                 identity.Passport,
 		page.Paths.IdentityWithBiometricResidencePermit: identity.BiometricResidencePermit,
 		page.Paths.IdentityWithDrivingLicencePaper:      identity.DrivingLicencePaper,
@@ -266,7 +266,7 @@ func Register(
 
 	handleWithLpa(page.Paths.ReadYourLpa, None,
 		Guidance(tmpls.Get("read_your_lpa.gohtml")))
-	handleWithLpa(page.Paths.YourLegalRightsAndResponsibilities, CanGoBack,
+	handleWithLpa(page.Paths.LpaYourLegalRightsAndResponsibilities, CanGoBack,
 		Guidance(tmpls.Get("your_legal_rights_and_responsibilities.gohtml")))
 	handleWithLpa(page.Paths.SignYourLpa, CanGoBack,
 		SignYourLpa(tmpls.Get("sign_your_lpa.gohtml"), donorStore))
@@ -291,22 +291,22 @@ const (
 	CanGoBack
 )
 
-func makeHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOpt, errorHandler page.ErrorHandler) func(string, handleOpt, page.Handler) {
-	return func(path string, opt handleOpt, h page.Handler) {
+func makeHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOpt, errorHandler page.ErrorHandler) func(page.Path, handleOpt, page.Handler) {
+	return func(path page.Path, opt handleOpt, h page.Handler) {
 		opt = opt | defaultOptions
 
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(path.String(), func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			appData := page.AppDataFromContext(ctx)
-			appData.Page = path
+			appData.Page = path.Format()
 			appData.CanGoBack = opt&CanGoBack != 0
 			appData.ActorType = actor.TypeDonor
 
 			if opt&RequireSession != 0 {
 				donorSession, err := sesh.Login(store, r)
 				if err != nil {
-					http.Redirect(w, r, page.Paths.Start, http.StatusFound)
+					http.Redirect(w, r, page.Paths.Start.Format(), http.StatusFound)
 					return
 				}
 
@@ -331,21 +331,20 @@ func makeHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOpt, 
 	}
 }
 
-func makeLpaHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOpt, errorHandler page.ErrorHandler, donorStore DonorStore, uidClient UidClient, logger Logger) func(string, handleOpt, Handler) {
-	return func(path string, opt handleOpt, h Handler) {
+func makeLpaHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOpt, errorHandler page.ErrorHandler, donorStore DonorStore, uidClient UidClient, logger Logger) func(page.LpaPath, handleOpt, Handler) {
+	return func(path page.LpaPath, opt handleOpt, h Handler) {
 		opt = opt | defaultOptions
 
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(path.String(), func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			appData := page.AppDataFromContext(ctx)
-			appData.Page = path
 			appData.CanGoBack = opt&CanGoBack != 0
 			appData.ActorType = actor.TypeDonor
 
 			donorSession, err := sesh.Login(store, r)
 			if err != nil {
-				http.Redirect(w, r, page.Paths.Start, http.StatusFound)
+				http.Redirect(w, r, page.Paths.Start.Format(), http.StatusFound)
 				return
 			}
 
@@ -361,6 +360,8 @@ func makeLpaHandle(mux *http.ServeMux, store sesh.Store, defaultOptions handleOp
 			} else {
 				ctx = page.ContextWithSessionData(ctx, &page.SessionData{SessionID: appData.SessionID, LpaID: appData.LpaID})
 			}
+
+			appData.Page = path.Format(appData.LpaID)
 
 			lpa, err := donorStore.Get(ctx)
 			if err != nil {

--- a/app/internal/page/donor/register_test.go
+++ b/app/internal/page/donor/register_test.go
@@ -137,7 +137,7 @@ func TestMakeHandleSessionError(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleSessionMissing(t *testing.T) {
@@ -157,7 +157,7 @@ func TestMakeHandleSessionMissing(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeHandleNoSessionRequired(t *testing.T) {
@@ -211,7 +211,7 @@ func TestMakeLpaHandleWhenDetailsProvidedAndUIDExists(t *testing.T) {
 	handle := makeLpaHandle(mux, sessionStore, RequireSession, nil, donorStore, nil, nil)
 	handle("/path", None, func(appData page.AppData, hw http.ResponseWriter, hr *http.Request, lpa *page.Lpa) error {
 		assert.Equal(t, page.AppData{
-			Page:      "/path",
+			Page:      "/lpa//path",
 			ActorType: actor.TypeDonor,
 			SessionID: "cmFuZG9t",
 		}, appData)
@@ -251,7 +251,7 @@ func TestMakeLpaHandleWhenSessionStoreError(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, page.Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestMakeLpaHandleWhenLpaStoreError(t *testing.T) {
@@ -337,7 +337,7 @@ func TestMakeLpaHandleWhenDetailsProvidedAndUIDDoesNotExist(t *testing.T) {
 	handle := makeLpaHandle(mux, sessionStore, RequireSession, nil, donorStore, uidClient, nil)
 	handle("/path", None, func(appData page.AppData, hw http.ResponseWriter, hr *http.Request, lpa *page.Lpa) error {
 		assert.Equal(t, page.AppData{
-			Page:      "/path",
+			Page:      "/lpa//path",
 			ActorType: actor.TypeDonor,
 			SessionID: "cmFuZG9t",
 		}, appData)
@@ -413,7 +413,7 @@ func TestMakeLpaHandleWhenDetailsProvidedAndUIDDoesNotExistOnUidClientError(t *t
 	handle := makeLpaHandle(mux, sessionStore, RequireSession, nil, donorStore, uidClient, logger)
 	handle("/path", None, func(appData page.AppData, hw http.ResponseWriter, hr *http.Request, lpa *page.Lpa) error {
 		assert.Equal(t, page.AppData{
-			Page:      "/path",
+			Page:      "/lpa//path",
 			ActorType: actor.TypeDonor,
 			SessionID: "cmFuZG9t",
 		}, appData)
@@ -515,7 +515,7 @@ func TestMakeLpaHandleSessionExistingSessionData(t *testing.T) {
 	handle := makeLpaHandle(mux, sessionStore, None, nil, donorStore, nil, nil)
 	handle("/path", RequireSession|CanGoBack, func(appData page.AppData, hw http.ResponseWriter, hr *http.Request, lpa *page.Lpa) error {
 		assert.Equal(t, page.AppData{
-			Page:      "/path",
+			Page:      "/lpa/123/path",
 			SessionID: "cmFuZG9t",
 			CanGoBack: true,
 			LpaID:     "123",

--- a/app/internal/page/donor/remove_attorney.go
+++ b/app/internal/page/donor/remove_attorney.go
@@ -23,7 +23,7 @@ func RemoveAttorney(logger Logger, tmpl template.Template, donorStore DonorStore
 		attorney, found := lpa.Attorneys.Get(id)
 
 		if found == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 		}
 
 		data := &removeAttorneyData{
@@ -52,7 +52,7 @@ func RemoveAttorney(logger Logger, tmpl template.Template, donorStore DonorStore
 					}
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary)
+				return appData.Redirect(w, r, lpa, page.Paths.ChooseAttorneysSummary.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/remove_attorney_test.go
+++ b/app/internal/page/donor/remove_attorney_test.go
@@ -61,13 +61,13 @@ func TestGetRemoveAttorneyAttorneyDoesNotExist(t *testing.T) {
 		},
 	}
 
-	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorney}})
+	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Attorneys: actor.Attorneys{attorney}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemoveAttorney(t *testing.T) {
@@ -78,14 +78,16 @@ func TestPostRemoveAttorney(t *testing.T) {
 	testcases := map[string]struct {
 		lpa        *page.Lpa
 		updatedLpa *page.Lpa
-		redirect   string
+		redirect   page.LpaPath
 	}{
 		"many left": {
 			lpa: &page.Lpa{
+				ID:                "lpa-id",
 				Attorneys:         actor.Attorneys{attorneyWithEmail, attorneyWithAddress, attorneyWithoutAddress},
 				AttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 			},
 			updatedLpa: &page.Lpa{
+				ID:                "lpa-id",
 				Attorneys:         actor.Attorneys{attorneyWithEmail, attorneyWithAddress},
 				AttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 				Tasks:             page.Tasks{ChooseAttorneys: actor.TaskInProgress},
@@ -94,18 +96,21 @@ func TestPostRemoveAttorney(t *testing.T) {
 		},
 		"one left": {
 			lpa: &page.Lpa{
+				ID:                "lpa-id",
 				Attorneys:         actor.Attorneys{attorneyWithAddress, attorneyWithoutAddress},
 				AttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 			},
 			updatedLpa: &page.Lpa{
+				ID:        "lpa-id",
 				Attorneys: actor.Attorneys{attorneyWithAddress},
 				Tasks:     page.Tasks{ChooseAttorneys: actor.TaskInProgress},
 			},
 			redirect: page.Paths.ChooseAttorneysSummary,
 		},
 		"none left": {
-			lpa: &page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress}},
+			lpa: &page.Lpa{ID: "lpa-id", Attorneys: actor.Attorneys{attorneyWithoutAddress}},
 			updatedLpa: &page.Lpa{
+				ID:        "lpa-id",
 				Attorneys: actor.Attorneys{},
 			},
 			redirect: page.Paths.ChooseAttorneysSummary,
@@ -136,7 +141,7 @@ func TestPostRemoveAttorney(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+tc.redirect, resp.Header.Get("Location"))
+			assert.Equal(t, tc.redirect.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -165,13 +170,13 @@ func TestPostRemoveAttorneyWithFormValueNo(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
+	err := RemoveAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", Attorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemoveAttorneyErrorOnPutStore(t *testing.T) {

--- a/app/internal/page/donor/remove_person_to_notify.go
+++ b/app/internal/page/donor/remove_person_to_notify.go
@@ -23,7 +23,7 @@ func RemovePersonToNotify(logger Logger, tmpl template.Template, donorStore Dono
 		person, found := lpa.PeopleToNotify.Get(id)
 
 		if found == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 		}
 
 		data := &removePersonToNotifyData{
@@ -49,7 +49,7 @@ func RemovePersonToNotify(logger Logger, tmpl template.Template, donorStore Dono
 					}
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary)
+				return appData.Redirect(w, r, lpa, page.Paths.ChoosePeopleToNotifySummary.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/remove_person_to_notify_test.go
+++ b/app/internal/page/donor/remove_person_to_notify_test.go
@@ -61,13 +61,13 @@ func TestGetRemovePersonToNotifyAttorneyDoesNotExist(t *testing.T) {
 		},
 	}
 
-	err := RemovePersonToNotify(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{PeopleToNotify: actor.PeopleToNotify{personToNotify}})
+	err := RemovePersonToNotify(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{personToNotify}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemovePersonToNotify(t *testing.T) {
@@ -96,16 +96,16 @@ func TestPostRemovePersonToNotify(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Put", r.Context(), &page.Lpa{PeopleToNotify: actor.PeopleToNotify{personToNotifyWithAddress}}).
+		On("Put", r.Context(), &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{personToNotifyWithAddress}}).
 		Return(nil)
 
-	err := RemovePersonToNotify(logger, template.Execute, donorStore)(testAppData, w, r, &page.Lpa{PeopleToNotify: actor.PeopleToNotify{personToNotifyWithoutAddress, personToNotifyWithAddress}})
+	err := RemovePersonToNotify(logger, template.Execute, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{personToNotifyWithoutAddress, personToNotifyWithAddress}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemovePersonToNotifyWithFormValueNo(t *testing.T) {
@@ -132,13 +132,13 @@ func TestPostRemovePersonToNotifyWithFormValueNo(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	err := RemovePersonToNotify(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{PeopleToNotify: actor.PeopleToNotify{personToNotifyWithoutAddress, personToNotifyWithAddress}})
+	err := RemovePersonToNotify(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", PeopleToNotify: actor.PeopleToNotify{personToNotifyWithoutAddress, personToNotifyWithAddress}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemovePersonToNotifyErrorOnPutStore(t *testing.T) {
@@ -232,12 +232,14 @@ func TestRemovePersonToNotifyRemoveLastPerson(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:             "lpa-id",
 			PeopleToNotify: actor.PeopleToNotify{},
 			Tasks:          page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, PeopleToNotify: actor.TaskNotStarted},
 		}).
 		Return(nil)
 
 	err := RemovePersonToNotify(logger, template.Execute, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:             "lpa-id",
 		PeopleToNotify: actor.PeopleToNotify{personToNotifyWithoutAddress},
 		Tasks:          page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, PeopleToNotify: actor.TaskCompleted},
 	})
@@ -246,7 +248,7 @@ func TestRemovePersonToNotifyRemoveLastPerson(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChoosePeopleToNotifySummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChoosePeopleToNotifySummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestRemovePersonToNotifyFormValidate(t *testing.T) {

--- a/app/internal/page/donor/remove_replacement_attorney.go
+++ b/app/internal/page/donor/remove_replacement_attorney.go
@@ -23,7 +23,7 @@ func RemoveReplacementAttorney(logger Logger, tmpl template.Template, donorStore
 		attorney, found := lpa.ReplacementAttorneys.Get(id)
 
 		if found == false {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 		}
 
 		data := &removeReplacementAttorneyData{
@@ -51,7 +51,7 @@ func RemoveReplacementAttorney(logger Logger, tmpl template.Template, donorStore
 					}
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+				return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/remove_replacement_attorney_test.go
+++ b/app/internal/page/donor/remove_replacement_attorney_test.go
@@ -59,13 +59,13 @@ func TestGetRemoveReplacementAttorneyAttorneyDoesNotExist(t *testing.T) {
 		},
 	}
 
-	err := RemoveReplacementAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{attorney}})
+	err := RemoveReplacementAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", ReplacementAttorneys: actor.Attorneys{attorney}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemoveReplacementAttorney(t *testing.T) {
@@ -76,14 +76,16 @@ func TestPostRemoveReplacementAttorney(t *testing.T) {
 	testcases := map[string]struct {
 		lpa        *page.Lpa
 		updatedLpa *page.Lpa
-		redirect   string
+		redirect   page.LpaPath
 	}{
 		"many left": {
 			lpa: &page.Lpa{
+				ID:                           "lpa-id",
 				ReplacementAttorneys:         actor.Attorneys{attorneyWithEmail, attorneyWithAddress, attorneyWithoutAddress},
 				ReplacementAttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 			},
 			updatedLpa: &page.Lpa{
+				ID:                           "lpa-id",
 				ReplacementAttorneys:         actor.Attorneys{attorneyWithEmail, attorneyWithAddress},
 				ReplacementAttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 				Tasks:                        page.Tasks{ChooseReplacementAttorneys: actor.TaskInProgress},
@@ -92,18 +94,21 @@ func TestPostRemoveReplacementAttorney(t *testing.T) {
 		},
 		"one left": {
 			lpa: &page.Lpa{
+				ID:                           "lpa-id",
 				ReplacementAttorneys:         actor.Attorneys{attorneyWithAddress, attorneyWithoutAddress},
 				ReplacementAttorneyDecisions: actor.AttorneyDecisions{How: actor.Jointly},
 			},
 			updatedLpa: &page.Lpa{
+				ID:                   "lpa-id",
 				ReplacementAttorneys: actor.Attorneys{attorneyWithAddress},
 				Tasks:                page.Tasks{ChooseReplacementAttorneys: actor.TaskInProgress},
 			},
 			redirect: page.Paths.ChooseReplacementAttorneysSummary,
 		},
 		"none left": {
-			lpa: &page.Lpa{ReplacementAttorneys: actor.Attorneys{attorneyWithoutAddress}},
+			lpa: &page.Lpa{ID: "lpa-id", ReplacementAttorneys: actor.Attorneys{attorneyWithoutAddress}},
 			updatedLpa: &page.Lpa{
+				ID:                   "lpa-id",
 				ReplacementAttorneys: actor.Attorneys{},
 			},
 			redirect: page.Paths.ChooseReplacementAttorneysSummary,
@@ -135,7 +140,7 @@ func TestPostRemoveReplacementAttorney(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+tc.redirect, resp.Header.Get("Location"))
+			assert.Equal(t, tc.redirect.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -164,13 +169,13 @@ func TestPostRemoveReplacementAttorneyWithFormValueNo(t *testing.T) {
 		Address: place.Address{},
 	}
 
-	err := RemoveReplacementAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ReplacementAttorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
+	err := RemoveReplacementAttorney(logger, template.Execute, nil)(testAppData, w, r, &page.Lpa{ID: "lpa-id", ReplacementAttorneys: actor.Attorneys{attorneyWithoutAddress, attorneyWithAddress}})
 
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.ChooseReplacementAttorneysSummary, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.ChooseReplacementAttorneysSummary.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRemoveReplacementAttorneyErrorOnPutStore(t *testing.T) {

--- a/app/internal/page/donor/resend_witness_code.go
+++ b/app/internal/page/donor/resend_witness_code.go
@@ -30,7 +30,7 @@ func ResendWitnessCode(tmpl template.Template, witnessCodeSender WitnessCodeSend
 				return err
 			}
 
-			return appData.Redirect(w, r, lpa, page.Paths.WitnessingAsCertificateProvider)
+			return appData.Redirect(w, r, lpa, page.Paths.WitnessingAsCertificateProvider.Format(lpa.ID))
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/resend_witness_code_test.go
+++ b/app/internal/page/donor/resend_witness_code_test.go
@@ -55,6 +55,7 @@ func TestPostResendWitnessCode(t *testing.T) {
 	r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 	lpa := &page.Lpa{
+		ID:                    "lpa-id",
 		Donor:                 actor.Donor{FirstNames: "john"},
 		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin, FirstNames: "john"},
 	}
@@ -69,7 +70,7 @@ func TestPostResendWitnessCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.WitnessingAsCertificateProvider, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.WitnessingAsCertificateProvider.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostResendWitnessCodeWhenSendErrors(t *testing.T) {

--- a/app/internal/page/donor/restrictions.go
+++ b/app/internal/page/donor/restrictions.go
@@ -34,7 +34,7 @@ func Restrictions(tmpl template.Template, donorStore DonorStore) Handler {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/restrictions_test.go
+++ b/app/internal/page/donor/restrictions_test.go
@@ -83,19 +83,21 @@ func TestPostRestrictions(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:           "lpa-id",
 			Restrictions: "blah",
 			Tasks:        page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, Restrictions: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := Restrictions(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:    "lpa-id",
 		Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostRestrictionsWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/select_your_identity_options.go
+++ b/app/internal/page/donor/select_your_identity_options.go
@@ -34,12 +34,12 @@ func SelectYourIdentityOptions(tmpl template.Template, donorStore DonorStore, pa
 			if data.Form.None {
 				switch pageIndex {
 				case 0:
-					return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1)
+					return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions1.Format(lpa.ID))
 				case 1:
-					return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions2)
+					return appData.Redirect(w, r, lpa, page.Paths.SelectYourIdentityOptions2.Format(lpa.ID))
 				default:
 					// will go to vouching flow when that is built
-					return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+					return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 				}
 			}
 
@@ -51,7 +51,7 @@ func SelectYourIdentityOptions(tmpl template.Template, donorStore DonorStore, pa
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.YourChosenIdentityOptions)
+				return appData.Redirect(w, r, lpa, page.Paths.YourChosenIdentityOptions.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/select_your_identity_options_test.go
+++ b/app/internal/page/donor/select_your_identity_options_test.go
@@ -85,6 +85,7 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                  "lpa-id",
 			DonorIdentityOption: identity.Passport,
 			Tasks: page.Tasks{
 				ConfirmYourIdentityAndSign: actor.TaskInProgress,
@@ -92,19 +93,19 @@ func TestPostSelectYourIdentityOptions(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r, &page.Lpa{})
+	err := SelectYourIdentityOptions(nil, donorStore, 0)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.YourChosenIdentityOptions, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.YourChosenIdentityOptions.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
-	for pageIndex, nextPath := range map[int]string{
-		0: "/lpa/lpa-id" + page.Paths.SelectYourIdentityOptions1,
-		1: "/lpa/lpa-id" + page.Paths.SelectYourIdentityOptions2,
-		2: "/lpa/lpa-id" + page.Paths.TaskList,
+	for pageIndex, nextPath := range map[int]page.LpaPath{
+		0: page.Paths.SelectYourIdentityOptions1,
+		1: page.Paths.SelectYourIdentityOptions2,
+		2: page.Paths.TaskList,
 	} {
 		t.Run(fmt.Sprintf("Page%d", pageIndex), func(t *testing.T) {
 			form := url.Values{
@@ -115,12 +116,12 @@ func TestPostSelectYourIdentityOptionsNone(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
-			err := SelectYourIdentityOptions(nil, nil, pageIndex)(testAppData, w, r, &page.Lpa{})
+			err := SelectYourIdentityOptions(nil, nil, pageIndex)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 			resp := w.Result()
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, nextPath, resp.Header.Get("Location"))
+			assert.Equal(t, nextPath.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }

--- a/app/internal/page/donor/sign_your_lpa.go
+++ b/app/internal/page/donor/sign_your_lpa.go
@@ -54,7 +54,7 @@ func SignYourLpa(tmpl template.Template, donorStore DonorStore) Handler {
 			}
 
 			if data.Errors.None() {
-				return appData.Redirect(w, r, lpa, page.Paths.WitnessingYourSignature)
+				return appData.Redirect(w, r, lpa, page.Paths.WitnessingYourSignature.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/sign_your_lpa_test.go
+++ b/app/internal/page/donor/sign_your_lpa_test.go
@@ -79,6 +79,7 @@ func TestPostSignYourLpa(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                    "lpa-id",
 			DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 			Tasks: page.Tasks{
 				ConfirmYourIdentityAndSign: actor.TaskCompleted,
@@ -88,12 +89,12 @@ func TestPostSignYourLpa(t *testing.T) {
 		}).
 		Return(nil)
 
-	err := SignYourLpa(nil, donorStore)(testAppData, w, r, &page.Lpa{DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin}})
+	err := SignYourLpa(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id", DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin}})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.WitnessingYourSignature, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.WitnessingYourSignature.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostSignYourLpaWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/task_list.go
+++ b/app/internal/page/donor/task_list.go
@@ -37,13 +37,13 @@ func TaskList(tmpl template.Template) Handler {
 
 		typeSpecificStep := taskListItem{
 			Name:  "chooseWhenTheLpaCanBeUsed",
-			Path:  page.Paths.WhenCanTheLpaBeUsed,
+			Path:  page.Paths.WhenCanTheLpaBeUsed.Format(lpa.ID),
 			State: lpa.Tasks.WhenCanTheLpaBeUsed,
 		}
 		if lpa.Type == page.LpaTypeHealthWelfare {
 			typeSpecificStep = taskListItem{
 				Name:  "lifeSustainingTreatment",
-				Path:  page.Paths.LifeSustainingTreatment,
+				Path:  page.Paths.LifeSustainingTreatment.Format(lpa.ID),
 				State: lpa.Tasks.LifeSustainingTreatment,
 			}
 		}
@@ -57,41 +57,41 @@ func TaskList(tmpl template.Template) Handler {
 					Items: []taskListItem{
 						{
 							Name:  "provideYourDetails",
-							Path:  page.Paths.YourDetails,
+							Path:  page.Paths.YourDetails.Format(lpa.ID),
 							State: lpa.Tasks.YourDetails,
 						},
 						{
 							Name:  "chooseYourAttorneys",
-							Path:  page.Paths.ChooseAttorneys,
+							Path:  page.Paths.ChooseAttorneys.Format(lpa.ID),
 							State: lpa.Tasks.ChooseAttorneys,
 							Count: len(lpa.Attorneys),
 						},
 						{
 							Name:  "chooseYourReplacementAttorneys",
-							Path:  page.Paths.DoYouWantReplacementAttorneys,
+							Path:  page.Paths.DoYouWantReplacementAttorneys.Format(lpa.ID),
 							State: lpa.Tasks.ChooseReplacementAttorneys,
 							Count: len(lpa.ReplacementAttorneys),
 						},
 						typeSpecificStep,
 						{
 							Name:  "addRestrictionsToTheLpa",
-							Path:  page.Paths.Restrictions,
+							Path:  page.Paths.Restrictions.Format(lpa.ID),
 							State: lpa.Tasks.Restrictions,
 						},
 						{
 							Name:  "chooseYourCertificateProvider",
-							Path:  page.Paths.WhoDoYouWantToBeCertificateProviderGuidance,
+							Path:  page.Paths.WhoDoYouWantToBeCertificateProviderGuidance.Format(lpa.ID),
 							State: lpa.Tasks.CertificateProvider,
 						},
 						{
 							Name:  "peopleToNotifyAboutYourLpa",
-							Path:  page.Paths.DoYouWantToNotifyPeople,
+							Path:  page.Paths.DoYouWantToNotifyPeople.Format(lpa.ID),
 							State: lpa.Tasks.PeopleToNotify,
 							Count: len(lpa.PeopleToNotify),
 						},
 						{
 							Name:  "checkAndSendToYourCertificateProvider",
-							Path:  page.Paths.CheckYourLpa,
+							Path:  page.Paths.CheckYourLpa.Format(lpa.ID),
 							State: lpa.Tasks.CheckYourLpa,
 						},
 					},
@@ -101,7 +101,7 @@ func TaskList(tmpl template.Template) Handler {
 					Items: []taskListItem{
 						{
 							Name:  "payForTheLpa",
-							Path:  page.Paths.AboutPayment,
+							Path:  page.Paths.AboutPayment.Format(lpa.ID),
 							State: lpa.Tasks.PayForLpa,
 						},
 					},
@@ -111,7 +111,7 @@ func TaskList(tmpl template.Template) Handler {
 					Items: []taskListItem{
 						{
 							Name:  "confirmYourIdentityAndSign",
-							Path:  signTaskPage,
+							Path:  signTaskPage.Format(lpa.ID),
 							State: lpa.Tasks.ConfirmYourIdentityAndSign,
 						},
 					},

--- a/app/internal/page/donor/task_list_test.go
+++ b/app/internal/page/donor/task_list_test.go
@@ -18,17 +18,17 @@ func TestGetTaskList(t *testing.T) {
 		expected func([]taskListSection) []taskListSection
 	}{
 		"empty": {
-			lpa: &page.Lpa{},
+			lpa: &page.Lpa{ID: "lpa-id"},
 			expected: func(sections []taskListSection) []taskListSection {
 				return sections
 			},
 		},
 		"hw": {
-			lpa: &page.Lpa{Type: page.LpaTypeHealthWelfare},
+			lpa: &page.Lpa{ID: "lpa-id", Type: page.LpaTypeHealthWelfare},
 			expected: func(sections []taskListSection) []taskListSection {
 				sections[0].Items[3] = taskListItem{
 					Name: "lifeSustainingTreatment",
-					Path: page.Paths.LifeSustainingTreatment,
+					Path: page.Paths.LifeSustainingTreatment.Format("lpa-id"),
 				}
 
 				return sections
@@ -36,11 +36,12 @@ func TestGetTaskList(t *testing.T) {
 		},
 		"confirmed identity": {
 			lpa: &page.Lpa{
+				ID:                    "lpa-id",
 				DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 			},
 			expected: func(sections []taskListSection) []taskListSection {
 				sections[2].Items = []taskListItem{
-					{Name: "confirmYourIdentityAndSign", Path: page.Paths.ReadYourLpa},
+					{Name: "confirmYourIdentityAndSign", Path: page.Paths.ReadYourLpa.Format("lpa-id")},
 				}
 
 				return sections
@@ -48,6 +49,7 @@ func TestGetTaskList(t *testing.T) {
 		},
 		"mixed": {
 			lpa: &page.Lpa{
+				ID: "lpa-id",
 				Donor: actor.Donor{
 					FirstNames: "this",
 				},
@@ -66,18 +68,18 @@ func TestGetTaskList(t *testing.T) {
 			},
 			expected: func(sections []taskListSection) []taskListSection {
 				sections[0].Items = []taskListItem{
-					{Name: "provideYourDetails", Path: page.Paths.YourDetails, State: actor.TaskCompleted},
-					{Name: "chooseYourAttorneys", Path: page.Paths.ChooseAttorneys, State: actor.TaskCompleted, Count: 2},
-					{Name: "chooseYourReplacementAttorneys", Path: page.Paths.DoYouWantReplacementAttorneys, State: actor.TaskInProgress, Count: 1},
-					{Name: "chooseWhenTheLpaCanBeUsed", Path: page.Paths.WhenCanTheLpaBeUsed, State: actor.TaskInProgress},
-					{Name: "addRestrictionsToTheLpa", Path: page.Paths.Restrictions, State: actor.TaskCompleted},
-					{Name: "chooseYourCertificateProvider", Path: page.Paths.WhoDoYouWantToBeCertificateProviderGuidance, State: actor.TaskInProgress},
-					{Name: "peopleToNotifyAboutYourLpa", Path: page.Paths.DoYouWantToNotifyPeople},
-					{Name: "checkAndSendToYourCertificateProvider", Path: page.Paths.CheckYourLpa, State: actor.TaskCompleted},
+					{Name: "provideYourDetails", Path: page.Paths.YourDetails.Format("lpa-id"), State: actor.TaskCompleted},
+					{Name: "chooseYourAttorneys", Path: page.Paths.ChooseAttorneys.Format("lpa-id"), State: actor.TaskCompleted, Count: 2},
+					{Name: "chooseYourReplacementAttorneys", Path: page.Paths.DoYouWantReplacementAttorneys.Format("lpa-id"), State: actor.TaskInProgress, Count: 1},
+					{Name: "chooseWhenTheLpaCanBeUsed", Path: page.Paths.WhenCanTheLpaBeUsed.Format("lpa-id"), State: actor.TaskInProgress},
+					{Name: "addRestrictionsToTheLpa", Path: page.Paths.Restrictions.Format("lpa-id"), State: actor.TaskCompleted},
+					{Name: "chooseYourCertificateProvider", Path: page.Paths.WhoDoYouWantToBeCertificateProviderGuidance.Format("lpa-id"), State: actor.TaskInProgress},
+					{Name: "peopleToNotifyAboutYourLpa", Path: page.Paths.DoYouWantToNotifyPeople.Format("lpa-id")},
+					{Name: "checkAndSendToYourCertificateProvider", Path: page.Paths.CheckYourLpa.Format("lpa-id"), State: actor.TaskCompleted},
 				}
 
 				sections[1].Items = []taskListItem{
-					{Name: "payForTheLpa", Path: page.Paths.AboutPayment, State: actor.TaskInProgress},
+					{Name: "payForTheLpa", Path: page.Paths.AboutPayment.Format("lpa-id"), State: actor.TaskInProgress},
 				}
 
 				return sections
@@ -99,26 +101,26 @@ func TestGetTaskList(t *testing.T) {
 						{
 							Heading: "fillInTheLpa",
 							Items: []taskListItem{
-								{Name: "provideYourDetails", Path: page.Paths.YourDetails},
-								{Name: "chooseYourAttorneys", Path: page.Paths.ChooseAttorneys},
-								{Name: "chooseYourReplacementAttorneys", Path: page.Paths.DoYouWantReplacementAttorneys},
-								{Name: "chooseWhenTheLpaCanBeUsed", Path: page.Paths.WhenCanTheLpaBeUsed},
-								{Name: "addRestrictionsToTheLpa", Path: page.Paths.Restrictions},
-								{Name: "chooseYourCertificateProvider", Path: page.Paths.WhoDoYouWantToBeCertificateProviderGuidance},
-								{Name: "peopleToNotifyAboutYourLpa", Path: page.Paths.DoYouWantToNotifyPeople},
-								{Name: "checkAndSendToYourCertificateProvider", Path: page.Paths.CheckYourLpa},
+								{Name: "provideYourDetails", Path: page.Paths.YourDetails.Format("lpa-id")},
+								{Name: "chooseYourAttorneys", Path: page.Paths.ChooseAttorneys.Format("lpa-id")},
+								{Name: "chooseYourReplacementAttorneys", Path: page.Paths.DoYouWantReplacementAttorneys.Format("lpa-id")},
+								{Name: "chooseWhenTheLpaCanBeUsed", Path: page.Paths.WhenCanTheLpaBeUsed.Format("lpa-id")},
+								{Name: "addRestrictionsToTheLpa", Path: page.Paths.Restrictions.Format("lpa-id")},
+								{Name: "chooseYourCertificateProvider", Path: page.Paths.WhoDoYouWantToBeCertificateProviderGuidance.Format("lpa-id")},
+								{Name: "peopleToNotifyAboutYourLpa", Path: page.Paths.DoYouWantToNotifyPeople.Format("lpa-id")},
+								{Name: "checkAndSendToYourCertificateProvider", Path: page.Paths.CheckYourLpa.Format("lpa-id")},
 							},
 						},
 						{
 							Heading: "payForTheLpa",
 							Items: []taskListItem{
-								{Name: "payForTheLpa", Path: page.Paths.AboutPayment},
+								{Name: "payForTheLpa", Path: page.Paths.AboutPayment.Format("lpa-id")},
 							},
 						},
 						{
 							Heading: "confirmYourIdentityAndSign",
 							Items: []taskListItem{
-								{Name: "confirmYourIdentityAndSign", Path: page.Paths.HowToConfirmYourIdentityAndSign},
+								{Name: "confirmYourIdentityAndSign", Path: page.Paths.HowToConfirmYourIdentityAndSign.Format("lpa-id")},
 							},
 						},
 					}),

--- a/app/internal/page/donor/want_replacement_attorneys.go
+++ b/app/internal/page/donor/want_replacement_attorneys.go
@@ -34,9 +34,9 @@ func WantReplacementAttorneys(tmpl template.Template, donorStore DonorStore) Han
 
 				if form.Want == "no" {
 					lpa.ReplacementAttorneys = actor.Attorneys{}
-					redirectUrl = page.Paths.TaskList
+					redirectUrl = page.Paths.TaskList.Format(lpa.ID)
 				} else {
-					redirectUrl = page.Paths.ChooseReplacementAttorneys
+					redirectUrl = page.Paths.ChooseReplacementAttorneys.Format(lpa.ID)
 				}
 
 				lpa.Tasks.ChooseReplacementAttorneys = page.ChooseReplacementAttorneysState(lpa)
@@ -50,7 +50,7 @@ func WantReplacementAttorneys(tmpl template.Template, donorStore DonorStore) Han
 		}
 
 		if len(lpa.ReplacementAttorneys) > 0 {
-			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary)
+			return appData.Redirect(w, r, lpa, page.Paths.ChooseReplacementAttorneysSummary.Format(lpa.ID))
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/when_can_the_lpa_be_used.go
+++ b/app/internal/page/donor/when_can_the_lpa_be_used.go
@@ -35,7 +35,7 @@ func WhenCanTheLpaBeUsed(tmpl template.Template, donorStore DonorStore) Handler 
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.TaskList)
+				return appData.Redirect(w, r, lpa, page.Paths.TaskList.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/when_can_the_lpa_be_used_test.go
+++ b/app/internal/page/donor/when_can_the_lpa_be_used_test.go
@@ -83,19 +83,21 @@ func TestPostWhenCanTheLpaBeUsed(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID:                  "lpa-id",
 			WhenCanTheLpaBeUsed: page.UsedWhenRegistered,
 			Tasks:               page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted, WhenCanTheLpaBeUsed: actor.TaskCompleted},
 		}).
 		Return(nil)
 
 	err := WhenCanTheLpaBeUsed(nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID:    "lpa-id",
 		Tasks: page.Tasks{YourDetails: actor.TaskCompleted, ChooseAttorneys: actor.TaskCompleted},
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.TaskList, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.TaskList.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostWhenCanTheLpaBeUsedWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance.go
+++ b/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance.go
@@ -31,7 +31,7 @@ func WhoDoYouWantToBeCertificateProviderGuidance(tmpl template.Template, donorSt
 				}
 			}
 
-			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderDetails)
+			return appData.Redirect(w, r, lpa, page.Paths.CertificateProviderDetails.Format(lpa.ID))
 		}
 
 		return tmpl(w, data)

--- a/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance_test.go
+++ b/app/internal/page/donor/who_do_you_want_to_be_certificate_provider_guidance_test.go
@@ -76,15 +76,15 @@ func TestPostWhoDoYouWantToBeCertificateProviderGuidance(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Put", r.Context(), &page.Lpa{Tasks: page.Tasks{CertificateProvider: actor.TaskInProgress}}).
+		On("Put", r.Context(), &page.Lpa{ID: "lpa-id", Tasks: page.Tasks{CertificateProvider: actor.TaskInProgress}}).
 		Return(nil)
 
-	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r, &page.Lpa{})
+	err := WhoDoYouWantToBeCertificateProviderGuidance(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.CertificateProviderDetails, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.CertificateProviderDetails.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostWhoDoYouWantToBeCertificateProviderGuidanceWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/who_is_the_lpa_for.go
+++ b/app/internal/page/donor/who_is_the_lpa_for.go
@@ -31,7 +31,7 @@ func WhoIsTheLpaFor(tmpl template.Template, donorStore DonorStore) Handler {
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.LpaType)
+				return appData.Redirect(w, r, lpa, page.Paths.LpaType.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/who_is_the_lpa_for_test.go
+++ b/app/internal/page/donor/who_is_the_lpa_for_test.go
@@ -78,15 +78,15 @@ func TestPostWhoIsTheLpaFor(t *testing.T) {
 
 	donorStore := newMockDonorStore(t)
 	donorStore.
-		On("Put", r.Context(), &page.Lpa{WhoFor: "me"}).
+		On("Put", r.Context(), &page.Lpa{ID: "lpa-id", WhoFor: "me"}).
 		Return(nil)
 
-	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r, &page.Lpa{})
+	err := WhoIsTheLpaFor(nil, donorStore)(testAppData, w, r, &page.Lpa{ID: "lpa-id"})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.LpaType, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.LpaType.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostWhoIsTheLpaForWhenStoreErrors(t *testing.T) {

--- a/app/internal/page/donor/witnessing_as_certificate_provider.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider.go
@@ -73,7 +73,7 @@ func WitnessingAsCertificateProvider(tmpl template.Template, donorStore DonorSto
 					}
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.YouHaveSubmittedYourLpa)
+				return appData.Redirect(w, r, lpa, page.Paths.YouHaveSubmittedYourLpa.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/witnessing_as_certificate_provider_test.go
+++ b/app/internal/page/donor/witnessing_as_certificate_provider_test.go
@@ -117,6 +117,7 @@ func TestPostWitnessingAsCertificateProvider(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:                     "lpa-id",
 					DonorIdentityUserData:  identity.UserData{OK: true, Provider: identity.OneLogin},
 					WitnessCodes:           page.WitnessCodes{{Code: "1234", Created: now}},
 					CPWitnessCodeValidated: true,
@@ -135,6 +136,7 @@ func TestPostWitnessingAsCertificateProvider(t *testing.T) {
 				Return(tc.certificateProvider, tc.err)
 
 			err := WitnessingAsCertificateProvider(nil, donorStore, nil, func() time.Time { return now }, certificateProviderStore)(testAppData, w, r, &page.Lpa{
+				ID:                    "lpa-id",
 				DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 				WitnessCodes:          page.WitnessCodes{{Code: "1234", Created: now}},
 			})
@@ -142,7 +144,7 @@ func TestPostWitnessingAsCertificateProvider(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.YouHaveSubmittedYourLpa, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.YouHaveSubmittedYourLpa.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -158,6 +160,7 @@ func TestPostWitnessingAsCertificateProviderWhenIdentityConfirmed(t *testing.T) 
 	now := time.Now()
 
 	lpa := &page.Lpa{
+		ID:                     "lpa-id",
 		DonorIdentityUserData:  identity.UserData{OK: true, Provider: identity.OneLogin},
 		CertificateProvider:    actor.CertificateProvider{Email: "name@example.com"},
 		WitnessCodes:           page.WitnessCodes{{Code: "1234", Created: now}},
@@ -185,6 +188,7 @@ func TestPostWitnessingAsCertificateProviderWhenIdentityConfirmed(t *testing.T) 
 		Return(nil)
 
 	err := WitnessingAsCertificateProvider(nil, donorStore, shareCodeSender, func() time.Time { return now }, certificateProviderStore)(testAppData, w, r, &page.Lpa{
+		ID:                    "lpa-id",
 		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 		CertificateProvider:   actor.CertificateProvider{Email: "name@example.com"},
 		WitnessCodes:          page.WitnessCodes{{Code: "1234", Created: now}},
@@ -193,7 +197,7 @@ func TestPostWitnessingAsCertificateProviderWhenIdentityConfirmed(t *testing.T) 
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.YouHaveSubmittedYourLpa, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.YouHaveSubmittedYourLpa.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostWitnessingAsCertificateProviderWhenShareCodeSendErrors(t *testing.T) {

--- a/app/internal/page/donor/witnessing_your_signature.go
+++ b/app/internal/page/donor/witnessing_your_signature.go
@@ -21,7 +21,7 @@ func WitnessingYourSignature(tmpl template.Template, witnessCodeSender WitnessCo
 				return err
 			}
 
-			return appData.Redirect(w, r, lpa, page.Paths.WitnessingAsCertificateProvider)
+			return appData.Redirect(w, r, lpa, page.Paths.WitnessingAsCertificateProvider.Format(lpa.ID))
 		}
 
 		data := &witnessingYourSignatureData{

--- a/app/internal/page/donor/witnessing_your_signature_test.go
+++ b/app/internal/page/donor/witnessing_your_signature_test.go
@@ -54,6 +54,7 @@ func TestPostWitnessingYourSignature(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	lpa := &page.Lpa{
+		ID:                    "lpa-id",
 		DonorIdentityUserData: identity.UserData{OK: true, Provider: identity.OneLogin},
 		CertificateProvider:   actor.CertificateProvider{Mobile: "07535111111"},
 	}
@@ -68,7 +69,7 @@ func TestPostWitnessingYourSignature(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.WitnessingAsCertificateProvider, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.WitnessingAsCertificateProvider.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostWitnessingYourSignatureWhenWitnessCodeSenderErrors(t *testing.T) {

--- a/app/internal/page/donor/your_address.go
+++ b/app/internal/page/donor/your_address.go
@@ -33,7 +33,7 @@ func YourAddress(logger Logger, tmpl template.Template, addressClient AddressCli
 						return err
 					}
 
-					return appData.Redirect(w, r, lpa, page.Paths.WhoIsTheLpaFor)
+					return appData.Redirect(w, r, lpa, page.Paths.WhoIsTheLpaFor.Format(lpa.ID))
 				}
 
 			case "postcode-select":

--- a/app/internal/page/donor/your_address_test.go
+++ b/app/internal/page/donor/your_address_test.go
@@ -121,18 +121,21 @@ func TestPostYourAddressManual(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			Donor: actor.Donor{
 				Address: testAddress,
 			},
 		}).
 		Return(nil)
 
-	err := YourAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{})
+	err := YourAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
+	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.WhoIsTheLpaFor, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.WhoIsTheLpaFor.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostYourAddressManualWhenStoreErrors(t *testing.T) {
@@ -180,6 +183,7 @@ func TestPostYourAddressManualFromStore(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			Donor: actor.Donor{
 				FirstNames: "John",
 				Address:    testAddress,
@@ -189,6 +193,7 @@ func TestPostYourAddressManualFromStore(t *testing.T) {
 		Return(nil)
 
 	err := YourAddress(nil, nil, nil, donorStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Donor: actor.Donor{
 			FirstNames: "John",
 			Address:    place.Address{Line1: "abc"},
@@ -199,7 +204,7 @@ func TestPostYourAddressManualFromStore(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.WhoIsTheLpaFor, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.WhoIsTheLpaFor.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostYourAddressManualWhenValidationError(t *testing.T) {

--- a/app/internal/page/donor/your_chosen_identity_options.go
+++ b/app/internal/page/donor/your_chosen_identity_options.go
@@ -20,7 +20,7 @@ type yourChosenIdentityOptionsData struct {
 func YourChosenIdentityOptions(tmpl template.Template) Handler {
 	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
 		if r.Method == http.MethodPost {
-			return appData.Redirect(w, r, lpa, identityOptionPath(appData.Paths, lpa.DonorIdentityOption))
+			return appData.Redirect(w, r, lpa, identityOptionPath(appData.Paths, lpa.DonorIdentityOption).Format(lpa.ID))
 		}
 
 		data := &yourChosenIdentityOptionsData{
@@ -33,7 +33,7 @@ func YourChosenIdentityOptions(tmpl template.Template) Handler {
 	}
 }
 
-func identityOptionPath(paths page.AppPaths, identityOption identity.Option) string {
+func identityOptionPath(paths page.AppPaths, identityOption identity.Option) page.LpaPath {
 	switch identityOption {
 	case identity.OneLogin:
 		return paths.IdentityWithOneLogin

--- a/app/internal/page/donor/your_chosen_identity_options_test.go
+++ b/app/internal/page/donor/your_chosen_identity_options_test.go
@@ -55,11 +55,12 @@ func TestPostYourChosenIdentityOptions(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/", nil)
 
 	err := YourChosenIdentityOptions(nil)(testAppData, w, r, &page.Lpa{
+		ID:                  "lpa-id",
 		DonorIdentityOption: identity.Passport,
 	})
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.IdentityWithPassport, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.IdentityWithPassport.Format("lpa-id"), resp.Header.Get("Location"))
 }

--- a/app/internal/page/donor/your_details.go
+++ b/app/internal/page/donor/your_details.go
@@ -76,7 +76,7 @@ func YourDetails(tmpl template.Template, donorStore DonorStore, sessionStore ses
 					return err
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.YourAddress)
+				return appData.Redirect(w, r, lpa, page.Paths.YourAddress.Format(lpa.ID))
 			}
 		}
 

--- a/app/internal/page/donor/your_details_test.go
+++ b/app/internal/page/donor/your_details_test.go
@@ -135,6 +135,7 @@ func TestPostYourDetails(t *testing.T) {
 			donorStore := newMockDonorStore(t)
 			donorStore.
 				On("Put", r.Context(), &page.Lpa{
+					ID:    "lpa-id",
 					Donor: tc.person,
 					Tasks: page.Tasks{YourDetails: actor.TaskInProgress},
 				}).
@@ -146,6 +147,7 @@ func TestPostYourDetails(t *testing.T) {
 				Return(&sessions.Session{Values: map[any]any{"session": &sesh.LoginSession{Sub: "xyz", Email: "name@example.com"}}}, nil)
 
 			err := YourDetails(nil, donorStore, sessionStore)(testAppData, w, r, &page.Lpa{
+				ID: "lpa-id",
 				Donor: actor.Donor{
 					FirstNames: "John",
 					Address:    place.Address{Line1: "abc"},
@@ -155,7 +157,7 @@ func TestPostYourDetails(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, http.StatusFound, resp.StatusCode)
-			assert.Equal(t, "/lpa/lpa-id"+page.Paths.YourAddress, resp.Header.Get("Location"))
+			assert.Equal(t, page.Paths.YourAddress.Format("lpa-id"), resp.Header.Get("Location"))
 		})
 	}
 }
@@ -179,6 +181,7 @@ func TestPostYourDetailsWhenTaskCompleted(t *testing.T) {
 	donorStore := newMockDonorStore(t)
 	donorStore.
 		On("Put", r.Context(), &page.Lpa{
+			ID: "lpa-id",
 			Donor: actor.Donor{
 				FirstNames:  "John",
 				LastName:    "Doe",
@@ -196,6 +199,7 @@ func TestPostYourDetailsWhenTaskCompleted(t *testing.T) {
 		Return(&sessions.Session{Values: map[any]any{"session": &sesh.LoginSession{Sub: "xyz", Email: "name@example.com"}}}, nil)
 
 	err := YourDetails(nil, donorStore, sessionStore)(testAppData, w, r, &page.Lpa{
+		ID: "lpa-id",
 		Donor: actor.Donor{
 			FirstNames: "John",
 			Address:    place.Address{Line1: "abc"},
@@ -206,7 +210,7 @@ func TestPostYourDetailsWhenTaskCompleted(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, "/lpa/lpa-id"+page.Paths.YourAddress, resp.Header.Get("Location"))
+	assert.Equal(t, page.Paths.YourAddress.Format("lpa-id"), resp.Header.Get("Location"))
 }
 
 func TestPostYourDetailsWhenInputRequired(t *testing.T) {

--- a/app/internal/page/fixtures.go
+++ b/app/internal/page/fixtures.go
@@ -41,7 +41,7 @@ func Fixtures(tmpl template.Template) Handler {
 						"lpa.replacementAttorneysAct": {"jointly"},
 						"lpa.type":                    {data.Form.Type},
 						"lpa.restrictions":            {"1"},
-						"redirect":                    {Paths.Attorney.Start},
+						"redirect":                    {Paths.Attorney.Start.Format()},
 					}
 					if data.Form.Email != "" {
 						if data.Form.ForReplacementAttorney != "" {
@@ -95,7 +95,7 @@ func Fixtures(tmpl template.Template) Handler {
 						values.Add("lpa.peopleToNotify", data.Form.PersonToNotifyCount)
 					}
 				case "everything":
-					values = url.Values{"fresh": {"1"}, "lpa.complete": {"1"}, "redirect": {Paths.Dashboard}}
+					values = url.Values{"fresh": {"1"}, "lpa.complete": {"1"}, "redirect": {Paths.Dashboard.Format()}}
 
 					if r.FormValue("as-attorney") != "" {
 						values.Add("attorneyProvided", "1")

--- a/app/internal/page/login.go
+++ b/app/internal/page/login.go
@@ -15,7 +15,7 @@ type LoginOneLoginClient interface {
 	AuthCodeURL(state, nonce, locale string, identity bool) string
 }
 
-func Login(logger LoginLogger, oneLoginClient LoginOneLoginClient, store sesh.Store, randomString func(int) string, redirect string) Handler {
+func Login(logger LoginLogger, oneLoginClient LoginOneLoginClient, store sesh.Store, randomString func(int) string, redirect Path) Handler {
 	return func(appData AppData, w http.ResponseWriter, r *http.Request) error {
 		locale := "en"
 		if appData.Lang == localize.Cy {
@@ -31,7 +31,7 @@ func Login(logger LoginLogger, oneLoginClient LoginOneLoginClient, store sesh.St
 			State:    state,
 			Nonce:    nonce,
 			Locale:   locale,
-			Redirect: redirect,
+			Redirect: redirect.Format(),
 		}); err != nil {
 			logger.Print(err)
 			return nil

--- a/app/internal/page/login_callback.go
+++ b/app/internal/page/login_callback.go
@@ -13,7 +13,7 @@ type LoginCallbackOneLoginClient interface {
 	UserInfo(ctx context.Context, accessToken string) (onelogin.UserInfo, error)
 }
 
-func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh.Store, redirect string) Handler {
+func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh.Store, redirect Path) Handler {
 	return func(appData AppData, w http.ResponseWriter, r *http.Request) error {
 		oneLoginSession, err := sesh.OneLogin(sessionStore, r)
 		if err != nil {
@@ -38,6 +38,6 @@ func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh
 			return err
 		}
 
-		return appData.Redirect(w, r, nil, redirect)
+		return appData.Redirect(w, r, nil, redirect.Format())
 	}
 }

--- a/app/internal/page/login_callback_test.go
+++ b/app/internal/page/login_callback_test.go
@@ -63,7 +63,7 @@ func TestLoginCallback(t *testing.T) {
 	resp := w.Result()
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, Paths.Attorney.EnterReferenceNumber, resp.Header.Get("Location"))
+	assert.Equal(t, Paths.Attorney.EnterReferenceNumber.Format(), resp.Header.Get("Location"))
 }
 
 func TestLoginCallbackSessionMissing(t *testing.T) {
@@ -134,7 +134,7 @@ func TestLoginCallbackWhenExchangeErrors(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{
 			Values: map[any]any{
-				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Locale: "en", Redirect: Paths.LoginCallback},
+				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Locale: "en", Redirect: Paths.LoginCallback.Format()},
 			},
 		}, nil)
 
@@ -159,7 +159,7 @@ func TestLoginCallbackWhenUserInfoError(t *testing.T) {
 		On("Get", r, "params").
 		Return(&sessions.Session{
 			Values: map[any]any{
-				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Locale: "en", Redirect: Paths.LoginCallback},
+				"one-login": &sesh.OneLoginSession{State: "my-state", Nonce: "my-nonce", Locale: "en", Redirect: Paths.LoginCallback.Format()},
 			},
 		}, nil)
 
@@ -188,7 +188,7 @@ func TestLoginCallbackWhenSessionError(t *testing.T) {
 					State:    "my-state",
 					Nonce:    "my-nonce",
 					Locale:   "en",
-					Redirect: Paths.LoginCallback,
+					Redirect: Paths.LoginCallback.Format(),
 				},
 			},
 		}, nil)

--- a/app/internal/page/paths.go
+++ b/app/internal/page/paths.go
@@ -1,139 +1,179 @@
 package page
 
-import (
-	"strings"
+type Path string
 
-	"golang.org/x/exp/slices"
-)
+func (p Path) String() string {
+	return string(p)
+}
+
+func (p Path) Format() string {
+	return string(p)
+}
+
+type LpaPath string
+
+func (p LpaPath) String() string {
+	return string(p)
+}
+
+func (p LpaPath) Format(id string) string {
+	return "/lpa/" + id + string(p)
+}
+
+type AttorneyPath string
+
+func (p AttorneyPath) String() string {
+	return string(p)
+}
+
+func (p AttorneyPath) Format(id string) string {
+	return "/attorney/" + id + string(p)
+}
+
+type CertificateProviderPath string
+
+func (p CertificateProviderPath) String() string {
+	return string(p)
+}
+
+func (p CertificateProviderPath) Format(id string) string {
+	return "/certificate-provider/" + id + string(p)
+}
 
 type AttorneyPaths struct {
-	CheckYourName             string
-	CodeOfConduct             string
-	EnterReferenceNumber      string
-	Login                     string
-	LoginCallback             string
-	MobileNumber              string
-	ReadTheLpa                string
-	RightsAndResponsibilities string
-	Sign                      string
-	Start                     string
-	TaskList                  string
-	WhatHappensNext           string
-	WhatHappensWhenYouSign    string
+	EnterReferenceNumber Path
+	Login                Path
+	LoginCallback        Path
+	Start                Path
+
+	CheckYourName             AttorneyPath
+	CodeOfConduct             AttorneyPath
+	MobileNumber              AttorneyPath
+	ReadTheLpa                AttorneyPath
+	RightsAndResponsibilities AttorneyPath
+	Sign                      AttorneyPath
+	TaskList                  AttorneyPath
+	WhatHappensNext           AttorneyPath
+	WhatHappensWhenYouSign    AttorneyPath
 }
 
 type CertificateProviderPaths struct {
-	CertificateProvided                  string
-	CheckYourName                        string
-	EnterDateOfBirth                     string
-	EnterMobileNumber                    string
-	EnterReferenceNumber                 string
-	IdentityWithBiometricResidencePermit string
-	IdentityWithDrivingLicencePaper      string
-	IdentityWithDrivingLicencePhotocard  string
-	IdentityWithOneLogin                 string
-	IdentityWithOneLoginCallback         string
-	IdentityWithOnlineBankAccount        string
-	IdentityWithPassport                 string
-	IdentityWithYoti                     string
-	IdentityWithYotiCallback             string
-	Login                                string
-	LoginCallback                        string
-	ProvideCertificate                   string
-	ReadTheLpa                           string
-	SelectYourIdentityOptions            string
-	SelectYourIdentityOptions1           string
-	SelectYourIdentityOptions2           string
-	WhatHappensNext                      string
-	WhatYoullNeedToConfirmYourIdentity   string
-	WhoIsEligible                        string
-	YourChosenIdentityOptions            string
+	Login                Path
+	LoginCallback        Path
+	EnterReferenceNumber Path
+	WhoIsEligible        Path
+
+	CertificateProvided                  CertificateProviderPath
+	CheckYourName                        CertificateProviderPath
+	EnterDateOfBirth                     CertificateProviderPath
+	EnterMobileNumber                    CertificateProviderPath
+	IdentityWithBiometricResidencePermit CertificateProviderPath
+	IdentityWithDrivingLicencePaper      CertificateProviderPath
+	IdentityWithDrivingLicencePhotocard  CertificateProviderPath
+	IdentityWithOneLogin                 CertificateProviderPath
+	IdentityWithOneLoginCallback         CertificateProviderPath
+	IdentityWithOnlineBankAccount        CertificateProviderPath
+	IdentityWithPassport                 CertificateProviderPath
+	IdentityWithYoti                     CertificateProviderPath
+	IdentityWithYotiCallback             CertificateProviderPath
+	ProvideCertificate                   CertificateProviderPath
+	ReadTheLpa                           CertificateProviderPath
+	SelectYourIdentityOptions            CertificateProviderPath
+	SelectYourIdentityOptions1           CertificateProviderPath
+	SelectYourIdentityOptions2           CertificateProviderPath
+	WhatHappensNext                      CertificateProviderPath
+	WhatYoullNeedToConfirmYourIdentity   CertificateProviderPath
+	YourChosenIdentityOptions            CertificateProviderPath
 }
+
 type HealthCheckPaths struct {
-	Service    string
-	Dependency string
+	Service    Path
+	Dependency Path
 }
 
 type AppPaths struct {
-	Attorney                                                   AttorneyPaths
-	CertificateProvider                                        CertificateProviderPaths
-	AboutPayment                                               string
-	AreYouHappyIfOneAttorneyCantActNoneCan                     string
-	AreYouHappyIfOneReplacementAttorneyCantActNoneCan          string
-	AreYouHappyIfRemainingAttorneysCanContinueToAct            string
-	AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct string
-	AuthRedirect                                               string
-	CertificateProviderAddress                                 string
-	CertificateProviderDetails                                 string
-	CertificateProviderOptOut                                  string
-	CertificateProviderStart                                   string
-	CheckYourLpa                                               string
-	ChooseAttorneys                                            string
-	ChooseAttorneysAddress                                     string
-	ChooseAttorneysSummary                                     string
-	ChoosePeopleToNotify                                       string
-	ChoosePeopleToNotifyAddress                                string
-	ChoosePeopleToNotifySummary                                string
-	ChooseReplacementAttorneys                                 string
-	ChooseReplacementAttorneysAddress                          string
-	ChooseReplacementAttorneysSummary                          string
-	CookiesConsent                                             string
-	Dashboard                                                  string
-	DoYouWantReplacementAttorneys                              string
-	DoYouWantToNotifyPeople                                    string
-	Fixtures                                                   string
-	HealthCheck                                                HealthCheckPaths
-	HowDoYouKnowYourCertificateProvider                        string
-	HowLongHaveYouKnownCertificateProvider                     string
-	HowShouldAttorneysMakeDecisions                            string
-	HowShouldReplacementAttorneysMakeDecisions                 string
-	HowShouldReplacementAttorneysStepIn                        string
-	HowToConfirmYourIdentityAndSign                            string
-	HowWouldCertificateProviderPreferToCarryOutTheirRole       string
-	IdentityConfirmed                                          string
-	IdentityWithBiometricResidencePermit                       string
-	IdentityWithDrivingLicencePaper                            string
-	IdentityWithDrivingLicencePhotocard                        string
-	IdentityWithOneLogin                                       string
-	IdentityWithOneLoginCallback                               string
-	IdentityWithOnlineBankAccount                              string
-	IdentityWithPassport                                       string
-	IdentityWithYoti                                           string
-	IdentityWithYotiCallback                                   string
-	LifeSustainingTreatment                                    string
-	Login                                                      string
-	LoginCallback                                              string
-	LpaType                                                    string
-	PaymentConfirmation                                        string
-	Progress                                                   string
-	ReadYourLpa                                                string
-	RemoveAttorney                                             string
-	RemovePersonToNotify                                       string
-	RemoveReplacementAttorney                                  string
-	ResendWitnessCode                                          string
-	Restrictions                                               string
-	Root                                                       string
-	SelectYourIdentityOptions                                  string
-	SelectYourIdentityOptions1                                 string
-	SelectYourIdentityOptions2                                 string
-	SignOut                                                    string
-	SignYourLpa                                                string
-	Start                                                      string
-	TaskList                                                   string
-	TestingStart                                               string
-	UseExistingAddress                                         string
-	WhatYoullNeedToConfirmYourIdentity                         string
-	WhenCanTheLpaBeUsed                                        string
-	WhoDoYouWantToBeCertificateProviderGuidance                string
-	WhoIsTheLpaFor                                             string
-	WitnessingAsCertificateProvider                            string
-	WitnessingYourSignature                                    string
-	YotiRedirect                                               string
-	YouHaveSubmittedYourLpa                                    string
-	YourAddress                                                string
-	YourChosenIdentityOptions                                  string
-	YourDetails                                                string
-	YourLegalRightsAndResponsibilities                         string
+	Attorney            AttorneyPaths
+	CertificateProvider CertificateProviderPaths
+	HealthCheck         HealthCheckPaths
+
+	AuthRedirect                       Path
+	Login                              Path
+	LoginCallback                      Path
+	Root                               Path
+	SignOut                            Path
+	Fixtures                           Path
+	YourLegalRightsAndResponsibilities Path
+	CertificateProviderStart           Path
+	Start                              Path
+	TestingStart                       Path
+	Dashboard                          Path
+	YotiRedirect                       Path
+	CookiesConsent                     Path
+
+	LpaYourLegalRightsAndResponsibilities                      LpaPath
+	AboutPayment                                               LpaPath
+	AreYouHappyIfOneAttorneyCantActNoneCan                     LpaPath
+	AreYouHappyIfOneReplacementAttorneyCantActNoneCan          LpaPath
+	AreYouHappyIfRemainingAttorneysCanContinueToAct            LpaPath
+	AreYouHappyIfRemainingReplacementAttorneysCanContinueToAct LpaPath
+	CertificateProviderAddress                                 LpaPath
+	CertificateProviderDetails                                 LpaPath
+	CertificateProviderOptOut                                  LpaPath
+	CheckYourLpa                                               LpaPath
+	ChooseAttorneys                                            LpaPath
+	ChooseAttorneysAddress                                     LpaPath
+	ChooseAttorneysSummary                                     LpaPath
+	ChoosePeopleToNotify                                       LpaPath
+	ChoosePeopleToNotifyAddress                                LpaPath
+	ChoosePeopleToNotifySummary                                LpaPath
+	ChooseReplacementAttorneys                                 LpaPath
+	ChooseReplacementAttorneysAddress                          LpaPath
+	ChooseReplacementAttorneysSummary                          LpaPath
+	DoYouWantReplacementAttorneys                              LpaPath
+	DoYouWantToNotifyPeople                                    LpaPath
+	HowDoYouKnowYourCertificateProvider                        LpaPath
+	HowLongHaveYouKnownCertificateProvider                     LpaPath
+	HowShouldAttorneysMakeDecisions                            LpaPath
+	HowShouldReplacementAttorneysMakeDecisions                 LpaPath
+	HowShouldReplacementAttorneysStepIn                        LpaPath
+	HowToConfirmYourIdentityAndSign                            LpaPath
+	HowWouldCertificateProviderPreferToCarryOutTheirRole       LpaPath
+	IdentityConfirmed                                          LpaPath
+	IdentityWithBiometricResidencePermit                       LpaPath
+	IdentityWithDrivingLicencePaper                            LpaPath
+	IdentityWithDrivingLicencePhotocard                        LpaPath
+	IdentityWithOneLogin                                       LpaPath
+	IdentityWithOneLoginCallback                               LpaPath
+	IdentityWithOnlineBankAccount                              LpaPath
+	IdentityWithPassport                                       LpaPath
+	IdentityWithYoti                                           LpaPath
+	IdentityWithYotiCallback                                   LpaPath
+	LifeSustainingTreatment                                    LpaPath
+	LpaType                                                    LpaPath
+	PaymentConfirmation                                        LpaPath
+	Progress                                                   LpaPath
+	ReadYourLpa                                                LpaPath
+	RemoveAttorney                                             LpaPath
+	RemovePersonToNotify                                       LpaPath
+	RemoveReplacementAttorney                                  LpaPath
+	ResendWitnessCode                                          LpaPath
+	Restrictions                                               LpaPath
+	SelectYourIdentityOptions                                  LpaPath
+	SelectYourIdentityOptions1                                 LpaPath
+	SelectYourIdentityOptions2                                 LpaPath
+	SignYourLpa                                                LpaPath
+	TaskList                                                   LpaPath
+	UseExistingAddress                                         LpaPath
+	WhatYoullNeedToConfirmYourIdentity                         LpaPath
+	WhenCanTheLpaBeUsed                                        LpaPath
+	WhoDoYouWantToBeCertificateProviderGuidance                LpaPath
+	WhoIsTheLpaFor                                             LpaPath
+	WitnessingAsCertificateProvider                            LpaPath
+	WitnessingYourSignature                                    LpaPath
+	YouHaveSubmittedYourLpa                                    LpaPath
+	YourAddress                                                LpaPath
+	YourChosenIdentityOptions                                  LpaPath
+	YourDetails                                                LpaPath
 }
 
 var Paths = AppPaths{
@@ -259,76 +299,5 @@ var Paths = AppPaths{
 	YourChosenIdentityOptions:                            "/your-chosen-identity-options",
 	YourDetails:                                          "/your-details",
 	YourLegalRightsAndResponsibilities:                   "/your-legal-rights-and-responsibilities",
-}
-
-// IsAttorneyPath checks whether the url should be prefixed with /attorney/.
-func IsAttorneyPath(url string) bool {
-	path, _, _ := strings.Cut(url, "?")
-
-	return slices.Contains([]string{
-		Paths.Attorney.CheckYourName,
-		Paths.Attorney.CodeOfConduct,
-		Paths.Attorney.MobileNumber,
-		Paths.Attorney.ReadTheLpa,
-		Paths.Attorney.RightsAndResponsibilities,
-		Paths.Attorney.Sign,
-		Paths.Attorney.TaskList,
-		Paths.Attorney.WhatHappensNext,
-		Paths.Attorney.WhatHappensWhenYouSign,
-	}, path)
-}
-
-// IsCertificateProviderPath checks whether the url should be prefixed with /certificate-provider/.
-func IsCertificateProviderPath(url string) bool {
-	path, _, _ := strings.Cut(url, "?")
-
-	return slices.Contains([]string{
-		Paths.CertificateProvider.CertificateProvided,
-		Paths.CertificateProvider.CheckYourName,
-		Paths.CertificateProvider.EnterDateOfBirth,
-		Paths.CertificateProvider.EnterMobileNumber,
-		Paths.CertificateProvider.IdentityWithBiometricResidencePermit,
-		Paths.CertificateProvider.IdentityWithDrivingLicencePaper,
-		Paths.CertificateProvider.IdentityWithDrivingLicencePhotocard,
-		Paths.CertificateProvider.IdentityWithOneLogin,
-		Paths.CertificateProvider.IdentityWithOneLoginCallback,
-		Paths.CertificateProvider.IdentityWithOnlineBankAccount,
-		Paths.CertificateProvider.IdentityWithPassport,
-		Paths.CertificateProvider.IdentityWithYoti,
-		Paths.CertificateProvider.IdentityWithYotiCallback,
-		Paths.CertificateProvider.ProvideCertificate,
-		Paths.CertificateProvider.ReadTheLpa,
-		Paths.CertificateProvider.SelectYourIdentityOptions,
-		Paths.CertificateProvider.SelectYourIdentityOptions1,
-		Paths.CertificateProvider.SelectYourIdentityOptions2,
-		Paths.CertificateProvider.WhatHappensNext,
-		Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity,
-		Paths.CertificateProvider.YourChosenIdentityOptions,
-	}, path)
-}
-
-// IsLpaPath checks whether the url should be prefixed with /lpa/.
-func IsLpaPath(url string) bool {
-	path, _, _ := strings.Cut(url, "?")
-
-	return !IsAttorneyPath(url) &&
-		!IsCertificateProviderPath(url) &&
-		!slices.Contains([]string{
-			Paths.Attorney.EnterReferenceNumber,
-			Paths.Attorney.Login,
-			Paths.Attorney.LoginCallback,
-			Paths.Attorney.Start,
-			Paths.AuthRedirect,
-			Paths.CertificateProvider.EnterReferenceNumber,
-			Paths.CertificateProvider.Login,
-			Paths.CertificateProvider.LoginCallback,
-			Paths.CertificateProvider.WhoIsEligible,
-			Paths.CertificateProviderStart,
-			Paths.Dashboard,
-			Paths.Login,
-			Paths.LoginCallback,
-			Paths.SignOut,
-			Paths.Start,
-			Paths.YotiRedirect,
-		}, path)
+	LpaYourLegalRightsAndResponsibilities:                "/lpa-your-legal-rights-and-responsibilities",
 }

--- a/app/internal/page/paths_test.go
+++ b/app/internal/page/paths_test.go
@@ -6,28 +6,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsLpaPath(t *testing.T) {
-	testCases := map[string]struct {
-		url               string
-		expectedIsLpaPage bool
-	}{
-		"dashboard": {
-			url:               Paths.Dashboard + "?someQuery=5",
-			expectedIsLpaPage: false,
-		},
-		"start": {
-			url:               Paths.Start + "?someQuery=6",
-			expectedIsLpaPage: false,
-		},
-		"any other page": {
-			url:               "/other?someQuery=7",
-			expectedIsLpaPage: true,
-		},
-	}
+func TestPathString(t *testing.T) {
+	assert.Equal(t, "/anything", Path("/anything").String())
+}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedIsLpaPage, IsLpaPath(tc.url))
-		})
-	}
+func TestPathFormat(t *testing.T) {
+	assert.Equal(t, "/anything", Path("/anything").Format())
+}
+
+func TestLpaPathString(t *testing.T) {
+	assert.Equal(t, "/anything", LpaPath("/anything").String())
+}
+
+func TestLpaPathFormat(t *testing.T) {
+	assert.Equal(t, "/lpa/abc/anything", LpaPath("/anything").Format("abc"))
+}
+
+func TestAttorneyPathString(t *testing.T) {
+	assert.Equal(t, "/anything", AttorneyPath("/anything").String())
+}
+
+func TestAttorneyPathFormat(t *testing.T) {
+	assert.Equal(t, "/attorney/abc/anything", AttorneyPath("/anything").Format("abc"))
+}
+
+func TestCertificateProviderPathString(t *testing.T) {
+	assert.Equal(t, "/anything", CertificateProviderPath("/anything").String())
+}
+
+func TestCertificateProviderPathFormat(t *testing.T) {
+	assert.Equal(t, "/certificate-provider/abc/anything", CertificateProviderPath("/anything").Format("abc"))
 }

--- a/app/internal/page/root.go
+++ b/app/internal/page/root.go
@@ -16,7 +16,7 @@ type rootData struct {
 func Root(tmpl template.Template, logger Logger) Handler {
 	return func(appData AppData, w http.ResponseWriter, r *http.Request) error {
 		if r.URL.Path == "/" {
-			http.Redirect(w, r, Paths.Start, http.StatusFound)
+			http.Redirect(w, r, Paths.Start.Format(), http.StatusFound)
 			return nil
 		}
 

--- a/app/internal/page/root_test.go
+++ b/app/internal/page/root_test.go
@@ -16,7 +16,7 @@ func TestRoot(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Equal(t, Paths.Start, resp.Header.Get("Location"))
+	assert.Equal(t, Paths.Start.Format(), resp.Header.Get("Location"))
 }
 
 func TestRootNotFound(t *testing.T) {

--- a/app/internal/page/sign_out.go
+++ b/app/internal/page/sign_out.go
@@ -18,7 +18,7 @@ func SignOut(logger Logger, sessionStore sesh.Store, oneLoginClient OneLoginClie
 			logger.Print(fmt.Sprintf("unable to expire session: %s", err.Error()))
 		}
 
-		http.Redirect(w, r, oneLoginClient.EndSessionURL(idToken, appPublicURL+Paths.Start), http.StatusFound)
+		http.Redirect(w, r, oneLoginClient.EndSessionURL(idToken, appPublicURL+Paths.Start.Format()), http.StatusFound)
 		return nil
 	}
 }

--- a/app/internal/page/sign_out_test.go
+++ b/app/internal/page/sign_out_test.go
@@ -32,7 +32,7 @@ func TestSignOut(t *testing.T) {
 
 	oneLoginClient := newMockOneLoginClient(t)
 	oneLoginClient.
-		On("EndSessionURL", "id-token", "http://public"+Paths.Start).
+		On("EndSessionURL", "id-token", "http://public"+Paths.Start.Format()).
 		Return("http://end-session")
 
 	err := SignOut(nil, sessionStore, oneLoginClient, "http://public")(TestAppData, w, r)
@@ -64,7 +64,7 @@ func TestSignOutWhenClearSessionFails(t *testing.T) {
 
 	oneLoginClient := newMockOneLoginClient(t)
 	oneLoginClient.
-		On("EndSessionURL", "id-token", "http://public"+Paths.Start).
+		On("EndSessionURL", "id-token", "http://public"+Paths.Start.Format()).
 		Return("http://end-session")
 
 	err := SignOut(logger, sessionStore, oneLoginClient, "http://public")(TestAppData, w, r)

--- a/app/internal/page/testing_start.go
+++ b/app/internal/page/testing_start.go
@@ -411,10 +411,23 @@ func TestingStart(store sesh.Store, donorStore DonorStore, randomString func(int
 		switch r.FormValue("loginAs") {
 		case "attorney":
 			_ = sesh.SetLoginSession(store, r, w, &sesh.LoginSession{Sub: attorneySub, Email: testEmail})
+			if redirect != "" {
+				redirect = "/attorney/" + lpa.ID + redirect
+			}
 		case "certificate-provider":
 			_ = sesh.SetLoginSession(store, r, w, &sesh.LoginSession{Sub: certificateProviderSub, Email: testEmail})
+			if redirect != "" {
+				redirect = "/certificate-provider/" + lpa.ID + redirect
+			}
 		default:
 			_ = sesh.SetLoginSession(store, r, w, &sesh.LoginSession{Sub: donorSub, Email: testEmail})
+			if redirect != "" &&
+				redirect != Paths.Start.Format() &&
+				redirect != Paths.Dashboard.Format() &&
+				redirect != Paths.CertificateProviderStart.Format() &&
+				redirect != Paths.Attorney.Start.Format() {
+				redirect = "/lpa/" + lpa.ID + redirect
+			}
 		}
 
 		if cookiesAccepted {
@@ -441,7 +454,7 @@ func TestingStart(store sesh.Store, donorStore DonorStore, randomString func(int
 				Localizer: localizer,
 			}, false, lpa)
 
-			redirect = Paths.CertificateProviderStart
+			redirect = Paths.CertificateProviderStart.Format()
 		}
 
 		if asCertificateProvider != "" {
@@ -520,7 +533,7 @@ func TestingStart(store sesh.Store, donorStore DonorStore, randomString func(int
 		}
 
 		if asReplacementAttorney {
-			_, err := attorneyStore.Create(donorCtx, donorSessionID, lpa.ReplacementAttorneys[0].ID, true)
+			_, err := attorneyStore.Create(attorneyCtx, attorneySessionID, lpa.ReplacementAttorneys[0].ID, true)
 			if err != nil {
 				logger.Print("asReplacementAttorney:", err)
 			}

--- a/app/internal/page/yoti_redirect.go
+++ b/app/internal/page/yoti_redirect.go
@@ -22,9 +22,9 @@ func YotiRedirect(logger Logger, store sesh.Store) http.HandlerFunc {
 
 		appData := AppData{Lang: lang, LpaID: yotiSession.LpaID}
 
-		redirect := Paths.IdentityWithYotiCallback
+		redirect := Paths.IdentityWithYotiCallback.Format(yotiSession.LpaID)
 		if yotiSession.CertificateProvider {
-			redirect = Paths.CertificateProvider.IdentityWithYotiCallback
+			redirect = Paths.CertificateProvider.IdentityWithYotiCallback.Format(yotiSession.LpaID)
 		}
 		appData.Redirect(w, r, nil, redirect+"?"+r.URL.RawQuery)
 	}

--- a/app/internal/page/yoti_redirect_test.go
+++ b/app/internal/page/yoti_redirect_test.go
@@ -19,14 +19,14 @@ func TestYotiRedirect(t *testing.T) {
 			session: &sesh.YotiSession{
 				LpaID: "123",
 			},
-			redirect: "/lpa/123" + Paths.IdentityWithYotiCallback,
+			redirect: Paths.IdentityWithYotiCallback.Format("123"),
 		},
 		"donor identity welsh": {
 			session: &sesh.YotiSession{
 				Locale: "cy",
 				LpaID:  "123",
 			},
-			redirect: "/cy/lpa/123" + Paths.IdentityWithYotiCallback,
+			redirect: "/cy" + Paths.IdentityWithYotiCallback.Format("123"),
 		},
 		"certificate provider identity": {
 			session: &sesh.YotiSession{
@@ -34,7 +34,7 @@ func TestYotiRedirect(t *testing.T) {
 				LpaID:               "123",
 				CertificateProvider: true,
 			},
-			redirect: "/certificate-provider/123" + Paths.CertificateProvider.IdentityWithYotiCallback,
+			redirect: Paths.CertificateProvider.IdentityWithYotiCallback.Format("123"),
 		},
 	}
 

--- a/app/internal/templatefn/fn.go
+++ b/app/internal/templatefn/fn.go
@@ -28,8 +28,6 @@ func All(tag, region string) map[string]any {
 		"details":            details,
 		"inc":                inc,
 		"link":               link,
-		"linkWithID":         linkWithID,
-		"linkLang":           linkLang,
 		"contains":           contains,
 		"tr":                 tr,
 		"trFormat":           trFormat,
@@ -136,18 +134,6 @@ func inc(i int) int {
 
 func link(app page.AppData, path string) string {
 	return app.BuildUrl(path)
-}
-
-func linkWithID(app page.AppData, path, lpaID string) string {
-	return page.AppData{Lang: app.Lang, LpaID: lpaID}.BuildUrl(path)
-}
-
-func linkLang(app page.AppData, path string) string {
-	if app.Lang == localize.Cy {
-		return "/" + app.Lang.String() + path
-	}
-
-	return path
 }
 
 func contains(needle string, list []string) bool {
@@ -273,13 +259,13 @@ func listAttorneys(attorneys actor.Attorneys, app page.AppData, attorneyType str
 	}
 
 	if attorneyType == "replacement" {
-		props["DetailsPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseReplacementAttorneys, app.Page)
-		props["AddressPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseReplacementAttorneysAddress, app.Page)
-		props["RemovePath"] = fmt.Sprintf("%s?from=%s", app.Paths.RemoveReplacementAttorney, app.Page)
+		props["DetailsPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseReplacementAttorneys.Format(lpa.ID), app.Page)
+		props["AddressPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseReplacementAttorneysAddress.Format(lpa.ID), app.Page)
+		props["RemovePath"] = fmt.Sprintf("%s?from=%s", app.Paths.RemoveReplacementAttorney.Format(lpa.ID), app.Page)
 	} else {
-		props["DetailsPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseAttorneys, app.Page)
-		props["AddressPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseAttorneysAddress, app.Page)
-		props["RemovePath"] = fmt.Sprintf("%s?from=%s", app.Paths.RemoveAttorney, app.Page)
+		props["DetailsPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseAttorneys.Format(lpa.ID), app.Page)
+		props["AddressPath"] = fmt.Sprintf("%s?from=%s", app.Paths.ChooseAttorneysAddress.Format(lpa.ID), app.Page)
+		props["RemovePath"] = fmt.Sprintf("%s?from=%s", app.Paths.RemoveAttorney.Format(lpa.ID), app.Page)
 	}
 
 	return props

--- a/app/internal/templatefn/fn_test.go
+++ b/app/internal/templatefn/fn_test.go
@@ -142,20 +142,6 @@ func TestInc(t *testing.T) {
 func TestLink(t *testing.T) {
 	assert.Equal(t, "/dashboard", link(page.AppData{}, "/dashboard"))
 	assert.Equal(t, "/cy/dashboard", link(page.AppData{Lang: localize.Cy}, "/dashboard"))
-	assert.Equal(t, "/lpa/123/somewhere", link(page.AppData{LpaID: "123"}, "/somewhere"))
-	assert.Equal(t, "/cy/lpa/123/somewhere", link(page.AppData{Lang: localize.Cy, LpaID: "123"}, "/somewhere"))
-}
-
-func TestLinkWithID(t *testing.T) {
-	assert.Equal(t, "/lpa/123/task-list", linkWithID(page.AppData{}, "/task-list", "123"))
-	assert.Equal(t, "/cy/lpa/123/task-list", linkWithID(page.AppData{Lang: localize.Cy}, "/task-list", "123"))
-}
-
-func TestLinkLang(t *testing.T) {
-	assert.Equal(t, "/dashboard", linkLang(page.AppData{}, "/dashboard"))
-	assert.Equal(t, "/cy/dashboard", linkLang(page.AppData{Lang: localize.Cy}, "/dashboard"))
-	assert.Equal(t, "/somewhere", linkLang(page.AppData{LpaID: "123"}, "/somewhere"))
-	assert.Equal(t, "/cy/somewhere", linkLang(page.AppData{Lang: localize.Cy, LpaID: "123"}, "/somewhere"))
 }
 
 func TestContains(t *testing.T) {
@@ -275,7 +261,7 @@ func TestListAttorneysWithAttorneys(t *testing.T) {
 
 	app := page.AppData{SessionID: "abc", Page: "/here"}
 	withHeaders := true
-	lpa := &page.Lpa{}
+	lpa := &page.Lpa{ID: "lpa-id"}
 	attorneyType := "attorney"
 
 	want := map[string]interface{}{
@@ -284,9 +270,9 @@ func TestListAttorneysWithAttorneys(t *testing.T) {
 		"WithHeaders":  withHeaders,
 		"Lpa":          lpa,
 		"AttorneyType": attorneyType,
-		"DetailsPath":  app.Paths.ChooseAttorneys + "?from=/here",
-		"AddressPath":  app.Paths.ChooseAttorneysAddress + "?from=/here",
-		"RemovePath":   app.Paths.RemoveAttorney + "?from=/here",
+		"DetailsPath":  app.Paths.ChooseAttorneys.Format("lpa-id") + "?from=/here",
+		"AddressPath":  app.Paths.ChooseAttorneysAddress.Format("lpa-id") + "?from=/here",
+		"RemovePath":   app.Paths.RemoveAttorney.Format("lpa-id") + "?from=/here",
 	}
 
 	got := listAttorneys(attorneys, app, attorneyType, withHeaders, lpa)
@@ -302,7 +288,7 @@ func TestListAttorneysWithReplacementAttorneys(t *testing.T) {
 
 	app := page.AppData{SessionID: "abc", Page: "/here"}
 	withHeaders := true
-	lpa := &page.Lpa{}
+	lpa := &page.Lpa{ID: "lpa-id"}
 	attorneyType := "replacement"
 
 	want := map[string]interface{}{
@@ -311,9 +297,9 @@ func TestListAttorneysWithReplacementAttorneys(t *testing.T) {
 		"WithHeaders":  withHeaders,
 		"Lpa":          lpa,
 		"AttorneyType": attorneyType,
-		"DetailsPath":  app.Paths.ChooseReplacementAttorneys + "?from=/here",
-		"AddressPath":  app.Paths.ChooseReplacementAttorneysAddress + "?from=/here",
-		"RemovePath":   app.Paths.RemoveReplacementAttorney + "?from=/here",
+		"DetailsPath":  app.Paths.ChooseReplacementAttorneys.Format("lpa-id") + "?from=/here",
+		"AddressPath":  app.Paths.ChooseReplacementAttorneysAddress.Format("lpa-id") + "?from=/here",
+		"RemovePath":   app.Paths.RemoveReplacementAttorney.Format("lpa-id") + "?from=/here",
 	}
 
 	got := listAttorneys(attorneys, app, attorneyType, withHeaders, lpa)

--- a/app/main.go
+++ b/app/main.go
@@ -145,7 +145,7 @@ func main() {
 
 	sessionStore := sessions.NewCookieStore(sessionKeys...)
 
-	redirectURL := authRedirectBaseURL + page.Paths.AuthRedirect
+	redirectURL := authRedirectBaseURL + page.Paths.AuthRedirect.Format()
 
 	signInClient, err := onelogin.Discover(ctx, logger, httpClient, secretsClient, issuer, clientID, redirectURL)
 	if err != nil {
@@ -198,15 +198,15 @@ func main() {
 	uidClient := uid.New(uidBaseURL, httpClient, cfg, v4.NewSigner(), time.Now)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(page.Paths.HealthCheck.Service, func(w http.ResponseWriter, r *http.Request) {})
-	mux.Handle(page.Paths.HealthCheck.Dependency, page.DependencyHealthCheck(logger, uidClient))
+	mux.HandleFunc(page.Paths.HealthCheck.Service.String(), func(w http.ResponseWriter, r *http.Request) {})
+	mux.Handle(page.Paths.HealthCheck.Dependency.String(), page.DependencyHealthCheck(logger, uidClient))
 	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, webDir+"/robots.txt")
 	})
 	mux.Handle("/static/", http.StripPrefix("/static", handlers.CompressHandler(page.CacheControlHeaders(http.FileServer(http.Dir(webDir+"/static/"))))))
-	mux.Handle(page.Paths.AuthRedirect, page.AuthRedirect(logger, sessionStore))
-	mux.Handle(page.Paths.YotiRedirect, page.YotiRedirect(logger, sessionStore))
-	mux.Handle(page.Paths.CookiesConsent, page.CookieConsent(page.Paths))
+	mux.Handle(page.Paths.AuthRedirect.String(), page.AuthRedirect(logger, sessionStore))
+	mux.Handle(page.Paths.YotiRedirect.String(), page.YotiRedirect(logger, sessionStore))
+	mux.Handle(page.Paths.CookiesConsent.String(), page.CookieConsent(page.Paths))
 	mux.Handle("/cy/", http.StripPrefix("/cy", app.App(logger, bundle.For(localize.Cy), localize.Cy, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient)))
 	mux.Handle("/", app.App(logger, bundle.For(localize.En), localize.En, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient))
 

--- a/cypress/e2e/attorney/sign.cy.js
+++ b/cypress/e2e/attorney/sign.cy.js
@@ -31,7 +31,7 @@ describe('Sign', () => {
 
     describe('as a replacement attorney', () => {
         beforeEach(() => {
-            cy.visit('/testing-start?cookiesAccepted=1&redirect=/attorney-sign&lpa.complete=1&withReplacementAttorney=1&lpa.signedByDonor=1&certificateProviderProvided=certified&replacementAttorneyProvided=1');
+            cy.visit('/testing-start?cookiesAccepted=1&redirect=/attorney-sign&lpa.complete=1&withReplacementAttorney=1&lpa.signedByDonor=1&certificateProviderProvided=certified&replacementAttorneyProvided=1&loginAs=attorney');
         });
 
         it('can be signed', () => {

--- a/cypress/e2e/attorney/what-happens-when-you-sign-the-lpa.cy.js
+++ b/cypress/e2e/attorney/what-happens-when-you-sign-the-lpa.cy.js
@@ -21,7 +21,7 @@ describe('What happens when you sign the LPA', () => {
     });
 
     it('as a property and affairs replacement attorney', () => {
-        cy.visit('/testing-start?redirect=/attorney-what-happens-when-you-sign-the-lpa&lpa.complete=1&replacementAttorneyProvided=1');
+        cy.visit('/testing-start?redirect=/attorney-what-happens-when-you-sign-the-lpa&lpa.complete=1&replacementAttorneyProvided=1&loginAs=attorney');
 
         cy.contains('p', "you’re saying that you want to be a replacement attorney")
         cy.contains('li', "make decisions about their money or property")
@@ -29,7 +29,7 @@ describe('What happens when you sign the LPA', () => {
     });
 
     it('as a personal welfare replacement attorney', () => {
-        cy.visit('/testing-start?redirect=/attorney-what-happens-when-you-sign-the-lpa&lpa.complete=1&replacementAttorneyProvided=1&lpa.type=hw');
+        cy.visit('/testing-start?redirect=/attorney-what-happens-when-you-sign-the-lpa&lpa.complete=1&replacementAttorneyProvided=1&lpa.type=hw&loginAs=attorney');
 
         cy.contains('p', "you’re saying that you want to be a replacement attorney ")
         cy.contains('li', "their personal and medical care")

--- a/cypress/e2e/certificate-provider/certificate-provided.cy.js
+++ b/cypress/e2e/certificate-provider/certificate-provided.cy.js
@@ -1,6 +1,6 @@
 describe('Certificate provided', () => {
     beforeEach(() => {
-        cy.visit('/testing-start?redirect=/certificate-provided');
+        cy.visit('/testing-start?redirect=/certificate-provided&loginAs=certificate-provider');
     });
 
     it('has a button', () => {

--- a/cypress/e2e/certificate-provider/who-is-eligible.cy.js
+++ b/cypress/e2e/certificate-provider/who-is-eligible.cy.js
@@ -1,6 +1,7 @@
 describe('Who is eligible', () => {
     beforeEach(() => {
-        cy.visit('/testing-start?redirect=/certificate-provider-who-is-eligible&withShareCodeSession=1');
+        cy.visit('/testing-start?withShareCodeSession=1');
+        cy.visit('/certificate-provider-who-is-eligible');
     });
 
     it('can continue', () => {

--- a/cypress/e2e/donor/choose-attorneys-summary.cy.js
+++ b/cypress/e2e/donor/choose-attorneys-summary.cy.js
@@ -27,8 +27,8 @@ describe('Choose attorneys summary', () => {
 
         cy.get('#attorney-name-1').contains('a', 'Change').click();
 
-        cy.url().should('contain', '/choose-attorneys');
-        cy.url().should('contain', 'from=/choose-attorneys-summary');
+        cy.url().should('contain', '/choose-attorneys?from=');
+        cy.url().should('contain', '/choose-attorneys-summary');
         cy.url().should('match', /id=\w*/);
 
         cy.get('#f-first-names').clear().type('Mark');
@@ -45,8 +45,8 @@ describe('Choose attorneys summary', () => {
 
         cy.get('#attorney-address-2').contains('a', 'Change').click();
 
-        cy.url().should('contain', '/choose-attorneys-address');
-        cy.url().should('contain', 'from=/choose-attorneys-summary');
+        cy.url().should('contain', '/choose-attorneys-address?from=');
+        cy.url().should('contain', '/choose-attorneys-summary');
         cy.url().should('match', /id=\w*/);
 
         cy.contains('label', 'Enter a new address').click();

--- a/cypress/e2e/donor/dashboard.cy.js
+++ b/cypress/e2e/donor/dashboard.cy.js
@@ -1,7 +1,8 @@
 describe('Dashboard', () => {
     context('with incomplete LPA', () => {
         beforeEach(() => {
-            cy.visit('/testing-start?redirect=/dashboard&lpa.yourDetails=1');
+            cy.visit('/testing-start?lpa.yourDetails=1');
+            cy.visit('/dashboard');
         });
 
         it('shows my lasting power of attorney', () => {
@@ -36,7 +37,8 @@ describe('Dashboard', () => {
 
     context('with completed LPA', () => {
         it('completed LPAs have a track progress button', () => {
-            cy.visit('/testing-start?redirect=/dashboard&lpa.complete=1')
+            cy.visit('/testing-start?lpa.complete=1')
+            cy.visit('/dashboard');
 
             cy.get('button').should('not.contain', 'Continue');
 
@@ -49,8 +51,9 @@ describe('Dashboard', () => {
     });
 
     context('with various roles', () => {
-        it.only('shows all of my LPAs', () => {
-            cy.visit('/testing-start?redirect=/dashboard&lpa.complete=1&attorneyProvided=1&certificateProviderProvided=1&fresh=1')
+        it('shows all of my LPAs', () => {
+            cy.visit('/testing-start?lpa.complete=1&attorneyProvided=1&certificateProviderProvided=1&fresh=1')
+            cy.visit('/dashboard');
 
             cy.contains('My LPAs');
             cy.contains('I’m an attorney');

--- a/cypress/e2e/donor/your-legal-rights-and-responsibilities.cy.js
+++ b/cypress/e2e/donor/your-legal-rights-and-responsibilities.cy.js
@@ -12,7 +12,7 @@ describe('Your legal rights and responsibilities', () => {
 
     describe('when signed in', () => {
         it('is accessible from the footer', () => {
-            cy.visit('/testing-start?redirect=/your-legal-rights-and-responsibilities');
+            cy.visit('/testing-start?redirect=/lpa-your-legal-rights-and-responsibilities');
             cy.contains('a', 'Continue to signing page');
 
             cy.contains('footer a', 'Your legal rights and responsibilities').click();

--- a/web/template/about_payment.gohtml
+++ b/web/template/about_payment.gohtml
@@ -28,7 +28,7 @@
       <form novalidate method="post">
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "continueToPayment" }}</button>
-          <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+          <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
         </div>
         {{ template "csrf-field" . }}
       </form>

--- a/web/template/attorney_code_of_conduct.gohtml
+++ b/web/template/attorney_code_of_conduct.gohtml
@@ -46,7 +46,7 @@
       "DonorFullNamePossessive" (possessive .App .Lpa.Donor.FullName)
       "DonorFirstNamesPossessive" (possessive .App .Lpa.Donor.FirstNames) }}
 
-      <a class="govuk-button" href="{{ link .App .App.Paths.Attorney.TaskList }}">{{ tr .App "continue" }}</a>
+      <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.TaskList.Format .App.LpaID) }}">{{ tr .App "continue" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/attorney_legal_rights_and_responsibilities.gohtml
+++ b/web/template/attorney_legal_rights_and_responsibilities.gohtml
@@ -9,7 +9,7 @@
 
             {{ trHtml .App "attorneyRightsAndResponsibilitiesContent" }}
 
-            <a class="govuk-button" href="{{ link .App .App.Paths.Attorney.WhatHappensWhenYouSign }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+            <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.WhatHappensWhenYouSign.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
         </div>
     </div>
 {{ end }}

--- a/web/template/attorney_start.gohtml
+++ b/web/template/attorney_start.gohtml
@@ -8,7 +8,7 @@
       {{ trHtml .App "beAnAttorneyContent" }}
 
       <p class="govuk-body">
-        <a href="{{ link .App .App.Paths.Attorney.Login }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="{{ link .App .App.Paths.Attorney.Login.Format }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           {{ tr .App "start" }}
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/web/template/attorney_what_happens_next.gohtml
+++ b/web/template/attorney_what_happens_next.gohtml
@@ -25,7 +25,7 @@
 
       {{ trFormatHtml .App "attorneyWhatHappensNextContent" "DonorFirstNamesPossessive" (possessive .App .Lpa.Donor.FirstNames) }}
 
-      <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard }}">{{ tr .App "goToYourDashboard" }}</a>
+      <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard.Format }}">{{ tr .App "goToYourDashboard" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/attorney_what_happens_when_you_sign.gohtml
+++ b/web/template/attorney_what_happens_when_you_sign.gohtml
@@ -35,7 +35,7 @@
 
             {{ end }}
 
-            <a class="govuk-button" href="{{ link .App .App.Paths.Attorney.Sign }}" data-module="govuk-button">{{ tr .App "continueToSigningPage" }}</a>
+            <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.Sign.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "continueToSigningPage" }}</a>
         </div>
     </div>
 {{ end }}

--- a/web/template/certificate_provider_read_the_lpa.gohtml
+++ b/web/template/certificate_provider_read_the_lpa.gohtml
@@ -25,9 +25,9 @@
         {{ $progress := .Lpa.Progress .CertificateProvider }}
 
         {{ if $progress.LpaSigned.Completed }}
-          <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.ProvideCertificate }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.CertificateProvider.ProvideCertificate.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
         {{ else }}
-          <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.WhatHappensNext }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.CertificateProvider.WhatHappensNext.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
         {{ end }}
       </p>
     </div>

--- a/web/template/certificate_provider_start.gohtml
+++ b/web/template/certificate_provider_start.gohtml
@@ -8,7 +8,7 @@
       {{ trHtml .App "beACertificateProviderContent" }}
 
       <p class="govuk-body">
-        <a href="{{ link .App .App.Paths.CertificateProvider.EnterReferenceNumber }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        <a href="{{ link .App .App.Paths.CertificateProvider.EnterReferenceNumber.Format }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           {{ tr .App "start" }}
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/web/template/certificate_provider_what_youll_need_to_confirm_your_identity.gohtml
+++ b/web/template/certificate_provider_what_youll_need_to_confirm_your_identity.gohtml
@@ -9,7 +9,7 @@
 
       {{ trHtml .App "confirmYourIdentityContent" }}
 
-      <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App .App.Paths.CertificateProvider.SelectYourIdentityOptions }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
+      <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App (.App.Paths.CertificateProvider.SelectYourIdentityOptions.Format .App.LpaID) }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/certificate_provider_who_is_eligible.gohtml
+++ b/web/template/certificate_provider_who_is_eligible.gohtml
@@ -38,7 +38,7 @@
 
         {{ template "warning" (warning .App "ifAnyStatementsApplyYouCannotBeACertificateProvider") }}
 
-        <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.Login }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+        <a class="govuk-button" href="{{ link .App .App.Paths.CertificateProvider.Login.Format }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
     </div>
 </div>
 {{ end }}

--- a/web/template/check_your_lpa.gohtml
+++ b/web/template/check_your_lpa.gohtml
@@ -61,7 +61,7 @@
 
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "confirm" }}</button>
-          <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+          <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
         </div>
         {{ template "csrf-field" . }}
       </form>

--- a/web/template/dashboard.gohtml
+++ b/web/template/dashboard.gohtml
@@ -11,9 +11,9 @@
       <span class="govuk-hint"><strong>{{ tr $.App "applicationNumber" }}:</strong> {{ .Item.ID }}</span>
       <div class="govuk-button-group govuk-!-margin-top-4">
         {{ if .Item.Submitted.IsZero }}
-          <a class="govuk-button" href="{{ linkWithID .App .App.Paths.TaskList .Item.ID }}">{{ tr .App "continue" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.TaskList.Format .Item.ID) }}">{{ tr .App "continue" }}</a>
         {{ else }}
-          <a class="govuk-button" href="{{ linkWithID .App .App.Paths.Progress .Item.ID }}">{{ tr .App "trackLpaProgress" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.Progress.Format .Item.ID) }}">{{ tr .App "trackLpaProgress" }}</a>
         {{ end }}
         <a class="govuk-button govuk-button--secondary" href="#">{{ tr .App "options" }}</a>
       </div>
@@ -29,7 +29,7 @@
       <h2 class="govuk-heading-m govuk-!-padding-top-0 govuk-!-margin-bottom-1">{{ if eq "pfa" .Item.Type }}{{ tr .App "lpaTypePfa" }}{{ else }}{{ tr .App "lpaTypeHw" }}{{ end }}: <span class="govuk-!-font-weight-regular">{{ .Item.Donor.FirstNames }} {{ .Item.Donor.LastName }}</span></h2>
       <span class="govuk-hint"><strong>{{ tr .App "applicationNumber" }}:</strong> {{ .Item.ID }}</span>
       <div class="govuk-button-group govuk-!-margin-top-4">
-        <a class="govuk-button" href="{{ linkWithID .App .App.Paths.Attorney.TaskList .Item.ID }}">{{ tr .App "continue" }}</a>
+        <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.TaskList.Format .Item.ID) }}">{{ tr .App "continue" }}</a>
         <a class="govuk-button govuk-button--secondary" href="#">{{ tr .App "options" }}</a>
       </div>
     </div>
@@ -44,7 +44,7 @@
       <h2 class="govuk-heading-m govuk-!-padding-top-0 govuk-!-margin-bottom-1">{{ if eq "pfa" .Item.Type }}{{ tr .App "lpaTypePfa" }}{{ else }}{{ tr .App "lpaTypeHw" }}{{ end }}: <span class="govuk-!-font-weight-regular">{{ .Item.Donor.FirstNames }} {{ .Item.Donor.LastName }}</span></h2>
       <span class="govuk-hint"><strong>{{ tr .App "applicationNumber" }}:</strong> {{ .Item.ID }}</span>
       <div class="govuk-button-group govuk-!-margin-top-4">
-        <a class="govuk-button" href="{{ linkWithID .App .App.Paths.CertificateProvider.CheckYourName .Item.ID }}">{{ tr .App "continue" }}</a>
+        <a class="govuk-button" href="{{ link .App (.App.Paths.CertificateProvider.CheckYourName.Format .Item.ID) }}">{{ tr .App "continue" }}</a>
         <a class="govuk-button govuk-button--secondary" href="#">{{ tr .App "options" }}</a>
       </div>
     </div>

--- a/web/template/error-404.gohtml
+++ b/web/template/error-404.gohtml
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ tr .App "pageNotFound" }}</h1>
 
-      {{ trFormatHtml .App "pageNotFoundContent" "Start" (link .App .App.Paths.Start) }}
+      {{ trFormatHtml .App "pageNotFoundContent" "Start" (link .App .App.Paths.Start.Format) }}
     </div>
   </div>
 {{ end }}

--- a/web/template/how_to_confirm_your_identity_and_sign.gohtml
+++ b/web/template/how_to_confirm_your_identity_and_sign.gohtml
@@ -18,8 +18,8 @@
         </div>
 
         <div class="govuk-button-group">
-          <a class="govuk-button" href="{{ link .App .App.Paths.WhatYoullNeedToConfirmYourIdentity }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
-          <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.WhatYoullNeedToConfirmYourIdentity.Format .App.LpaID) }}" data-module="govuk-button">{{ tr $.App "continue" }}</a>
+          <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
       </div>
     </div>
 {{ end }}

--- a/web/template/layout/certificate-provider-details.gohtml
+++ b/web/template/layout/certificate-provider-details.gohtml
@@ -9,7 +9,7 @@
       </dd>
       {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}?from={{.App.Page}}#f-first-names">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.CertificateProviderDetails.Format .App.LpaID) }}?from={{.App.Page}}#f-first-names">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ lowerFirst (tr .App "certificateProvider") }}</span>
           </a>
         </dd>
@@ -31,7 +31,7 @@
       </dd>
       {{ if and (not $.Lpa.Tasks.ConfirmYourIdentityAndSign.Completed) $.App.IsDonor }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.CertificateProviderDetails }}?from={{.App.Page}}#f-mobile">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.CertificateProviderDetails.Format .App.LpaID) }}?from={{.App.Page}}#f-mobile">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "certificateProviderMobile" }}</span>
           </a>
         </dd>

--- a/web/template/layout/continue-and-return-buttons.gohtml
+++ b/web/template/layout/continue-and-return-buttons.gohtml
@@ -1,6 +1,6 @@
 {{ define "continue-and-return-buttons" }}
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "continue" }}</button>
-    <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+    <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
   </div>
 {{ end }}

--- a/web/template/layout/donor-details.gohtml
+++ b/web/template/layout/donor-details.gohtml
@@ -16,7 +16,7 @@
       {{ end }}
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.YourDetails }}?from={{.App.Page}}#f-first-names">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.YourDetails.Format .App.LpaID) }}?from={{.App.Page}}#f-first-names">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "name" }}</span>
           </a>
         </dd>
@@ -32,7 +32,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.YourDetails }}?from={{.App.Page}}#f-date-of-birth">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.YourDetails.Format .App.LpaID) }}?from={{.App.Page}}#f-date-of-birth">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "dateOfBirth" }}</span>
           </a>
         </dd>
@@ -60,7 +60,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.YourAddress }}?from={{.App.Page}}#f-address-line-1">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.YourAddress.Format .App.LpaID) }}?from={{.App.Page}}#f-address-line-1">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "address" }}</span>
           </a>
         </dd>

--- a/web/template/layout/login-header.gohtml
+++ b/web/template/layout/login-header.gohtml
@@ -108,7 +108,7 @@
           <nav aria-label="{{ trFormat .App "serviceNameNavigationMenu" "ServiceName" (tr .App "serviceName") }}">
             <ul class="service-header__nav-list service-header__nav" id="service-header__nav" data-open-class="service-header__nav--open">
               <li class="service-header__nav-list-item service-header__nav-list-item--active">
-                <a class="service-header__nav-list-item-link" aria-current="page" href="{{ link .App .App.Paths.Dashboard }}">{{ tr .App "manageYourLpas" }}</a>
+                <a class="service-header__nav-list-item-link" aria-current="page" href="{{ link .App .App.Paths.Dashboard.Format }}">{{ tr .App "manageYourLpas" }}</a>
               </li>
               <li class="service-header__nav-list-item"><a class="service-header__nav-list-item-link" href="#">{{ tr .App "helpAndSupport" }}</a></li>
             </ul>

--- a/web/template/layout/lpa-decisions.gohtml
+++ b/web/template/layout/lpa-decisions.gohtml
@@ -15,7 +15,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.LpaType }}">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.LpaType.Format .App.LpaID) }}">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "typeOfLpa" }}</span>
           </a>
         </dd>
@@ -35,7 +35,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.WhenCanTheLpaBeUsed }}">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.WhenCanTheLpaBeUsed.Format .App.LpaID) }}">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "whenYourAttorneysCanUseYourLpa" }}</span>
           </a>
         </dd>
@@ -57,7 +57,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.ChooseAttorneys }}">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.ChooseAttorneys.Format .App.LpaID) }}">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "yourAttorneys" }}</span>
           </a>
         </dd>
@@ -89,7 +89,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.HowShouldAttorneysMakeDecisions }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.HowShouldAttorneysMakeDecisions.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ lowerFirst (tr .App $title) }}</span>
             </a>
           </dd>
@@ -120,7 +120,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.AreYouHappyIfOneAttorneyCantActNoneCan }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.AreYouHappyIfOneAttorneyCantActNoneCan.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ lowerFirst (tr .App $title) }}</span>
             </a>
           </dd>
@@ -147,7 +147,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.ChooseReplacementAttorneys }}">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.ChooseReplacementAttorneys.Format .App.LpaID) }}">
             {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ tr .App "yourReplacementAttorneys" }}</span>
           </a>
         </dd>
@@ -178,7 +178,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.HowShouldReplacementAttorneysMakeDecisions }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.HowShouldReplacementAttorneysMakeDecisions.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ lowerFirst (tr .App $title) }}</span>
             </a>
           </dd>
@@ -206,7 +206,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.HowShouldReplacementAttorneysStepIn }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.HowShouldReplacementAttorneysStepIn.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ lowerFirst (tr .App $title) }}</span>
             </a>
           </dd>
@@ -237,7 +237,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.AreYouHappyIfOneReplacementAttorneyCantActNoneCan.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden">{{ lowerFirst (tr .App $title) }}</span>
             </a>
           </dd>
@@ -259,7 +259,7 @@
         </dd>
         {{ if $canChange }}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{ link .App .App.Paths.LifeSustainingTreatment }}">
+            <a class="govuk-link" href="{{ link .App (.App.Paths.LifeSustainingTreatment.Format .App.LpaID) }}">
               {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "lifeSustainingTreatment" }}</span>
             </a>
           </dd>
@@ -276,7 +276,7 @@
       </dd>
       {{ if $canChange }}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ link .App .App.Paths.Restrictions }}">
+          <a class="govuk-link" href="{{ link .App (.App.Paths.Restrictions.Format .App.LpaID) }}">
             {{ tr .App "change" }}<span class="govuk-visually-hidden"> {{ tr .App "yourRestrictions" }}</span>
           </a>
         </dd>

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -157,7 +157,7 @@
                   </a>
                 </li>
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="{{ linkLang .App .App.Paths.YourLegalRightsAndResponsibilities }}">
+                  <a class="govuk-footer__link" href="{{ link .App .App.Paths.YourLegalRightsAndResponsibilities.Format }}">
                     {{ tr .App "yourLegalRightsAndResponsibilities" }}
                   </a>
                 </li>

--- a/web/template/layout/people-to-notify-summary.gohtml
+++ b/web/template/layout/people-to-notify-summary.gohtml
@@ -2,9 +2,9 @@
     {{range $i, $p := .Lpa.PeopleToNotify}}
         {{ $personNumber := inc $i }}
 
-        {{ $detailsLink := printf "%s?from=%s&id=%s" $.App.Paths.ChoosePeopleToNotify $.App.Page .ID }}
-        {{ $addressLink := printf "%s?from=%s&id=%s" $.App.Paths.ChoosePeopleToNotifyAddress $.App.Page .ID }}
-        {{ $removeLink := printf "%s?from=%s&id=%s" $.App.Paths.RemovePersonToNotify $.App.Page .ID }}
+        {{ $detailsLink := printf "%s?from=%s&id=%s" ($.App.Paths.ChoosePeopleToNotify.Format $.App.LpaID) $.App.Page .ID }}
+        {{ $addressLink := printf "%s?from=%s&id=%s" ($.App.Paths.ChoosePeopleToNotifyAddress.Format $.App.LpaID) $.App.Page .ID }}
+        {{ $removeLink := printf "%s?from=%s&id=%s" ($.App.Paths.RemovePersonToNotify.Format $.App.LpaID) $.App.Page .ID }}
 
         {{ if $.WithHeaders}}
             <h2 class="govuk-heading-m">Person {{ $personNumber }}</h2>

--- a/web/template/layout/save-and-return-buttons.gohtml
+++ b/web/template/layout/save-and-return-buttons.gohtml
@@ -1,6 +1,6 @@
 {{ define "save-and-return-buttons" }}
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</button>
-    <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+    <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
   </div>
 {{ end }}

--- a/web/template/lpa_progress.gohtml
+++ b/web/template/lpa_progress.gohtml
@@ -18,7 +18,7 @@
 
             {{ template "progress-bar" (progressBar .App .Lpa .CertificateProvider) }}
 
-            <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard }}">{{ tr .App "backToDashboard" }}</a>
+            <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard.Format }}">{{ tr .App "backToDashboard" }}</a>
 
             <h2 class="govuk-heading-m">{{ tr .App "lpaDecisions"}}</h2>
 

--- a/web/template/payment_confirmation.gohtml
+++ b/web/template/payment_confirmation.gohtml
@@ -16,7 +16,7 @@
 
       {{ trHtml .App "paymentConfirmationContent" }}
 
-      <a class="govuk-button" href="{{ link .App .App.Paths.TaskList }}">{{ tr .App "continue" }}</a>
+      <a class="govuk-button" href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}">{{ tr .App "continue" }}</a>
     </div>
   </div>
 {{ end }}

--- a/web/template/read_your_lpa.gohtml
+++ b/web/template/read_your_lpa.gohtml
@@ -25,10 +25,10 @@
       {{ template "people-named-on-lpa" (peopleNamedOnLpa .App .Lpa false) }}
 
       <p class="govuk-body">
-        <a href="{{ link .App .App.Paths.YourLegalRightsAndResponsibilities }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        <a href="{{ link .App (.App.Paths.LpaYourLegalRightsAndResponsibilities.Format .App.LpaID) }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
           {{ tr .App "continue" }}
         </a>
-        <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+        <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
       </p>
     </div>
   </div>

--- a/web/template/sign_your_lpa.gohtml
+++ b/web/template/sign_your_lpa.gohtml
@@ -74,7 +74,7 @@
           <button type="submit" class="govuk-button" data-module="govuk-button">
             {{ tr .App "submitMySignature" }}
           </button>
-          <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+          <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
         </div>
         {{ template "csrf-field" . }}
       </form>

--- a/web/template/start.gohtml
+++ b/web/template/start.gohtml
@@ -9,7 +9,7 @@
 
       {{ trHtml .App "startContent" }}
 
-      <a href="{{ link .App .App.Paths.Login }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      <a href="{{ link .App .App.Paths.Login.Format }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
         {{ tr .App "start" }}
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/web/template/what_youll_need_to_confirm_your_identity.gohtml
+++ b/web/template/what_youll_need_to_confirm_your_identity.gohtml
@@ -10,11 +10,11 @@
       {{ trHtml .App "whatYoullNeedToConfirmYourIdentityContent" }}
 
       {{ if eq .App.Page .App.Paths.CertificateProvider.WhatYoullNeedToConfirmYourIdentity }}
-        <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App .App.Paths.CertificateProviderSelectYourIdentityOptions }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
+        <a class="govuk-button govuk-!-margin-top-4" href="{{ link .App (.App.Paths.CertificateProviderSelectYourIdentityOptions.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "continue" }}</a>
       {{ else }}
         <div class="govuk-button-group govuk-!-margin-top-4">
-          <a class="govuk-button" href="{{ link .App .App.Paths.SelectYourIdentityOptions }}" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</a>
-          <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+          <a class="govuk-button" href="{{ link .App (.App.Paths.SelectYourIdentityOptions.Format .App.LpaID) }}" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</a>
+          <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
         </div>
       {{ end }}
     </div>

--- a/web/template/witnessing_as_certificate_provider.gohtml
+++ b/web/template/witnessing_as_certificate_provider.gohtml
@@ -16,7 +16,7 @@
         </div>
 
         <p class="govuk-body">
-          <a href="{{ link .App .App.Paths.ResendWitnessCode }}" class="govuk-link">{{ trFormat .App "cpNotReceivedCodeLink" "CpFirstName" .Lpa.CertificateProvider.FirstNames }}</a>
+          <a href="{{ link .App (.App.Paths.ResendWitnessCode.Format .App.LpaID) }}" class="govuk-link">{{ trFormat .App "cpNotReceivedCodeLink" "CpFirstName" .Lpa.CertificateProvider.FirstNames }}</a>
         </p>
 
         <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</button>

--- a/web/template/you_have_submitted_your_lpa.gohtml
+++ b/web/template/you_have_submitted_your_lpa.gohtml
@@ -19,7 +19,7 @@
       {{ $signIn4WeeksWarning := trFormat .App "signIn4WeeksWarning" "CpFirstNames" .Lpa.CertificateProvider.FirstNames "AttorneysAndCpSigningDeadline" $formattedDeadline}}
       {{ template "warning" (warning .App $signIn4WeeksWarning) }}
 
-      <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard }}" data-module="govuk-button">
+      <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard.Format }}" data-module="govuk-button">
         {{ tr .App "saveAndContinue" }}
       </a>
     </div>

--- a/web/template/your_legal_rights_and_responsibilities.gohtml
+++ b/web/template/your_legal_rights_and_responsibilities.gohtml
@@ -14,10 +14,10 @@
       {{ end }}
 
       <p class="govuk-button-group govuk-!-margin-top-8">
-        <a href="{{ link .App .App.Paths.SignYourLpa }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        <a href="{{ link .App (.App.Paths.SignYourLpa.Format .App.LpaID) }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
           {{ tr .App "continueToSigningPage" }}
         </a>
-        <a href="{{ link .App .App.Paths.TaskList }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
+        <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
The idea is that `.String` returns just the end path component, so suitable for using in routers, and in basically every other situation we should use `.Format` so we can't miss the params.