### PR TITLE
MLPAB-1155 - Deploy antivirus scanning infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 **/.terraform/
 **/terraform.tfstate.d/
+**/EICAR.txt
 **/.infracost/
 
 geckodriver.log

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -47,18 +47,19 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "2.15.1"
   constraints = "~> 2.15.0"
   hashes = [
-    "h1:512yrpWZZKXOH/Bkb1U986p187XvWaPPQJk+Bue1TT0=",
-    "h1:5zugui/m/JcGngPvPx7qvi5VeMPluFnaOf8T2/WFuJI=",
-    "h1:6ANIjt7OTielRExPpc+T2DGx8UknuWkOgb541ZzqrVs=",
-    "h1:6SSxj8Mto3i6oTq2rKHrDDOgatrYvhwnUpuNfYbL2wQ=",
-    "h1:8bAwuGmNN7b0Dny8ctggUqqe5OqDhUmPWRCZ3nuNhwI=",
-    "h1:9mTMHAzQCSwtfWsWPqFPyi4UcjxdXXoTZvawi0ALXio=",
-    "h1:O8wwHaCre8M6txqVukE+MNNl0ec0FrpjFt3NM616j1g=",
-    "h1:bg61Nj9PG3HG5Cq7ihsb60v4ltwHv+L/SurQsUFt00U=",
     "h1:cCeUEFz72Y9Dm/QeJtDcR0rg5Nb/UJOfJvqQsujakGI=",
-    "h1:dAjTVhb+K9akI/fHpqyYzfM6cHLzDn2VI7jHW16l/Y4=",
-    "h1:jnR8kdGHpIsi5VD7cJQkoMy3O/pMo8g2dGjJe36ZfKw=",
-    "h1:mTn/EsAuMsSaIsmEby7r/TcQ+ATh2OhVg+mRPtdOymk=",
-    "h1:oqn6PjmB2dF5DOS6k8mCYDnV7eFFA3c+3TdxGMQNNP8=",
+    "zh:02efce75070b172fd78263b03c79dc828184a1d111c6730259a7402d7cb3bcd9",
+    "zh:0edfcc57019f2bb559f4b37683063b3182fff322307b805fc45dd2313409b5e7",
+    "zh:414541f46385dcecadac2845e349ee0919a6f5957b22bf0d32608dd3189e703f",
+    "zh:464f2951fa5e87dc82d3e9c59567b25ca83958e369430054ab829e7c5e487e52",
+    "zh:4c3afc1b81733777c55ecf07218a0fbe18012483c1e17846959fde92928bf4f8",
+    "zh:6f174795f0fcca626c898b7f6c9a5b74ed2daa5958174db74c966cef07b39967",
+    "zh:71ca22ef20cf19bf4c0eb46aa17cd0d36af1abf49bc69d1a43c5da89d811012a",
+    "zh:76f162353d69c23689d45160da37876602af9463f656c5b5dc003a6e0b46576d",
+    "zh:82d20ac160b06c9f28cfc5978dbd76369ab3c11653c3cce2d3418d7996b3bfb8",
+    "zh:9d1a055db86edceb65c52828ff803df5fd42a7ff3c3229ee9112ab99476a056e",
+    "zh:a477defe95189a55d1c06406bfea2ca7965081f16dab2e4ce9bf25b92b6eca71",
+    "zh:b58c624c68beea1a9aa1090ffb58a44a552b13e789abea80faee7237f0e70b2d",
+    "zh:f08d4b0927704682a5b965e010d5398a7aaf92a523e16f2f3e77e0690f1e7de7",
   ]
 }

--- a/terraform/environment/global/iam_s3_antivirus.tf
+++ b/terraform/environment/global/iam_s3_antivirus.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_role" "s3_antivirus" {
+  name               = "s3-antivirus-${data.aws_default_tags.current.tags.environment-name}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  provider           = aws.global
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+  provider = aws.global
+}
+
+resource "aws_iam_role_policy_attachment" "s3_antivirus_execution_role" {
+  role       = aws_iam_role.s3_antivirus.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  provider   = aws.global
+}

--- a/terraform/environment/global/outputs.tf
+++ b/terraform/environment/global/outputs.tf
@@ -6,5 +6,6 @@ output "iam_roles" {
   value = {
     ecs_execution_role = aws_iam_role.execution_role,
     app_ecs_task_role  = aws_iam_role.app_task_role,
+    s3_antivirus       = aws_iam_role.s3_antivirus,
   }
 }

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -39,8 +39,8 @@ module "app" {
     public_subnets      = data.aws_subnet.public.*.id
   }
   uploads_s3_bucket = {
-    bucket_name = module.uploads_s3_bucket.id
-    bucket_arn  = module.uploads_s3_bucket.arn
+    bucket_name = module.uploads_s3_bucket.bucket.id
+    bucket_arn  = module.uploads_s3_bucket.bucket.arn
   }
   aws_rum_guest_role_arn                               = data.aws_iam_role.rum_monitor_unauthenticated.arn
   rum_monitor_application_id_secretsmanager_secret_arn = aws_secretsmanager_secret.rum_monitor_application_id.id

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -18,8 +18,8 @@ module "application_logs" {
 module "app" {
   source                          = "./modules/app"
   ecs_cluster                     = aws_ecs_cluster.main.id
-  ecs_execution_role              = var.ecs_execution_role
-  ecs_task_role                   = var.ecs_task_roles.app
+  ecs_execution_role              = var.iam_roles.ecs_execution_role
+  ecs_task_role                   = var.iam_roles.app_ecs_task_role
   ecs_service_desired_count       = 1
   ecs_application_log_group_name  = module.application_logs.cloudwatch_log_group.name
   ecs_capacity_provider           = var.ecs_capacity_provider

--- a/terraform/environment/region/iam_execution_policy.tf
+++ b/terraform/environment/region/iam_execution_policy.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role_policy" "execution_role_region" {
   name     = "${data.aws_default_tags.current.tags.environment-name}-execution-role-${data.aws_region.current.name}"
   policy   = data.aws_iam_policy_document.execution_role_region.json
-  role     = var.ecs_execution_role.id
+  role     = var.iam_roles.ecs_execution_role.id
   provider = aws.global
 }
 

--- a/terraform/environment/region/modules/s3_antivirus/alarms.tf
+++ b/terraform/environment/region/modules/s3_antivirus/alarms.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket_metric" "virus_infections" {
+  bucket = var.data_store_bucket.id
+  name   = "${data.aws_default_tags.current.tags.environment-name}-virus-infections"
+
+  filter {
+    tags = {
+      "${var.environment_variables.ANTIVIRUS_TAG_KEY}" = var.environment_variables.ANTIVIRUS_TAG_VALUE_FAIL
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_cloudwatch_metric_alarm" "virus_infections" {
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  alarm_description         = "Possible viruses detected in ${data.aws_default_tags.current.tags.environment-name} S3 objectes"
+  alarm_name                = "${data.aws_default_tags.current.tags.environment-name}-virus-infections"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
+  insufficient_data_actions = []
+  metric_name               = aws_s3_bucket_metric.virus_infections.name
+  namespace                 = "Monitoring"
+  ok_actions                = [var.alarm_sns_topic_arn]
+  period                    = 300
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  provider                  = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/data_sources.tf
+++ b/terraform/environment/region/modules/s3_antivirus/data_sources.tf
@@ -1,0 +1,12 @@
+
+data "aws_region" "current" {
+  provider = aws.region
+}
+
+data "aws_caller_identity" "current" {
+  provider = aws.region
+}
+
+data "aws_default_tags" "current" {
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/iam.tf
+++ b/terraform/environment/region/modules/s3_antivirus/iam.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role_policy" "lambda" {
+  name     = "s3-antivirus-policy"
+  role     = var.lambda_task_role.id
+  policy   = data.aws_iam_policy_document.lambda.json
+  provider = aws.region
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    sid       = "allowLogging"
+    effect    = "Allow"
+    resources = [aws_cloudwatch_log_group.lambda.arn]
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+  }
+
+  statement {
+    sid       = "allowS3Tagging"
+    effect    = "Allow"
+    resources = [var.data_store_bucket.arn, "${var.data_store_bucket.arn}/*"]
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging"
+    ]
+  }
+
+  statement {
+    sid       = "allowVirusDefinitions"
+    effect    = "Allow"
+    resources = [var.definition_bucket.arn, "${var.definition_bucket.arn}/*"]
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject"
+    ]
+  }
+
+  statement {
+    sid       = "tracing"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+      "xray:GetSamplingStatisticSummaries"
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_lambda_permission" "allow_lambda_execution_operator" {
+  statement_id  = "AllowExecutionOperator"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_function.function_name
+  principal     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"
+  provider      = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -5,7 +5,7 @@ data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
 
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/s3-antivirus-${data.aws_default_tags.current.tags.environment-name}"
-  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_id
+  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
   retention_in_days = 30
   provider          = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -1,0 +1,54 @@
+data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_cloudwatch_application_logs_encryption"
+  provider = aws.region
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/s3-antivirus-${data.aws_default_tags.current.tags.environment-name}"
+  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_id
+  retention_in_days = 30
+  provider          = aws.region
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  function_name = "s3-antivirus-${data.aws_default_tags.current.tags.environment-name}"
+  image_uri     = var.ecr_image_uri
+  package_type  = "Image"
+  role          = var.lambda_task_role.arn
+  timeout       = 300
+  memory_size   = 4096
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  vpc_config {
+    subnet_ids = var.aws_subnet_ids
+    security_group_ids = [
+      data.aws_security_group.lambda_egress.id
+    ]
+  }
+
+  dynamic "environment" {
+    for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
+    content {
+      variables = var.environment_variables
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_lambda_permission" "allow_bucket_to_run" {
+  statement_id   = "AllowExecutionFromS3Bucket"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.lambda_function.function_name
+  principal      = "s3.amazonaws.com"
+  source_account = data.aws_caller_identity.current.account_id
+  source_arn     = var.data_store_bucket.arn
+  provider       = aws.region
+}
+
+data "aws_security_group" "lambda_egress" {
+  name     = "lambda-egress-${data.aws_region.current.name}"
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/s3.tf
+++ b/terraform/environment/region/modules/s3_antivirus/s3.tf
@@ -1,0 +1,15 @@
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  count  = var.enable_autoscan ? 1 : 0
+  bucket = var.data_store_bucket.id
+
+  lambda_function {
+    id                  = "bucket-av-scan"
+    lambda_function_arn = aws_lambda_function.lambda_function.arn
+    events              = ["s3:ObjectCreated:Put"]
+  }
+
+  depends_on = [
+    aws_lambda_permission.allow_bucket_to_run
+  ]
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/terraform.tf
+++ b/terraform/environment/region/modules/s3_antivirus/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.5.2"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.region,
+      ]
+    }
+  }
+}

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -1,0 +1,36 @@
+variable "alarm_sns_topic_arn" {
+  description = "ARN of the SNS topic for alarm notifications"
+  type        = string
+}
+
+variable "aws_subnet_ids" {
+  description = "List of Sirius private subnet Ids"
+}
+
+variable "data_store_bucket" {
+  description = "Data store bucket to scan for viruses"
+}
+
+variable "definition_bucket" {
+  description = "Bucket containing virus definitions"
+}
+
+variable "ecr_image_uri" {
+  description = "URI of ECR image to use for Lambda"
+}
+
+variable "enable_autoscan" {
+  description = "Whether to enable the automatic scan of newly uploaded objects"
+  type        = bool
+  default     = false
+}
+
+variable "environment_variables" {
+  description = "A map that defines environment variables for the Lambda Function."
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_task_role" {
+  description = "Execution role for Lambda"
+}

--- a/terraform/environment/region/modules/uploads_s3_bucket/outputs.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/outputs.tf
@@ -1,13 +1,3 @@
-output "id" {
-  description = "The name of the bucket."
-  value       = aws_s3_bucket.bucket.id
-}
-
-output "arn" {
-  description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
-  value       = aws_s3_bucket.bucket.arn
-}
-
 output "bucket" {
   description = "S3 uploads bucket."
   value       = aws_s3_bucket.bucket

--- a/terraform/environment/region/modules/uploads_s3_bucket/outputs.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/outputs.tf
@@ -7,3 +7,8 @@ output "arn" {
   description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
   value       = aws_s3_bucket.bucket.arn
 }
+
+output "bucket" {
+  description = "S3 uploads bucket."
+  value       = aws_s3_bucket.bucket
+}

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -1,0 +1,41 @@
+data "aws_ecr_repository" "s3_antivirus" {
+  name     = "s3-antivirus"
+  provider = aws.management
+}
+
+data "aws_ecr_image" "s3_antivirus" {
+  repository_name = data.aws_ecr_repository.s3_antivirus.name
+  image_tag       = "latest"
+  provider        = aws.management
+}
+
+data "aws_s3_bucket" "antivirus_definitions" {
+  bucket   = "virus-definitions-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}"
+  provider = aws.region
+}
+
+module "s3_antivirus" {
+  source              = "./modules/s3_antivirus"
+  alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
+  aws_subnet_ids      = data.aws_subnet.application.*.id
+  data_store_bucket   = module.uploads_s3_bucket.id
+  definition_bucket   = data.aws_s3_bucket.antivirus_definitions
+  ecr_image_uri       = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
+  enable_autoscan     = true
+  lambda_task_role    = var.iam_roles.s3_antivirus
+
+  environment_variables = {
+    ANTIVIRUS_DEFINITIONS_BUCKET = data.aws_s3_bucket.antivirus_definitions.id
+    ANTIVIRUS_TAG_KEY            = "virus-scan-status"
+    ANTIVIRUS_TAG_VALUE_PASS     = "ok"
+    ANTIVIRUS_TAG_VALUE_FAIL     = "infected"
+  }
+  providers = {
+    aws.region = aws.region
+  }
+}
+
+data "aws_sns_topic" "custom_cloudwatch_alarms" {
+  name     = "custom_cloudwatch_alarms"
+  provider = aws.region
+}

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -18,7 +18,7 @@ module "s3_antivirus" {
   source              = "./modules/s3_antivirus"
   alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
   aws_subnet_ids      = data.aws_subnet.application.*.id
-  data_store_bucket   = module.uploads_s3_bucket.id
+  data_store_bucket   = module.uploads_s3_bucket.bucket
   definition_bucket   = data.aws_s3_bucket.antivirus_definitions
   ecr_image_uri       = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
   enable_autoscan     = true

--- a/terraform/environment/region/terraform.tf
+++ b/terraform/environment/region/terraform.tf
@@ -8,6 +8,7 @@ terraform {
         aws.region,
         aws.global,
         aws.management_global,
+        aws.management,
       ]
     }
     pagerduty = {

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -2,14 +2,11 @@ locals {
   name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
 }
 
-variable "ecs_execution_role" {
-  type        = any
-  description = "The task execution role that the Amazon ECS container agent and the Docker daemon can assume."
-}
-
-variable "ecs_task_roles" {
+variable "iam_roles" {
   type = object({
-    app = any
+    ecs_execution_role = any
+    app_ecs_task_role  = any
+    s3_antivirus       = any
   })
   description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -8,11 +8,12 @@ module "allow_list" {
 }
 
 module "eu_west_1" {
-  source             = "./region"
-  count              = contains(local.environment.regions, "eu-west-1") ? 1 : 0
-  ecs_execution_role = module.global.iam_roles.ecs_execution_role
-  ecs_task_roles = {
-    app = module.global.iam_roles.app_ecs_task_role
+  source = "./region"
+  count  = contains(local.environment.regions, "eu-west-1") ? 1 : 0
+  iam_roles = {
+    ecs_execution_role = module.global.iam_roles.ecs_execution_role
+    app_ecs_task_role  = module.global.iam_roles.app_ecs_task_role
+    s3_antivirus       = module.global.iam_roles.s3_antivirus
   }
   application_log_retention_days  = local.environment.cloudwatch_log_groups.application_log_retention_days
   ecs_capacity_provider           = local.ecs_capacity_provider
@@ -38,15 +39,17 @@ module "eu_west_1" {
     aws.region            = aws.eu_west_1
     aws.global            = aws.global
     aws.management_global = aws.management_global
+    aws.management        = aws.management_eu_west_1
   }
 }
 
 module "eu_west_2" {
-  source             = "./region"
-  count              = contains(local.environment.regions, "eu-west-2") ? 1 : 0
-  ecs_execution_role = module.global.iam_roles.ecs_execution_role
-  ecs_task_roles = {
-    app = module.global.iam_roles.app_ecs_task_role
+  source = "./region"
+  count  = contains(local.environment.regions, "eu-west-2") ? 1 : 0
+  iam_roles = {
+    ecs_execution_role = module.global.iam_roles.ecs_execution_role
+    app_ecs_task_role  = module.global.iam_roles.app_ecs_task_role
+    s3_antivirus       = module.global.iam_roles.s3_antivirus
   }
   application_log_retention_days  = local.environment.cloudwatch_log_groups.application_log_retention_days
   ecs_capacity_provider           = local.ecs_capacity_provider
@@ -72,6 +75,7 @@ module "eu_west_2" {
     aws.region            = aws.eu_west_2
     aws.global            = aws.global
     aws.management_global = aws.management_global
+    aws.management        = aws.management_eu_west_2
   }
 }
 


### PR DESCRIPTION
# Purpose

Scan and tag objects uploaded as reduced fees evidence

Fixes MLPAB-1155

## Approach

- trigger antivirus scans when objects are uploaded (execute lambda on object put event)
- tag objects as `ok` or `infected`
- test with an EICAR test file

put an object with an EICAR signature (EICARs aren't committed to the repo)

```sh
aws-vault exec mlpa-dev -- aws s3api put-object --bucket uploads-opg-modernising-lpa-<environment>-<eu-west-1> --key test_signature/EICAR.pdf --body region/modules/s3_antivirus/EICAR.pdf --server-side-encryption AES256
```

## Learning
- https://en.wikipedia.org/wiki/EICAR_test_file
- the terraform aws provider `aws_cloudwatch_log_group` asks for a `kms_key_id`, but it wants a KMS key arn https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#kms_key_id
