### PR TITLE
MLPAB-1370 - create endpoints for logs, ssm, secrets manager and ecr

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -136,7 +136,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: false
+      smoke: true
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -136,7 +136,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: true
+      smoke: false
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -31,6 +31,11 @@ resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
 locals {
   interface_endpoint = toset([
     "ec2",
+    "ecr.api",
+    "ecr.dkr",
+    "logs",
+    "secretsmanager",
+    "ssm",
   ])
 }
 


### PR DESCRIPTION
# Purpose

Direct requests to AWS services via a VPC endpoint to reduce the egress vector through the internet gateway

Fixes MLPAB-1370

## Approach

- Create interface endpoints for services we use

## Learning

- https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html