### PR TITLE
MLPAB-1377 - Setup go while specifying version

### DIFF
--- a/.github/workflows/analysis-codeql.yml
+++ b/.github/workflows/analysis-codeql.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '^1.20'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
# Purpose

The detected version of Go is lower than the version specified in go.mod (in the code scanning job)

Fixes MLPAB-1377

## Approach

- Setup go and specify version

## Learning

- https://github.com/actions/setup-go#basic