### PR TITLE
MLPAB-1048: Use env var to set onelogin URL

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,7 @@ coverage:
     - "./app/internal/telemetry"
     - "./app/internal/page/fixtures.go"
     - "./app/internal/page/testing_start.go"
+    - "./app/main.go"
   status:
     project:
       default:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "app/main.go",
         "hashed_secret": "dc9c2ac186b77d3f4f84400225d460ddcc5940db",
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 163,
         "is_secret": false
       }
     ],
@@ -355,5 +355,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-15T10:28:13Z"
+  "generated_at": "2023-06-20T09:13:09Z"
 }

--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -67,6 +67,7 @@ func App(
 	paths page.AppPaths,
 	oneLoginClient *onelogin.Client,
 	uidClient *uid.Client,
+	oneloginURL string,
 ) http.Handler {
 	donorStore := &donorStore{dataStore: dataStore, uuidString: uuid.NewString, now: time.Now}
 	certificateProviderStore := &certificateProviderStore{dataStore: dataStore, now: time.Now}
@@ -154,10 +155,10 @@ func App(
 		uidClient,
 	)
 
-	return withAppData(page.ValidateCsrf(rootMux, sessionStore, random.String, errorHandler), localizer, lang, rumConfig, staticHash)
+	return withAppData(page.ValidateCsrf(rootMux, sessionStore, random.String, errorHandler), localizer, lang, rumConfig, staticHash, oneloginURL)
 }
 
-func withAppData(next http.Handler, localizer page.Localizer, lang localize.Lang, rumConfig page.RumConfig, staticHash string) http.HandlerFunc {
+func withAppData(next http.Handler, localizer page.Localizer, lang localize.Lang, rumConfig page.RumConfig, staticHash, oneloginURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		localizer.SetShowTranslationKeys(r.FormValue("showTranslationKeys") == "1")
@@ -171,6 +172,7 @@ func withAppData(next http.Handler, localizer page.Localizer, lang localize.Lang
 		appData.StaticHash = staticHash
 		appData.Paths = page.Paths
 		appData.ActorTypes = actor.ActorTypes
+		appData.OneloginURL = oneloginURL
 
 		_, cookieErr := r.Cookie("cookies-consent")
 		appData.CookieConsentSet = cookieErr != http.ErrNoCookie

--- a/app/internal/app/app_test.go
+++ b/app/internal/app/app_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestApp(t *testing.T) {
-	app := App(&logging.Logger{}, &localize.Localizer{}, localize.En, template.Templates{}, nil, &dynamo.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, &notify.Client{}, &place.Client{}, page.RumConfig{}, "?%3fNEI0t9MN", page.Paths, &onelogin.Client{}, &uid.Client{})
+	app := App(&logging.Logger{}, &localize.Localizer{}, localize.En, template.Templates{}, nil, &dynamo.Client{}, "http://public.url", &pay.Client{}, &identity.YotiClient{}, &notify.Client{}, &place.Client{}, page.RumConfig{}, "?%3fNEI0t9MN", page.Paths, &onelogin.Client{}, &uid.Client{}, "http://onelogin.url")
 
 	assert.Implements(t, (*http.Handler)(nil), app)
 }

--- a/app/internal/page/app_data.go
+++ b/app/internal/page/app_data.go
@@ -25,6 +25,7 @@ type AppData struct {
 	ActorTypes       actor.Types
 	ActorType        actor.Type
 	AttorneyID       string
+	OneloginURL      string
 }
 
 func (d AppData) Redirect(w http.ResponseWriter, r *http.Request, lpa *Lpa, url string) error {

--- a/app/main.go
+++ b/app/main.go
@@ -71,6 +71,7 @@ func main() {
 		}
 		uidBaseURL  = env.Get("UID_BASE_URL", "http://uid-mock:8080")
 		metadataURL = env.Get("ECS_CONTAINER_METADATA_URI_V4", "")
+		oneloginURL = env.Get("ONELOGIN_URL", "https://home.integration.account.gov.uk")
 	)
 
 	staticHash, err := dirhash.HashDir(webDir+"/static", webDir, dirhash.DefaultHash)
@@ -207,8 +208,8 @@ func main() {
 	mux.Handle(page.Paths.AuthRedirect, page.AuthRedirect(logger, sessionStore))
 	mux.Handle(page.Paths.YotiRedirect, page.YotiRedirect(logger, sessionStore))
 	mux.Handle(page.Paths.CookiesConsent, page.CookieConsent(page.Paths))
-	mux.Handle("/cy/", http.StripPrefix("/cy", app.App(logger, bundle.For(localize.Cy), localize.Cy, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient)))
-	mux.Handle("/", app.App(logger, bundle.For(localize.En), localize.En, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient))
+	mux.Handle("/cy/", http.StripPrefix("/cy", app.App(logger, bundle.For(localize.Cy), localize.Cy, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient, oneloginURL)))
+	mux.Handle("/", app.App(logger, bundle.For(localize.En), localize.En, tmpls, sessionStore, dynamoClient, appPublicURL, payClient, yotiClient, notifyClient, addressClient, rumConfig, staticHash, page.Paths, signInClient, uidClient, oneloginURL))
 
 	var handler http.Handler = mux
 	if xrayEnabled {

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -352,6 +352,10 @@ locals {
           name  = "UID_BASE_URL",
           value = var.app_env_vars.uid_base_url
         },
+        {
+          name  = "ONELOGIN_URL",
+          value = var.app_env_vars.onelogin_url
+        },
       ]
     }
   )

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -15,7 +15,8 @@
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",
           "yoti_sandbox": "1",
-          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current"
+          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current",
+          "onelogin_url": "https://home.integration.account.gov.uk"
         },
         "autoscaling": {
           "minimum": 1,
@@ -58,7 +59,8 @@
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",
           "yoti_sandbox": "1",
-          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current"
+          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current",
+          "onelogin_url": "https://home.integration.account.gov.uk"
         },
         "autoscaling": {
           "minimum": 1,
@@ -100,7 +102,8 @@
           "yoti_client_sdk_id": "6b17e8cb-7423-484d-9a66-796251476203",
           "yoti_scenario_id": "2e57b5bb-0469-47e4-a866-edcd10a8b239",
           "yoti_sandbox": "1",
-          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current"
+          "uid_base_url": "https://eu4tet9kqd.execute-api.eu-west-1.amazonaws.com/current",
+          "onelogin_url": "https://home.integration.account.gov.uk"
         },
         "autoscaling": {
           "minimum": 1,
@@ -142,7 +145,8 @@
           "yoti_client_sdk_id": "8ebb1f85-5921-4b24-978d-b145071b4965",
           "yoti_scenario_id": "bad5778b-c948-4779-8f47-0c835d0491d4",
           "yoti_sandbox": "",
-          "uid_base_url": "https://43m1msyjjb.execute-api.eu-west-1.amazonaws.com/current"
+          "uid_base_url": "https://43m1msyjjb.execute-api.eu-west-1.amazonaws.com/current",
+          "onelogin_url": "https://home.integration.account.gov.uk"
         },
         "autoscaling": {
           "minimum": 1,
@@ -184,7 +188,8 @@
           "yoti_client_sdk_id": "d920d4fe-bddf-45a3-bed5-234b4a1e78b8",
           "yoti_scenario_id": "04371367-fcee-4bc0-a0e5-cdd5855861ea",
           "yoti_sandbox": "",
-          "uid_base_url": "https://xd8ey5fxu8.execute-api.eu-west-1.amazonaws.com/current"
+          "uid_base_url": "https://xd8ey5fxu8.execute-api.eu-west-1.amazonaws.com/current",
+          "onelogin_url": "https://home.integration.account.gov.uk"
         },
         "autoscaling": {
           "minimum": 1,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -41,6 +41,7 @@ variable "environments" {
           yoti_scenario_id       = string
           yoti_sandbox           = string
           uid_base_url           = string
+          onelogin_url           = string
         })
         autoscaling = object({
           minimum = number

--- a/web/template/layout/login-header.gohtml
+++ b/web/template/layout/login-header.gohtml
@@ -46,11 +46,11 @@
         </span>
         <!--<![endif]-->
       </button>
-      
+
       <nav aria-label="GOV.UK One Login menu" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
         <ul class="one-login-header__nav__list">
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link one-login-header__nav__link--one-login" href="https://home.account.gov.uk/">
+            <a class="one-login-header__nav__link one-login-header__nav__link--one-login" href="{{ .App.OneloginURL }}">
               <span class="one-login-header__nav__link-content">
                 GOV.UK One Login
               </span>


### PR DESCRIPTION
# Purpose

Pulls the URL for the onelogin account path via env var rather than hard coding. Defaulting to the integration URL for now but we can vary this once we are in private beta.

Fixes MLPAB-1048