### PR TITLE
MLPAB-1125: Fix modal design and display bugs

### DIFF
--- a/web/template/layout/data-loss-warning-dialog.gohtml
+++ b/web/template/layout/data-loss-warning-dialog.gohtml
@@ -12,8 +12,8 @@
         <p id="dialog-description" class="govuk-body" tabindex="0">{{ trHtml .App "unsavedChangesDialogContent" }}</p>
 
         <div class="govuk-button-group">
-            <button type="button" id='back-to-page-btn' class="govuk-button" data-module="govuk-button" aria-label="{{ tr .App "backToPage" }}">{{ tr .App "backToPage" }}</button>
-            <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" id='return-to-task-list-dialog-btn' class="govuk-button govuk-button--secondary">{{ tr .App "continueWithoutSaving" }}</a>
+            <button type="button" id='back-to-page-btn' class="govuk-button govuk-button--secondary" data-module="govuk-button" aria-label="{{ tr .App "backToPage" }}">{{ tr .App "backToPage" }}</button>
+            <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" id='return-to-task-list-dialog-btn' class="govuk-button govuk-button--warning">{{ tr .App "continueWithoutSaving" }}</a>
         </div>
     </div>
 {{ end }}

--- a/web/template/layout/data-loss-warning-dialog.gohtml
+++ b/web/template/layout/data-loss-warning-dialog.gohtml
@@ -12,7 +12,7 @@
         <p id="dialog-description" class="govuk-body" tabindex="0">{{ trHtml .App "unsavedChangesDialogContent" }}</p>
 
         <div class="govuk-button-group">
-            <button type="button" id='back-to-page-btn' class="govuk-button govuk-button--secondary" data-module="govuk-button" aria-label="{{ tr .App "backToPage" }}">{{ tr .App "backToPage" }}</button>
+            <button type="button" id='back-to-page-dialog-btn' class="govuk-button govuk-button--secondary" data-module="govuk-button" aria-label="{{ tr .App "backToPage" }}">{{ tr .App "backToPage" }}</button>
             <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" id='return-to-task-list-dialog-btn' class="govuk-button govuk-button--warning">{{ tr .App "continueWithoutSaving" }}</a>
         </div>
     </div>

--- a/web/template/layout/save-and-return-buttons.gohtml
+++ b/web/template/layout/save-and-return-buttons.gohtml
@@ -2,7 +2,7 @@
   {{template "data-loss-warning-dialog" . }}
 
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</button>
+    <button type="submit" id="save-and-continue-btn" class="govuk-button" data-module="govuk-button">{{ tr .App "saveAndContinue" }}</button>
     <a href="{{ link .App (.App.Paths.TaskList.Format .App.LpaID) }}" id="return-to-tasklist-btn" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
   </div>
 {{ end }}


### PR DESCRIPTION
# Purpose

This fixes a bug we noticed while demo-ing where the dialog does not appear when expected after an invalid form submission. I've added some further work around for this where we save the previous form values in a short-lived cookie and compare. I manually tested the following scenarios:

```
Given I navigate to a page with an empty form
When I enter a value in to the form
And I click return to task list
Then I should see a warning modal

Given I navigate to a page with an empty form
When I enter an invalid value in to the form
And I click save and continue
And the page reloads with validation errors
And I click return to task list
Then I should see a warning modal

Given I navigate to a page with an empty form
When I enter an invalid value in to the form
And I click save and continue
And the page reloads with validation errors
And I remove all form values
And I click return to task list
Then I should not see a warning modal
And I should be on the task list page

Given I navigate to a page with a form containing existing values
When I click return to task list
Then I should not see a warning modal
And I should be on the task list page

Given I navigate to a page with a form containing existing values
When I change one of the values
And I click return to task list
Then I should see a warning modal

Given I navigate to a page with a form containing existing values
When I change one of the values in the form to an invalid value
And I click save and continue
And the page reloads with validation errors
And I click return to task list
Then I should see a warning modal
```

If we want to automate this I can add some cypress tests in but given this should be pretty static going forward I wasn't totally convinced of the value. Happy to be challenged on that.

Also corrects the button colours as per figma.

Fixes MLPAB-1125
