### PR TITLE
MLPAB-1303 pull additional allowed ingress CIDR ranges

### DIFF
--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -15,6 +15,11 @@ module "application_logs" {
   }
 }
 
+data "aws_ssm_parameter" "additional_allowed_ingress_cidrs" {
+  name     = "/modernising-lpa/additional-allowed-ingress-cidrs/${data.aws_default_tags.global.tags.account-name}"
+  provider = aws.management_global
+}
+
 module "app" {
   source                          = "./modules/app"
   ecs_cluster                     = aws_ecs_cluster.main.id

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -32,7 +32,7 @@ module "app" {
   app_allowed_api_arns            = var.app_allowed_api_arns
   app_service_repository_url      = var.app_service_repository_url
   app_service_container_version   = var.app_service_container_version
-  ingress_allow_list_cidr         = var.ingress_allow_list_cidr
+  ingress_allow_list_cidr         = concat(var.ingress_allow_list_cidr, split(",", data.aws_ssm_parameter.additional_allowed_ingress_cidrs.value))
   alb_deletion_protection_enabled = var.alb_deletion_protection_enabled
   lpas_table                      = var.lpas_table
   reduced_fees_table              = var.reduced_fees.table

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -16,7 +16,7 @@ module "application_logs" {
 }
 
 data "aws_ssm_parameter" "additional_allowed_ingress_cidrs" {
-  name     = "/modernising-lpa/additional-allowed-ingress-cidrs/${data.aws_default_tags.global.tags.account-name}"
+  name     = "/modernising-lpa/additional-allowed-ingress-cidrs/${data.aws_default_tags.current.tags.account-name}"
   provider = aws.management_global
 }
 


### PR DESCRIPTION
# Purpose

Pull additional CIDR ranges to allow those outside of MoJ sites to access an environment

Fixes MLPAB-1303

## Approach

- Pull from parameter store
- consolidate list into var for security group

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter
- https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html#what-is-a-parameter
- https://developer.hashicorp.com/terraform/language/functions/split