### PR TITLE
MLPAB-1367 - Create a dns firewall in the account

### DIFF
--- a/terraform/account/region/dns_firewall.tf
+++ b/terraform/account/region/dns_firewall.tf
@@ -1,0 +1,8 @@
+module "dns_firewall" {
+  source                             = "./modules/dns_firewall"
+  vpc_id                             = module.network.vpc.id
+  cloudwatch_log_group_kms_key_alias = var.cloudwatch_log_group_kms_key_alias
+  providers = {
+    aws.region = aws.region
+  }
+}

--- a/terraform/account/region/modules/dns_firewall/data_sources.tf
+++ b/terraform/account/region/modules/dns_firewall/data_sources.tf
@@ -1,0 +1,8 @@
+data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
+  name     = var.cloudwatch_log_group_kms_key_alias
+  provider = aws.region
+}
+
+data "aws_region" "current" {
+  provider = aws.region
+}

--- a/terraform/account/region/modules/dns_firewall/main.tf
+++ b/terraform/account/region/modules/dns_firewall/main.tf
@@ -1,0 +1,110 @@
+resource "aws_cloudwatch_log_group" "aws_route53_resolver_query_log" {
+  name              = "route53-resolver-query-log"
+  retention_in_days = 400
+  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
+  tags = {
+    "Name" = "route53-resolver-query-log"
+  }
+  provider = aws.region
+}
+
+resource "aws_route53_resolver_query_log_config" "egress" {
+  name            = "egress"
+  destination_arn = aws_cloudwatch_log_group.aws_route53_resolver_query_log.arn
+  provider        = aws.region
+}
+
+resource "aws_route53_resolver_query_log_config_association" "egress" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.egress.id
+  resource_id                  = var.vpc_id
+  provider                     = aws.region
+}
+
+locals {
+  service_id = [
+    "logs",
+    "ecr",
+    "dynamodb",
+    "kms",
+    "secretsmanager",
+    "ecr.api",
+  ]
+}
+
+data "aws_service" "services" {
+  for_each   = toset(local.service_id)
+  region     = data.aws_region.current.name
+  service_id = each.value
+  provider   = aws.region
+}
+
+locals {
+  aws_service_dns_name = [for service in data.aws_service.services : "${service.dns_name}."]
+  interpolated_dns = [
+    "prod-${data.aws_region.current.name}-starport-layer-bucket.s3.${data.aws_region.current.name}.amazonaws.com.",
+    "public-keys.auth.elb.${data.aws_region.current.name}.amazonaws.com.",
+    "311462405659.dkr.ecr.${data.aws_region.current.name}.amazonaws.com.",
+  ]
+}
+resource "aws_route53_resolver_firewall_domain_list" "egress_allow" {
+  name = "egress_allowed"
+  domains = concat(
+    local.interpolated_dns,
+    local.aws_service_dns_name,
+    # local.account.dns_firewall.domains_allowed
+  )
+  provider = aws.region
+}
+
+resource "aws_route53_resolver_firewall_domain_list" "egress_block" {
+  name     = "egress_blocked"
+  domains  = ["*."]
+  provider = aws.region
+}
+
+resource "aws_route53_resolver_firewall_rule_group" "egress" {
+  name     = "egress"
+  provider = aws.region
+}
+
+resource "aws_route53_resolver_firewall_rule" "egress_allow" {
+  name                    = "egress_allowed"
+  action                  = "ALLOW"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.egress_allow.id
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.egress.id
+  priority                = 200
+  provider                = aws.region
+}
+
+resource "aws_route53_resolver_firewall_rule" "egress_block" {
+  name   = "egress_blocked"
+  action = "ALERT"
+  # action                  = "BLOCK"
+  # block_response          = "NODATA"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.egress_block.id
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.egress.id
+  priority                = 300
+  provider                = aws.region
+}
+
+resource "aws_route53_resolver_firewall_rule_group_association" "egress" {
+  name                   = "egress"
+  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.egress.id
+  priority               = 500
+  vpc_id                 = var.vpc_id
+  provider               = aws.region
+}
+
+
+resource "aws_cloudwatch_query_definition" "dns_firewall_statistics" {
+  name = "DNS Firewall Queries/DNS Firewall Statistics"
+
+  log_group_names = [aws_cloudwatch_log_group.aws_route53_resolver_query_log.name]
+
+  query_string = <<EOF
+fields @timestamp, query_name, firewall_rule_action
+| sort @timestamp desc
+| stats count() as frequency by query_name, firewall_rule_action
+EOF
+  provider     = aws.region
+}

--- a/terraform/account/region/modules/dns_firewall/terraform.tf
+++ b/terraform/account/region/modules/dns_firewall/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.5.2"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.region,
+      ]
+    }
+  }
+}

--- a/terraform/account/region/modules/dns_firewall/variables.tf
+++ b/terraform/account/region/modules/dns_firewall/variables.tf
@@ -1,0 +1,7 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "cloudwatch_log_group_kms_key_alias" {
+  type = string
+}


### PR DESCRIPTION
# Purpose

Reduce egress from app to permitted targets only

Fixes MLPAB-1367

## Approach

- create an account level DNS firewall
- configure some permitted entries 
- block all else
- set to monitor mode (does not block requests)

A further PR will associate environment resources with the firewall

## Learning

- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall.html