### PR TITLE
MLPAB-1143 - Limit what endpoints an environment can call

### DIFF
--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -24,6 +24,7 @@ module "app" {
   ecs_application_log_group_name  = module.application_logs.cloudwatch_log_group.name
   ecs_capacity_provider           = var.ecs_capacity_provider
   app_env_vars                    = var.app_env_vars
+  app_allowed_api_arns            = var.app_allowed_api_arns
   app_service_repository_url      = var.app_service_repository_url
   app_service_container_version   = var.app_service_container_version
   ingress_allow_list_cidr         = var.ingress_allow_list_cidr

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -229,20 +229,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
     actions = [
       "execute-api:Invoke",
     ]
-    resources = [
-      "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
-      "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-      "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
-      "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-      "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
-      "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
-      "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health",
-    ]
+    resources = var.app_allowed_api_arns.uid_service
   }
 
   provider = aws.region

--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -95,3 +95,8 @@ variable "rum_monitor_application_id_secretsmanager_secret_arn" {
   description = "ARN of the AWS Secrets Manager secret containing the RUM monitor application ID"
   nullable    = true
 }
+
+variable "app_allowed_api_arns" {
+  type        = map(list(string))
+  description = "ARNs of allowed APIs"
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -73,3 +73,8 @@ variable "dns_weighting" {
   type        = number
   description = "Weighting for DNS records"
 }
+
+variable "app_allowed_api_arns" {
+  type        = map(list(string))
+  description = "ARNs of allowed APIs"
+}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -26,6 +26,7 @@ module "eu_west_1" {
     name = aws_dynamodb_table.lpas_table.name
   }
   app_env_vars           = local.environment.app.env
+  app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled
   pagerduty_service_name = local.environment.pagerduty_service_name
   dns_weighting          = 100
@@ -55,6 +56,7 @@ module "eu_west_2" {
     name = aws_dynamodb_table.lpas_table.name
   }
   app_env_vars           = local.environment.app.env
+  app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled
   pagerduty_service_name = local.environment.pagerduty_service_name
   dns_weighting          = 0

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,6 +21,22 @@
         "autoscaling": {
           "minimum": 1,
           "maximum": 3
+        },
+        "allowed_api_arns": {
+          "uid_service": [
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+          ]
         }
       },
       "backups": {
@@ -69,6 +85,22 @@
         "autoscaling": {
           "minimum": 1,
           "maximum": 3
+        },
+        "allowed_api_arns": {
+          "uid_service": [
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+          ]
         }
       },
       "backups": {
@@ -116,6 +148,22 @@
         "autoscaling": {
           "minimum": 1,
           "maximum": 3
+        },
+        "allowed_api_arns": {
+          "uid_service": [
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+          ]
         }
       },
       "backups": {
@@ -163,6 +211,22 @@
         "autoscaling": {
           "minimum": 1,
           "maximum": 3
+        },
+        "allowed_api_arns": {
+          "uid_service": [
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+          ]
         }
       },
       "backups": {
@@ -210,6 +274,22 @@
         "autoscaling": {
           "minimum": 1,
           "maximum": 3
+        },
+        "allowed_api_arns": {
+          "uid_service": [
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
+            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
+            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+          ]
         }
       },
       "backups": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -26,16 +26,8 @@
           "uid_service": [
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
           ]
         }
       },
@@ -90,16 +82,8 @@
           "uid_service": [
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
           ]
         }
       },
@@ -153,16 +137,8 @@
           "uid_service": [
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
           ]
         }
       },
@@ -214,18 +190,10 @@
         },
         "allowed_api_arns": {
           "uid_service": [
-            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
             "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
+            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health"
           ]
         }
       },
@@ -277,16 +245,8 @@
         },
         "allowed_api_arns": {
           "uid_service": [
-            "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-1:649098267436:*/*/POST/cases",
             "arn:aws:execute-api:eu-west-2:649098267436:*/*/POST/cases",
-            "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-            "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health",
             "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/health",
             "arn:aws:execute-api:eu-west-2:649098267436:*/*/GET/health"
           ]

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -47,6 +47,9 @@ variable "environments" {
           minimum = number
           maximum = number
         })
+        allowed_api_arns = object({
+          uid_service = list(string)
+        })
       })
       backups = object({
         backup_plan_enabled = bool


### PR DESCRIPTION
# Purpose

We currently allow any environment to call all instances of an API. This is too permissive

Fixes MLPAB-1143

## Approach

- pass list of ARNs to ECS task policy using variables via TFVARs
- limit the ARNs per environment