### PR TITLE
MLPAB-1352 - Fix notifications for path to live failures

### DIFF
--- a/.github/workflows/on_path_to_live_failure.yml
+++ b/.github/workflows/on_path_to_live_failure.yml
@@ -2,7 +2,7 @@ name: "[Job] Slack Notification of Path to Live Workflow Failure"
 
 on:
   workflow_run:
-    workflows: [Path to Live]
+    workflows: ["[Workflow] Path To Live"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
# Purpose

Path to live notifications when pipeline fails stopped working when the name of the path to live workflow changed.

Fixes MLPAB-1352

## Approach

- use correct name for path to live workflow