### PR TITLE
Allow Sirius accounts to send events

### DIFF
--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -2,6 +2,7 @@ module "event_bus" {
   source               = "./modules/event_bus"
   target_event_bus_arn = var.target_event_bus_arn
   iam_role             = var.iam_roles.cross_account_put
+  receive_account_id   = var.receive_account_id
   providers = {
     aws.region = aws.region
   }

--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -2,7 +2,7 @@ module "event_bus" {
   source               = "./modules/event_bus"
   target_event_bus_arn = var.target_event_bus_arn
   iam_role             = var.iam_roles.cross_account_put
-  receive_account_id   = var.receive_account_id
+  receive_account_ids  = var.receive_account_ids
   providers = {
     aws.region = aws.region
   }

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -68,13 +68,13 @@ data "aws_iam_policy_document" "main" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.receive_account_id]
+      identifiers = var.receive_account_ids
     }
   }
 }
 
 resource "aws_cloudwatch_event_bus_policy" "main" {
-  count          = var.receive_account_id == "" ? 0 : 1
+  count          = length(var.receive_account_ids) > 0 ? 1 : 0
   event_bus_name = aws_cloudwatch_event_bus.main.name
   policy         = data.aws_iam_policy_document.main.json
   provider       = aws.region

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_event_target" "cross_account_put" {
 }
 
 # Allow other accounts to send messages
-data "aws_iam_policy_document" "main" {
+data "aws_iam_policy_document" "cross_account_receive" {
   statement {
     sid    = "CrossAccountAccess"
     effect = "Allow"
@@ -73,10 +73,10 @@ data "aws_iam_policy_document" "main" {
   }
 }
 
-resource "aws_cloudwatch_event_bus_policy" "main" {
+resource "aws_cloudwatch_event_bus_policy" "cross_account_receive" {
   count          = length(var.receive_account_ids) > 0 ? 1 : 0
   event_bus_name = aws_cloudwatch_event_bus.main.name
-  policy         = data.aws_iam_policy_document.main.json
+  policy         = data.aws_iam_policy_document.cross_account_receive.json
   provider       = aws.region
 }
 

--- a/terraform/environment/region/modules/event_bus/variables.tf
+++ b/terraform/environment/region/modules/event_bus/variables.tf
@@ -8,8 +8,8 @@ variable "iam_role" {
   description = "IAM role to allow cross account put to event bus"
 }
 
-variable "receive_account_id" {
-  type        = string
-  description = "ID of account to receive messages from"
-  default     = ""
+variable "receive_account_ids" {
+  type        = list(string)
+  description = "IDs of accounts to receive messages from"
+  default     = []
 }

--- a/terraform/environment/region/modules/event_bus/variables.tf
+++ b/terraform/environment/region/modules/event_bus/variables.tf
@@ -7,3 +7,9 @@ variable "iam_role" {
   type        = any
   description = "IAM role to allow cross account put to event bus"
 }
+
+variable "receive_account_id" {
+  type        = string
+  description = "ID of account to receive messages from"
+  default     = ""
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -90,3 +90,9 @@ variable "target_event_bus_arn" {
   type        = string
   description = "ARN of the event bus to forward events to"
 }
+
+variable "receive_account_id" {
+  type        = string
+  description = "ID of account to receive messages from"
+  default     = ""
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -91,8 +91,8 @@ variable "target_event_bus_arn" {
   description = "ARN of the event bus to forward events to"
 }
 
-variable "receive_account_id" {
-  type        = string
-  description = "ID of account to receive messages from"
-  default     = ""
+variable "receive_account_ids" {
+  type        = list(string)
+  description = "IDs of accounts to receive messages from"
+  default     = []
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -35,6 +35,7 @@ module "eu_west_1" {
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
+  receive_account_id     = local.environment.event_bus.receive_account_id
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled
@@ -76,6 +77,7 @@ module "eu_west_2" {
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
+  receive_account_id     = local.environment.event_bus.receive_account_id
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -35,7 +35,7 @@ module "eu_west_1" {
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
-  receive_account_id     = local.environment.event_bus.receive_account_id
+  receive_account_ids    = local.environment.event_bus.receive_account_ids
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled
@@ -77,7 +77,7 @@ module "eu_west_2" {
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
   target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
-  receive_account_id     = local.environment.event_bus.receive_account_id
+  receive_account_ids    = local.environment.event_bus.receive_account_ids
   app_env_vars           = local.environment.app.env
   app_allowed_api_arns   = local.environment.app.allowed_api_arns
   public_access_enabled  = var.public_access_enabled

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -52,7 +52,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_id": "288342028542"
+        "receive_account_ids": ["288342028542"]
       },
       "reduced_fees": {
         "enabled": true,
@@ -114,7 +114,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_id": "288342028542"
+        "receive_account_ids": ["288342028542"]
       },
       "reduced_fees": {
         "enabled": true,
@@ -176,7 +176,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
-        "receive_account_id": "288342028542"
+        "receive_account_ids": ["288342028542"]
       },
       "reduced_fees": {
         "enabled": true,
@@ -238,7 +238,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_id": "288342028542"
+        "receive_account_ids": ["288342028542"]
       },
       "reduced_fees": {
         "enabled": true,
@@ -300,7 +300,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_id": ""
+        "receive_account_ids": []
       },
       "reduced_fees": {
         "enabled": true,
@@ -362,7 +362,7 @@
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_id": ""
+        "receive_account_ids": []
       },
       "reduced_fees": {
         "enabled": true,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -51,7 +51,8 @@
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+        "receive_account_id": "288342028542"
       },
       "reduced_fees": {
         "enabled": true,
@@ -112,7 +113,8 @@
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+        "receive_account_id": "288342028542"
       },
       "reduced_fees": {
         "enabled": true,
@@ -173,7 +175,8 @@
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
+        "receive_account_id": "288342028542"
       },
       "reduced_fees": {
         "enabled": true,
@@ -234,7 +237,8 @@
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+        "receive_account_id": "288342028542"
       },
       "reduced_fees": {
         "enabled": true,
@@ -295,7 +299,8 @@
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+        "receive_account_id": ""
       },
       "reduced_fees": {
         "enabled": true,
@@ -356,7 +361,8 @@
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
       "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
+        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+        "receive_account_id": ""
       },
       "reduced_fees": {
         "enabled": true,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -73,7 +73,7 @@ variable "environments" {
       pagerduty_service_name                  = string
       event_bus = object({
         target_event_bus_arn = string
-        receive_account_id   = string
+        receive_account_ids  = list(string)
       })
       reduced_fees = object({
         enabled                                   = bool

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -73,6 +73,7 @@ variable "environments" {
       pagerduty_service_name                  = string
       event_bus = object({
         target_event_bus_arn = string
+        receive_account_id   = string
       })
       reduced_fees = object({
         enabled                                   = bool


### PR DESCRIPTION
# Purpose

Add permissions to event bus to allow specified account to send events to the bus.

For VEGA-2090 #minor

## Approach

Re-used permissions set from Sirius. I added an environment-level config parameter called `receive_account_id`, if it's an empty string then the permission isn't created.

## Learning

VS Code was much more helpful with this than I expected.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
* [ ] Changes to Github Actions jobs have been checked for all workflows
