### PR TITLE
MLPAB-1481 - Create endpoint for eventbridge

### DIFF
--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -33,6 +33,7 @@ locals {
     "ec2",
     "ecr.api",
     "ecr.dkr",
+    "events",
     "logs",
     "secretsmanager",
     "ssm",
@@ -88,6 +89,7 @@ resource "aws_vpc_endpoint" "s3" {
   route_table_ids   = tolist(data.aws_route_tables.public.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.s3_vpc_endpoint.json
+  tags              = { Name = "s3-private-${data.aws_region.current.name}" }
 }
 
 data "aws_iam_policy_document" "s3_vpc_endpoint" {
@@ -110,6 +112,7 @@ resource "aws_vpc_endpoint" "dynamodb" {
   route_table_ids   = tolist(data.aws_route_tables.public.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.dynamodb_vpc_endpoint.json
+  tags              = { Name = "dynamodb-private-${data.aws_region.current.name}" }
 }
 
 data "aws_iam_policy_document" "dynamodb_vpc_endpoint" {


### PR DESCRIPTION
# Purpose

Direct requests to AWS services via a VPC endpoint to reduce the egress vector through the internet gateway

Fixes MLPAB-1481

## Approach

- create events endpoint 
- name S3 and DynamoDB gateway endpoints