### PR TITLE
MLPAB-1296 - add a scheduler to invoke the lambda function

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -42,34 +42,22 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/pagerduty/pagerduty" {
-  version     = "2.15.2"
+  version     = "2.15.3"
   constraints = "~> 2.15.0"
   hashes = [
-    "h1:4U5n2m4WOStBigbe7lpWESzHjAwezD/Wx5zeP/21RVE=",
-    "h1:EiNqBvfp2ub4NKr43PfbMVLyl2C+lIGwCkFM109P3uM=",
-    "h1:G9w3QixZU5P8QYDLZPaJCDCf/NkVVtb91mNlf+xLjT8=",
-    "h1:HjuSvBhExTZcOM1mOmHvW/CfYZdfb8Gh6n5mFZsV7co=",
-    "h1:V2u32GcsLSrbwL8ydoBGpX8URHVIEm5Q5wtrcxdpWhU=",
-    "h1:VzIqvOvdsXZJKHKGtczHw1vEC6dOuUGFq0IXbpZeu+U=",
-    "h1:ZB3w9btlWm5HKYaOWwJOx7iPY+2Q0zIWWZxzjAf+ezg=",
-    "h1:aT1JaWQz6bsKNiqEk28D6EdyBpGN+THGWa4l65YThwc=",
-    "h1:kZUUmCVvNecHe5zVXPReVKKZ50+UlX/rxl+Ja4FFXVY=",
-    "h1:rrovBhemo96MxduXS9TDni7rhfG9BcTd7W8u9FSBi6A=",
-    "h1:w0z/fUZG1BfCIHA1e52c3DrNOLk239zVXkPc4Xfz930=",
-    "h1:wNRxJZuVIbbzdVuPVOGioB7ygKbNs6q7y358EwquTBA=",
-    "h1:xccKLR7kRP8Ihf8U4mP+L/2pAArp1GXaq18FGMJFkYg=",
-    "zh:1163620d4f6a43d81bf658642f2cc60f36737888ba0ccce28f550ed5b0391dc5",
-    "zh:1c1089e55780ebffba10a150aa7c0d0ad3fde019ee4778f07be2fe8f3f970d84",
-    "zh:8a9456c501f3d15fd21209f1f12a0824a403c3a269e39b6ddfc513281c4113c2",
-    "zh:a1dfc8da6dab6c5e2122a87da0930be2244355728dff3eb3649c36f39687ab6d",
-    "zh:ae4fd439c8d2fd74e6a11b75fba6ca884f2e1ef91f9ace4432ff78113389b1cd",
-    "zh:b8ad47bdf0057f388206f715114705fd860904425beb457f06bb760ea98c9259",
-    "zh:c1fa0ddf54acaa240b0cb822231894eed8047b5d22eec938d33afcd358fff2cc",
-    "zh:c72bd732056313e1bc247a42ebe319eaa13eacd69c3503d9d098070e3ad7ae79",
-    "zh:e31985cb27e48ac980232494fba2e26972b0a95dc73d4e3f4db0a5b13d92bc00",
-    "zh:e900d12a02c1cd7abdcc24b97d8997d19b92c072af0da82f920641264cadd95f",
-    "zh:f332930a6de94efc5b785b2c47aaae1ac4123cb7ffcdacc2904cda36eedaacc4",
-    "zh:ff5afde8723f0539d8dccb11bb4723907e31316cb1f038589371a44e6965cfe7",
-    "zh:ff96cad62002405de794e91654c962b75b17f5454ad66f5728adb01112776733",
+    "h1:Cnn9g8K8b8PeahsWCfRoo5PXZKLumIqy5gbsgzuymsA=",
+    "zh:05e1cf9bdc0fa554285c5b0cafe0c48faab57c7e1a34bebeb77a48fb6b162655",
+    "zh:09729485bf04d7645d932faf882da340a381aa5c272a8d3ea86be9aff18d64b6",
+    "zh:2e50ca854459f762ee3bfbef3df7f63cbc325d399a00b14fda218280af56772e",
+    "zh:2fb09e71d05835d6cb7132222ce1fa17ad844cfc25ea498b0c8279821575e874",
+    "zh:448461f5ec006df4b4b47a55c209b3fe584782c4f23e1fe08b2e3520248b5867",
+    "zh:5bd79f604d1818009a7376548d8368a94d1cf667dd160d456053c03307470b04",
+    "zh:a0760236b24f70637ddb00edb39275776208b50e4a54cd434b7eb3cd6a4f409f",
+    "zh:a5a54475359888966e7cb1c1f59311b2f6e610ef3c992ba8a8e8fc9790d077da",
+    "zh:be7d66fc33d519b836c117d90690491490a0da6e2cb9fba8d3dd14d48276ed1c",
+    "zh:bf48efb12411db0bc6f1e94e2a4bbeb8b5302daca6219005c3f77cb9ff5b2e0c",
+    "zh:cf24859e9a585862a22b5b531bad93110f46ca37ae2c7c0487399d82e93491e0",
+    "zh:cf67b6ac496883116138d24b4b262425c0f2a35da40d1c052bc8b46f5f8466bb",
+    "zh:e85abe3b2c08f86347960b4a708822facdc74ddc919dc06b6bdad5bea26aebae",
   ]
 }

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -1,6 +1,6 @@
 module "s3_create_batch_replication_jobs" {
   source      = "../lambda"
-  lambda_name = "create-s3-batch-replication-jobs-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  lambda_name = "create-s3-batch-replication-jobs-${data.aws_region.current.name}"
   description = "Function to create and run batch replication jobs"
   environment_variables = {
     ENVIRONMENT = data.aws_default_tags.current.tags.environment-name
@@ -78,7 +78,7 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
 }
 
 resource "aws_iam_role" "scheduler_role" {
-  name               = "s3-create-batch-replication-jobs-secheduler--${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  name               = "s3-create-batch-replication-jobs-secheduler-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
   assume_role_policy = data.aws_iam_policy_document.scheduler_invoke_lambda.json
   provider           = aws.region
 }

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -60,15 +60,14 @@ data "aws_iam_policy_document" "s3_create_batch_replication_jobs" {
 }
 
 resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
-  count = var.s3_replication.enable_s3_batch_job_replication_scheduler ? 1 : 0
-  name  = "invoke-lambda-every-15-minutes-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-  # group_name = "s3-create-batch-replication-jobs"
+  name = "invoke-lambda-every-15-minutes-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
 
   flexible_time_window {
     mode = "OFF"
   }
 
   schedule_expression = "rate(15 minutes)"
+  state               = var.s3_replication.enable_s3_batch_job_replication_scheduler ? "ENABLED" : "DISABLED"
 
   target {
     arn      = module.s3_create_batch_replication_jobs.lambda.arn

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -79,8 +79,29 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
 
 resource "aws_iam_role" "scheduler_role" {
   name               = "scheduler-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-  assume_role_policy = data.aws_iam_policy_document.scheduler_invoke_lambda.json
+  assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role.json
   provider           = aws.region
+}
+
+data "aws_iam_policy_document" "scheduler_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_iam_role_policy" "scheduler_invoke_lambda" {
+  name     = "scheduler-invoke-lambda-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  policy   = data.aws_iam_policy_document.scheduler_invoke_lambda.json
+  role     = aws_iam_role.scheduler_role.id
+  provider = aws.region
 }
 
 data "aws_iam_policy_document" "scheduler_invoke_lambda" {

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -78,7 +78,7 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
 }
 
 resource "aws_iam_role" "scheduler_role" {
-  name               = "s3-create-batch-replication-jobs-secheduler-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  name               = "scheduler-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
   assume_role_policy = data.aws_iam_policy_document.scheduler_invoke_lambda.json
   provider           = aws.region
 }

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -60,9 +60,9 @@ data "aws_iam_policy_document" "s3_create_batch_replication_jobs" {
 }
 
 resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
-  count      = var.s3_replication.enable_s3_batch_job_replication_scheduler ? 1 : 0
-  name       = "invoke-lambda-every-15-minutes-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-  group_name = "s3-create-batch-replication-jobs"
+  count = var.s3_replication.enable_s3_batch_job_replication_scheduler ? 1 : 0
+  name  = "invoke-lambda-every-15-minutes-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  # group_name = "s3-create-batch-replication-jobs"
 
   flexible_time_window {
     mode = "OFF"
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "scheduler_assume_role" {
     effect = "Allow"
     principals {
       type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      identifiers = ["scheduler.amazonaws.com"]
     }
   }
   provider = aws.region

--- a/terraform/environment/region/modules/uploads_s3_bucket/variables.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/variables.tf
@@ -11,23 +11,25 @@ variable "force_destroy" {
 
 variable "s3_replication" {
   type = object({
-    enabled                        = bool
-    destination_bucket_arn         = string
-    destination_encryption_key_arn = string
-    destination_account_id         = string
-    lambda_function_image_ecr_arn  = string
-    lambda_function_image_ecr_url  = string
-    lambda_function_image_tag      = string
+    enabled                                   = bool
+    destination_bucket_arn                    = string
+    destination_encryption_key_arn            = string
+    destination_account_id                    = string
+    lambda_function_image_ecr_arn             = string
+    lambda_function_image_ecr_url             = string
+    lambda_function_image_tag                 = string
+    enable_s3_batch_job_replication_scheduler = bool
   })
   description = <<EOT
     s3_replication = {
-      enabled                        = "Enable S3 object replication"
-      destination_bucket_arn         = "ARN of the destination bucket"
-      destination_encryption_key_arn = "ARN of the destination encryption key"
-      destination_account_id         = "Account ID of the destination bucket"
-      lambda_function_image_ecr_arn  = "ARN of the lambda function to be invoked on a schedule to create replication jobs"
-      lambda_function_image_ecr_url  = "URL of the lambda function to be invoked on a schedule to create replication jobs"
-      lambda_function_image_tag      = "Tag of the lambda function to be invoked on a schedule to create replication jobs"
+      enabled                                   = "Enable S3 object replication"
+      destination_bucket_arn                    = "ARN of the destination bucket"
+      destination_encryption_key_arn            = "ARN of the destination encryption key"
+      destination_account_id                    = "Account ID of the destination bucket"
+      lambda_function_image_ecr_arn             = "ARN of the lambda function to be invoked on a schedule to create replication jobs"
+      lambda_function_image_ecr_url             = "URL of the lambda function to be invoked on a schedule to create replication jobs"
+      lambda_function_image_tag                 = "Tag of the lambda function to be invoked on a schedule to create replication jobs"
+      enable_s3_batch_job_replication_scheduler = "Enable scheduler to create replication jobs"
     }
     EOT
 }

--- a/terraform/environment/region/uploads_s3_bucket.tf
+++ b/terraform/environment/region/uploads_s3_bucket.tf
@@ -20,13 +20,14 @@ module "uploads_s3_bucket" {
   bucket_name   = "uploads-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
   force_destroy = data.aws_default_tags.current.tags.environment-name != "production" ? true : false
   s3_replication = {
-    enabled                        = var.reduced_fees.s3_object_replication_enabled
-    destination_bucket_arn         = data.aws_ssm_parameter.replication_bucket_arn.value
-    destination_encryption_key_arn = data.aws_ssm_parameter.replication_encryption_key.value
-    destination_account_id         = var.reduced_fees.destination_account_id
-    lambda_function_image_ecr_arn  = data.aws_ecr_repository.s3_create_batch_replication_jobs.arn
-    lambda_function_image_ecr_url  = data.aws_ecr_repository.s3_create_batch_replication_jobs.repository_url
-    lambda_function_image_tag      = var.app_service_container_version
+    enabled                                   = var.reduced_fees.s3_object_replication_enabled
+    destination_bucket_arn                    = data.aws_ssm_parameter.replication_bucket_arn.value
+    destination_encryption_key_arn            = data.aws_ssm_parameter.replication_encryption_key.value
+    destination_account_id                    = var.reduced_fees.destination_account_id
+    lambda_function_image_ecr_arn             = data.aws_ecr_repository.s3_create_batch_replication_jobs.arn
+    lambda_function_image_ecr_url             = data.aws_ecr_repository.s3_create_batch_replication_jobs.repository_url
+    lambda_function_image_tag                 = var.app_service_container_version
+    enable_s3_batch_job_replication_scheduler = var.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   providers = {
     aws.region = aws.region

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -89,5 +89,6 @@ variable "reduced_fees" {
       arn  = string
       name = string
     })
+    enable_s3_batch_job_replication_scheduler = bool
   })
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -39,6 +39,7 @@ module "eu_west_1" {
       arn  = module.reduced_fees[0].event_bus.arn
       name = module.reduced_fees[0].event_bus.name
     }
+    enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns
@@ -85,6 +86,7 @@ module "eu_west_2" {
       arn  = module.reduced_fees[0].event_bus.arn
       name = module.reduced_fees[0].event_bus.name
     }
+    enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -56,7 +56,7 @@
         "s3_object_replication_enabled": true,
         "target_environment": "dev",
         "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": true
+        "enable_s3_batch_job_replication_scheduler": false
       }
     },
     "testevents": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -55,7 +55,8 @@
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "s3_object_replication_enabled": true,
         "target_environment": "dev",
-        "destination_account_id": "288342028542"
+        "destination_account_id": "288342028542",
+        "enable_s3_batch_job_replication_scheduler": false
       }
     },
     "testevents": {
@@ -113,7 +114,8 @@
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "s3_object_replication_enabled": true,
         "target_environment": "dev",
-        "destination_account_id": "288342028542"
+        "destination_account_id": "288342028542",
+        "enable_s3_batch_job_replication_scheduler": true
       }
     },
     "ur": {
@@ -171,7 +173,8 @@
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "s3_object_replication_enabled": true,
         "target_environment": "dev",
-        "destination_account_id": "288342028542"
+        "destination_account_id": "288342028542",
+        "enable_s3_batch_job_replication_scheduler": false
       }
     },
     "preproduction": {
@@ -229,7 +232,8 @@
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "s3_object_replication_enabled": false,
         "target_environment": "dev",
-        "destination_account_id": "288342028542"
+        "destination_account_id": "288342028542",
+        "enable_s3_batch_job_replication_scheduler": false
       }
     },
     "production": {
@@ -287,7 +291,8 @@
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "s3_object_replication_enabled": false,
         "target_environment": "dev",
-        "destination_account_id": "288342028542"
+        "destination_account_id": "288342028542",
+        "enable_s3_batch_job_replication_scheduler": false
       }
     }
   }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -56,7 +56,7 @@
         "s3_object_replication_enabled": true,
         "target_environment": "dev",
         "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
+        "enable_s3_batch_job_replication_scheduler": true
       }
     },
     "testevents": {

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -72,11 +72,12 @@ variable "environments" {
       cloudwatch_application_insights_enabled = bool
       pagerduty_service_name                  = string
       reduced_fees = object({
-        enabled                       = bool
-        target_event_bus_arn          = string
-        s3_object_replication_enabled = bool
-        target_environment            = string
-        destination_account_id        = string
+        enabled                                   = bool
+        target_event_bus_arn                      = string
+        s3_object_replication_enabled             = bool
+        target_environment                        = string
+        destination_account_id                    = string
+        enable_s3_batch_job_replication_scheduler = bool
       })
     })
   )


### PR DESCRIPTION
# Purpose

Create batch replication jobs every 15 minutes when schedulers are enabled on an environment

Fixes MLPAB-1296

## Approach

- create an Eventbridge scheduler
- Create a role for the scheduler to invoke the create batch job lambda function
- only create and start the scheduler if enabled for the environment

## Learning

- https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html
- https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html#managing-targets-templated-lambda
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule