### PR TITLE
MLPAB-1274 - allow batch operations to assume replication role

### DIFF
--- a/terraform/account/s3_replication_role.tf
+++ b/terraform/account/s3_replication_role.tf
@@ -1,10 +1,13 @@
-data "aws_iam_policy_document" "assume_role" {
+data "aws_iam_policy_document" "assume_replication_role" {
   statement {
     effect = "Allow"
 
     principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "batchoperations.s3.amazonaws.com"
+      ]
     }
 
     actions = ["sts:AssumeRole"]
@@ -14,6 +17,6 @@ data "aws_iam_policy_document" "assume_role" {
 
 resource "aws_iam_role" "replication" {
   name               = "reduced-fees-uploads-replication"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.assume_replication_role.json
   provider           = aws.global
 }


### PR DESCRIPTION
# Purpose

Let the shared role be used when performing batch replication operations

Fixes MLPAB-1274

## Approach

- add new principle

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html#batch-replication-scenario
