### PR TITLE
MLPAB-1313 - add default policy 

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -135,7 +135,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: false
+      smoke: true
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -135,7 +135,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: true
+      smoke: false
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/terraform/account/cloudwatch_kms.tf
+++ b/terraform/account/cloudwatch_kms.tf
@@ -39,6 +39,22 @@ data "aws_iam_policy_document" "cloudwatch_kms_merged" {
 
 data "aws_iam_policy_document" "cloudwatch_kms" {
   provider = aws.global
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
   statement {
     sid    = "Allow Key to be used for Encryption"
     effect = "Allow"

--- a/terraform/account/dynamodb_kms.tf
+++ b/terraform/account/dynamodb_kms.tf
@@ -14,6 +14,7 @@ resource "aws_kms_replica_key" "dynamodb_replica" {
   description             = "${local.default_tags.application} dynamodb Multi-Region replica key"
   deletion_window_in_days = 7
   primary_key_arn         = aws_kms_key.dynamodb.arn
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.dynamodb_kms_merged.json : data.aws_iam_policy_document.dynamodb_kms.json
   provider                = aws.eu_west_2
   lifecycle {
     prevent_destroy = true
@@ -44,6 +45,22 @@ data "aws_iam_policy_document" "dynamodb_kms_merged" {
 
 data "aws_iam_policy_document" "dynamodb_kms" {
   provider = aws.global
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
   statement {
     sid    = "Allow Key to be used for Encryption"
     effect = "Allow"


### PR DESCRIPTION
# Purpose

Ensure the AWS account can manage the key and it's IAM policies

Fixes MLPAB-1313

## Approach

- add default policy to keys
- ensure policy is appended to replica keys too

## Learning

- https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam