### PR TITLE
MLPAB-1150 - limit dynamodb actions for ECS task role

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -135,7 +135,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: false
+      smoke: true
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -135,7 +135,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: true
+      smoke: false
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -216,6 +216,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
     sid = "${local.policy_region_prefix}Allow"
 
     actions = [
+      "dynamodb:BatchGetItem",
       "dynamodb:DeleteItem",
       "dynamodb:GetItem",
       "dynamodb:PutItem",

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -215,7 +215,14 @@ data "aws_iam_policy_document" "task_role_access_policy" {
   statement {
     sid = "${local.policy_region_prefix}Allow"
 
-    actions = ["dynamodb:*"]
+    actions = [
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:UpdateItem",
+    ]
 
     resources = [
       var.lpas_table.arn,


### PR DESCRIPTION
# Purpose

The ECS task role had permission to use all DynamoDB actions which is not necessary

Fixes MLPAB-1150

## Approach

- replace `dynamodb:*` with specific actions required for the app to function

I ran the full ui suite on the env and got a pass
https://github.com/ministryofjustice/opg-modernising-lpa/actions/runs/5615133082/job/15214857346

## Learning

- https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazondynamodb.html