### PR TITLE
MLPAB-1312 - create a key for reduced fees uploads buckets

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.12.0"
-  constraints = "5.12.0"
+  constraints = ">= 5.5.0, 5.12.0"
   hashes = [
     "h1:3Gchmc4oyFvWh3B4tEOQN5UOCd0bfp0P4fEgdpatmlo=",
     "h1:4GV65EQN0ao20xQ8O/fqHWwl4Xv2sLayOYVzTUKH49Q=",
@@ -19,5 +19,20 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:pxx71bfqKRTjUvLqcSEpgpCV4f2uvNHca4X0OOSu+mU=",
     "h1:uw1ZfMHufDCC1ftzczNHofmRIB+E+8aWvyrLsdclVtA=",
     "h1:y7hzOYM6A7/eaRHfFVhk/gWh0/Bl7Kj/6/UB3DE6u9M=",
+    "zh:0953565eb67ece49556dc9046c77322dc6c76e0ae6fa0c9fd6710b6afa2588c9",
+    "zh:43676f3592c127a971719cc37b9199967376fb05d445b356f1545609e2b84bf8",
+    "zh:46422ab8044b35e90f422ffabc17fa043ec8e4a33e3df2f8b305d63a950c0edb",
+    "zh:4d34f024a82d31d10b5a9498d26fca71e3e35c543dfc5185c94c3205bc4dba22",
+    "zh:51be0eeb882f041fc2679bd621e64cd775d013ae003055cea013c9d630c15dfb",
+    "zh:7ca9252befa7271899febde25b679a73f90dbdb700cbbfec07d29389a3937131",
+    "zh:8325b2152be0534a718e497a3273cf6c42880e78f290dc35024feef2e0af8e97",
+    "zh:98f0c4d4c190cf4897cb9075a538f42f2998566e9f2d15755901fbb4862f8b32",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a71e0bc6754bb3924b31727d80f05b04fa65247c009ffdfd2a715a01d95b373d",
+    "zh:a82ae67ce3d4c7aaae761a592275b8cac5e9965a30b2dba951c1d965b3121006",
+    "zh:c5510eca023cec89557a8244648bf8ad9a0cd3189b6abf6dcceba30e3b2e8c6d",
+    "zh:cd11fe9c83793e838b6f90a55840fc45e7c106b358a68f0a88db09a29a321c9a",
+    "zh:e451ad353f219a2922b92e786a93c31658168b896317be127798cddfa9a99363",
+    "zh:e4b70a70e925b9ccb7d44e17fd8e7b89aa744a965f298f8bb2480a5c96f3c4f0",
   ]
 }

--- a/terraform/account/reduced_fees_uploads_s3_kms.tf
+++ b/terraform/account/reduced_fees_uploads_s3_kms.tf
@@ -11,7 +11,7 @@ resource "aws_kms_key" "reduced_fees_uploads_s3" {
 }
 
 resource "aws_kms_replica_key" "reduced_fees_uploads_s3_replica" {
-  description             = "${local.default_tags.application} reduced_fees_uploads_s3 Multi-Region replica key"
+  description             = "${local.default_tags.application} reduced fees uploads s3 Multi-Region replica key"
   deletion_window_in_days = 7
   primary_key_arn         = aws_kms_key.reduced_fees_uploads_s3.arn
   provider                = aws.eu_west_2

--- a/terraform/account/reduced_fees_uploads_s3_kms.tf
+++ b/terraform/account/reduced_fees_uploads_s3_kms.tf
@@ -1,0 +1,199 @@
+resource "aws_kms_key" "reduced_fees_uploads_s3" {
+  description             = "${local.default_tags.application} reduced_fees_uploads_s3 encryption key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.reduced_fees_uploads_s3_kms_merged.json : data.aws_iam_policy_document.reduced_fees_uploads_s3_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_replica_key" "reduced_fees_uploads_s3_replica" {
+  description             = "${local.default_tags.application} reduced_fees_uploads_s3 Multi-Region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.reduced_fees_uploads_s3.arn
+  provider                = aws.eu_west_2
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "reduced_fees_uploads_s3_alias_eu_west_1" {
+  name          = "alias/${local.default_tags.application}_reduced_fees_uploads_s3_encryption"
+  target_key_id = aws_kms_key.reduced_fees_uploads_s3.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "reduced_fees_uploads_s3_alias_eu_west_2" {
+  name          = "alias/${local.default_tags.application}_reduced_fees_uploads_s3_encryption"
+  target_key_id = aws_kms_replica_key.reduced_fees_uploads_s3_replica.key_id
+  provider      = aws.eu_west_2
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "reduced_fees_uploads_s3_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.reduced_fees_uploads_s3_kms.json,
+    data.aws_iam_policy_document.reduced_fees_uploads_s3_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "reduced_fees_uploads_s3_kms" {
+  provider = aws.global
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/${local.account.account_name}-app-task-role",
+        aws_iam_role.aws_backup_role.arn,
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+
+      values = [
+        "reduced_fees_uploads_s3.*.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:List*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "reduced_fees_uploads_s3_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid    = "Dev Account Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Purpose

Use customer managed encryption for objects uploaded to the reduced fees uploads bucket

Fixes MLPAB-1312

## Approach

- reuse the pattern for other kms keys
- add the default policy for adding

## Learning

- https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam