### PR TITLE
MLPAB-1149: Update /check-your-lpa and /lpa-details-saved variable template logic 

### DIFF
--- a/app/internal/page/donor/check_your_lpa.go
+++ b/app/internal/page/donor/check_your_lpa.go
@@ -34,6 +34,12 @@ func CheckYourLpa(tmpl template.Template, donorStore DonorStore, shareCodeSender
 			data.Errors = data.Form.Validate()
 
 			if data.Errors.None() {
+				redirect := page.Paths.LpaDetailsSaved.Format(lpa.ID)
+
+				if !data.Completed {
+					redirect = redirect + "?firstCheck=1"
+				}
+
 				lpa.CheckedAndHappy = data.Form.CheckedAndHappy
 				lpa.Tasks.CheckYourLpa = actor.TaskCompleted
 
@@ -59,7 +65,7 @@ func CheckYourLpa(tmpl template.Template, donorStore DonorStore, shareCodeSender
 					}
 				}
 
-				return appData.Redirect(w, r, lpa, page.Paths.LpaDetailsSaved.Format(lpa.ID))
+				return appData.Redirect(w, r, lpa, redirect)
 			}
 		}
 

--- a/app/internal/page/donor/lpa_details_saved.go
+++ b/app/internal/page/donor/lpa_details_saved.go
@@ -1,0 +1,26 @@
+package donor
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-modernising-lpa/app/internal/page"
+	"github.com/ministryofjustice/opg-modernising-lpa/app/internal/validation"
+)
+
+type LpaDetailsSavedData struct {
+	App          page.AppData
+	Lpa          *page.Lpa
+	IsFirstCheck bool
+	Errors       validation.List
+}
+
+func LpaDetailsSaved(tmpl template.Template) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, lpa *page.Lpa) error {
+		return tmpl(w, LpaDetailsSavedData{
+			App:          appData,
+			IsFirstCheck: r.URL.Query().Has("firstCheck"),
+			Lpa:          lpa,
+		})
+	}
+}

--- a/app/internal/page/donor/lpa_details_saved_test.go
+++ b/app/internal/page/donor/lpa_details_saved_test.go
@@ -1,0 +1,56 @@
+package donor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-modernising-lpa/app/internal/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetLpaDetailsSaved(t *testing.T) {
+	testCases := map[string]bool{
+		"/?firstCheck=1": true,
+		"/":              false,
+	}
+
+	for url, expectedIsFirstCheck := range testCases {
+		t.Run(url, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest(http.MethodGet, url, nil)
+
+			template := newMockTemplate(t)
+			template.
+				On("Execute", w, LpaDetailsSavedData{
+					App:          testAppData,
+					IsFirstCheck: expectedIsFirstCheck,
+					Lpa:          &page.Lpa{},
+				}).
+				Return(nil)
+
+			err := LpaDetailsSaved(template.Execute)(testAppData, w, r, &page.Lpa{})
+			resp := w.Result()
+
+			assert.Nil(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+func TestGetLpaDetailsSavedOnTemplateError(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	template := newMockTemplate(t)
+	template.
+		On("Execute", mock.Anything, mock.Anything).
+		Return(expectedError)
+
+	err := LpaDetailsSaved(template.Execute)(testAppData, w, r, &page.Lpa{})
+	resp := w.Result()
+
+	assert.Equal(t, expectedError, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/app/internal/page/donor/register.go
+++ b/app/internal/page/donor/register.go
@@ -261,7 +261,7 @@ func Register(
 	handleWithLpa(page.Paths.CheckYourLpa, CanGoBack,
 		CheckYourLpa(tmpls.Get("check_your_lpa.gohtml"), donorStore, shareCodeSender, notifyClient))
 	handleWithLpa(page.Paths.LpaDetailsSaved, CanGoBack,
-		Guidance(tmpls.Get("lpa_details_saved.gohtml")))
+		LpaDetailsSaved(tmpls.Get("lpa_details_saved.gohtml")))
 
 	handleWithLpa(page.Paths.AboutPayment, None,
 		Guidance(tmpls.Get("about_payment.gohtml")))

--- a/cypress/e2e/donor/check-your-lpa.cy.js
+++ b/cypress/e2e/donor/check-your-lpa.cy.js
@@ -28,7 +28,7 @@ describe('Check the LPA', () => {
 
     describe('CP acting on paper', () => {
         describe('on first check', () => {
-            it('content is tailored for paper CPs and a details component is shown', () => {
+            it('content is tailored for paper CPs, a details component is shown and nav redirects to payment', () => {
                 cy.visit('/testing-start?redirect=/check-your-lpa&lpa.yourDetails=1&lpa.certificateProvider=1&lpa.attorneys=1&lpa.replacementAttorneys=2&lpa.chooseWhenCanBeUsed=1&lpa.restrictions=1&lpa.peopleToNotify=1');
 
                 cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy to show it to my certificate provider, Jessie Jones')
@@ -47,9 +47,29 @@ describe('Check the LPA', () => {
             })
         })
 
-        describe('on subsequent check after completing LPA', () => {
-            it('content is tailored for paper CPs and a warning component is shown', () => {
-                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.complete=1');
+        describe('on subsequent check when LPA has not been paid for', () => {
+            it('content is tailored for paper CPs, a warning component is shown and nav redirects to payment', () => {
+                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.yourDetails=1&lpa.certificateProvider=1&lpa.attorneys=1&lpa.replacementAttorneys=2&lpa.chooseWhenCanBeUsed=1&lpa.restrictions=1&lpa.peopleToNotify=1&lpa.checkAndSend=1');
+
+                cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy to show it to my certificate provider, Jessie Jones')
+                cy.get('.govuk-warning-text').contains('Once you select the confirm button, your certificate provider will be sent a text telling them you have changed your LPA.')
+
+                cy.get('#f-checked-and-happy').check()
+                cy.contains('button', 'Confirm').click();
+
+                cy.url().should('contain', '/lpa-details-saved');
+
+                cy.get('div[data-module=govuk-notification-banner]').contains('We’ve saved your changes and sent a text to your certificate provider, Jessie Jones, to tell them that your LPA is ready for review. You should show them your LPA.')
+
+                cy.contains('a', 'Continue').click();
+
+                cy.url().should('contain', '/about-payment');
+            })
+        })
+
+        describe('on subsequent check when LPA has been paid for', () => {
+            it('content is tailored for paper CPs, a warning component is shown and nav redirects to dashboard', () => {
+                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.paid=1');
 
                 cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy to show it to my certificate provider, Jessie Jones')
                 cy.get('.govuk-warning-text').contains('Once you select the confirm button, your certificate provider will be sent a text telling them you have changed your LPA.')
@@ -70,7 +90,7 @@ describe('Check the LPA', () => {
 
     describe('CP acting online', () => {
         describe('on first check', () => {
-            it('content is tailored for online CPs and a details component is shown', () => {
+            it('content is tailored for online CPs, a details component is shown and nav redirects to payment', () => {
                 cy.visit('/testing-start?redirect=/check-your-lpa&lpa.yourDetails=1&lpa.certificateProvider=1&lpa.attorneys=1&lpa.replacementAttorneys=2&lpa.chooseWhenCanBeUsed=1&lpa.restrictions=1&lpa.peopleToNotify=1&lpa.certificateProviderActOnline=1');
 
                 cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy for OPG to share it with my certificate provider, Jessie Jones')
@@ -89,9 +109,29 @@ describe('Check the LPA', () => {
             })
         })
 
-        describe('on subsequent check after completing LPA', () => {
-            it('content is tailored for online CPs and a warning component is shown', () => {
-                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.complete=1&lpa.certificateProviderActOnline=1');
+        describe('on subsequent check when LPA has not been paid for', () => {
+            it('content is tailored for online CPs, a warning component is shown and nav redirects to payment', () => {
+                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.yourDetails=1&lpa.certificateProvider=1&lpa.attorneys=1&lpa.replacementAttorneys=2&lpa.chooseWhenCanBeUsed=1&lpa.restrictions=1&lpa.peopleToNotify=1&lpa.checkAndSend=1&lpa.certificateProviderActOnline=1');
+
+                cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy for OPG to share it with my certificate provider, Jessie Jones')
+                cy.get('.govuk-warning-text').contains('Once you select the confirm button, your certificate provider will be sent a text telling them you have changed your LPA.')
+
+                cy.get('#f-checked-and-happy').check()
+                cy.contains('button', 'Confirm').click();
+
+                cy.url().should('contain', '/lpa-details-saved');
+
+                cy.get('div[data-module=govuk-notification-banner]').contains('We’ve saved your changes and sent a text to your certificate provider, Jessie Jones, to tell them that they should review your LPA online.')
+
+                cy.contains('a', 'Continue').click();
+
+                cy.url().should('contain', '/about-payment');
+            })
+        })
+
+        describe('on subsequent check when LPA has been paid for', () => {
+            it('content is tailored for online CPs, a warning component is shown and nav redirects to dashboard', () => {
+                cy.visit('/testing-start?redirect=/check-your-lpa&lpa.paid=1&lpa.certificateProviderActOnline=1');
 
                 cy.get('label[for=f-checked-and-happy]').contains('I’ve checked this LPA and I’m happy for OPG to share it with my certificate provider, Jessie Jones')
                 cy.get('.govuk-warning-text').contains('Once you select the confirm button, your certificate provider will be sent a text telling them you have changed your LPA.')

--- a/web/template/check_your_lpa.gohtml
+++ b/web/template/check_your_lpa.gohtml
@@ -40,7 +40,7 @@
           </div>
         </div>
 
-        {{ if .Lpa.Tasks.PayForLpa.IsCompleted }}
+        {{ if .Completed }}
           <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">

--- a/web/template/lpa_details_saved.gohtml
+++ b/web/template/lpa_details_saved.gohtml
@@ -16,17 +16,17 @@
                 </div>
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-body">
-                        {{ if .Lpa.Tasks.PayForLpa.IsCompleted }}
-                            {{ if eq "paper" .Lpa.CertificateProvider.CarryOutBy }}
-                                {{ trFormat .App "lpaDetailsSavedContentOnSubsequentSubmissionCPCarryingOutRolePaper" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
-                            {{ else }}
-                                {{ trFormat .App "lpaDetailsSavedContentOnSubsequentSubmissionCPCarryingOutRoleOnline" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
-                            {{ end }}
-                        {{ else }}
+                        {{ if .IsFirstCheck }}
                             {{ if eq "paper" .Lpa.CertificateProvider.CarryOutBy }}
                                 {{ trFormat .App "lpaDetailsSavedContentOnFirstSubmissionCPCarryingOutRolePaper" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
                             {{ else }}
                                 {{ trFormat .App "lpaDetailsSavedContentOnFirstSubmissionCPCarryingOutRoleOnline" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
+                            {{ end }}
+                        {{ else }}
+                            {{ if eq "paper" .Lpa.CertificateProvider.CarryOutBy }}
+                                {{ trFormat .App "lpaDetailsSavedContentOnSubsequentSubmissionCPCarryingOutRolePaper" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
+                            {{ else }}
+                                {{ trFormat .App "lpaDetailsSavedContentOnSubsequentSubmissionCPCarryingOutRoleOnline" "CertificateProviderFullName" .Lpa.CertificateProvider.FullName }}
                             {{ end }}
                         {{ end }}
                     </p>
@@ -36,7 +36,7 @@
             {{ if .Lpa.Tasks.PayForLpa.IsCompleted }}
                 <a href="{{ link .App (.App.Paths.Dashboard.String) }}" class="govuk-button">{{ tr .App "returnToDashboard" }}</a>
             {{ else }}
-                {{ if eq "paper" .Lpa.CertificateProvider.CarryOutBy }}
+                {{ if and (eq "paper" .Lpa.CertificateProvider.CarryOutBy) .IsFirstCheck }}
                     {{ trFormatHtml .App "weveSentATextToCPContent" "CertificateProviderFirstName" .Lpa.CertificateProvider.FirstNames }}
                 {{ end }}
 


### PR DESCRIPTION
# Purpose

Now we contact the CP on the donor checking their LPA we can no longer rely on the paid task being completed to vary the content for these two pages. I've relied on a query param here as it seemed the most straightforward way of dealing with the first time the donor hits `/lpa-details-saved` when the check and send task will always be complete.

Fixes MLPAB-1149
