### PR TITLE
MLPAB-922 Add attorney progress page

### DIFF
--- a/cypress/e2e/attorney/progress.cy.js
+++ b/cypress/e2e/attorney/progress.cy.js
@@ -1,0 +1,28 @@
+describe('Progress', () => {
+    it('when nothing completed', () => {
+        cy.visit('/fixtures/attorney?redirect=/progress');
+        cy.checkA11yApp();
+
+        cy.contains('h1', 'Sam Smith’s property and affairs LPA');
+        cy.contains('li', 'You’ve signed the LPA In progress');
+        cy.contains('li', 'All attorneys have signed the LPA Not started');
+    });
+
+    it('when signed', () => {
+        cy.visit('/fixtures/attorney?redirect=/progress&progress=signedByAttorney');
+        cy.checkA11yApp();
+
+        cy.contains('h1', 'Sam Smith’s property and affairs LPA');
+        cy.contains('li', 'You’ve signed the LPA Completed');
+        cy.contains('li', 'All attorneys have signed the LPA In progress');
+    });
+
+    it('when all signed', () => {
+        cy.visit('/fixtures/attorney?redirect=/progress&progress=signedByAllAttorneys');
+        cy.checkA11yApp();
+
+        cy.contains('h1', 'Sam Smith’s property and affairs LPA');
+        cy.contains('li', 'You’ve signed the LPA Completed');
+        cy.contains('li', 'All attorneys have signed the LPA Completed');
+    });
+});

--- a/internal/actor/attorney_provided.go
+++ b/internal/actor/attorney_provided.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/form"
 )
 
-// AttorneyProvidedDetails contains details about an attorney or replacement attorney, provided by the attorney or replacement attorney
+// AttorneyProvidedDetails contains details about an attorney or replacement
+// attorney, provided by the attorney or replacement attorney
 type AttorneyProvidedDetails struct {
 	PK, SK string
 	// The identifier of the attorney or replacement attorney being edited
@@ -15,39 +16,49 @@ type AttorneyProvidedDetails struct {
 	LpaID string
 	// Tracking when AttorneyProvidedDetails is updated
 	UpdatedAt time.Time
-	// IsReplacement is true when the details relate to an attorney appointed as a replacement
+	// IsReplacement is true when the details relate to an attorney appointed as a
+	// replacement
 	IsReplacement bool
 	// IsTrustCorporation is true when the details relate to a trust corporation
 	IsTrustCorporation bool
 	// Mobile number of the attorney or replacement attorney
 	Mobile string
-	// Confirming the attorney or replacement attorney agrees to responsibilities and confirms the tick box is a legal signature
+	// LpaSignedAt is when the Lpa was signed at the time of the attorney
+	// confirming. This allows us to verify that the Lpa hasn't been resigned
+	// since the attorney confirmed.
+	LpaSignedAt time.Time
+	// Confirming the attorney or replacement attorney agrees to responsibilities
+	// and confirms the tick box is a legal signature
 	Confirmed time.Time
 	// WouldLikeSecondSignatory captures whether two signatories will be used for a trust corporation
 	WouldLikeSecondSignatory form.YesNo
-	// AuthorisedSignatories captures the details of the person who signed on behalf of a trust corporation, if one is acting as an attorney
+	// AuthorisedSignatories captures the details of the person who signed on
+	// behalf of a trust corporation, if one is acting as an attorney
 	AuthorisedSignatories [2]TrustCorporationSignatory
 	// Used to show attorney task list
 	Tasks AttorneyTasks
 }
 
-func (d AttorneyProvidedDetails) Signed(after time.Time) bool {
-	if after.IsZero() {
+// Signed checks whether the attorney has confirmed and if that confirmation is
+// still valid by checking that it was made for the donor's current signature.
+func (d AttorneyProvidedDetails) Signed(lpaSignedAt time.Time) bool {
+	if lpaSignedAt.IsZero() {
 		return false
 	}
 
 	if d.IsTrustCorporation {
 		switch d.WouldLikeSecondSignatory {
 		case form.Yes:
-			return d.AuthorisedSignatories[0].Confirmed.After(after) && d.AuthorisedSignatories[1].Confirmed.After(after)
+			return lpaSignedAt.Equal(d.AuthorisedSignatories[0].LpaSignedAt) && !d.AuthorisedSignatories[0].Confirmed.IsZero() &&
+				lpaSignedAt.Equal(d.AuthorisedSignatories[1].LpaSignedAt) && !d.AuthorisedSignatories[1].Confirmed.IsZero()
 		case form.No:
-			return d.AuthorisedSignatories[0].Confirmed.After(after)
+			return lpaSignedAt.Equal(d.AuthorisedSignatories[0].LpaSignedAt) && !d.AuthorisedSignatories[0].Confirmed.IsZero()
 		default:
 			return false
 		}
 	}
 
-	return d.Confirmed.After(after)
+	return lpaSignedAt.Equal(d.LpaSignedAt) && !d.Confirmed.IsZero()
 }
 
 type AttorneyTasks struct {
@@ -63,4 +74,5 @@ type TrustCorporationSignatory struct {
 	LastName          string
 	ProfessionalTitle string
 	Confirmed         time.Time
+	LpaSignedAt       time.Time
 }

--- a/internal/app/dashboard_store.go
+++ b/internal/app/dashboard_store.go
@@ -131,14 +131,16 @@ func (s *dashboardStore) GetAll(ctx context.Context) (donor, attorney, certifica
 				return nil, nil, nil, err
 			}
 
-			if entry, ok := attorneyMap[attorneyProvidedDetails.LpaID]; ok {
+			lpaID := attorneyProvidedDetails.LpaID
+
+			if entry, ok := attorneyMap[lpaID]; ok {
 				if attorneyProvidedDetails.IsReplacement && !entry.Lpa.SubmittedAt.IsZero() {
-					delete(attorneyMap, attorneyProvidedDetails.LpaID)
+					delete(attorneyMap, lpaID)
 					continue
 				}
 
 				entry.Attorney = attorneyProvidedDetails
-				attorneyMap[attorneyProvidedDetails.LpaID] = entry
+				attorneyMap[lpaID] = entry
 				continue
 			}
 		}
@@ -149,13 +151,15 @@ func (s *dashboardStore) GetAll(ctx context.Context) (donor, attorney, certifica
 				return nil, nil, nil, err
 			}
 
+			lpaID := certificateProviderProvidedDetails.LpaID
+
 			if certificateProviderProvidedDetails.Certificate.AgreeToStatement {
-				delete(certificateProviderMap, certificateProviderProvidedDetails.LpaID)
+				delete(certificateProviderMap, lpaID)
 			}
 
-			if entry, ok := certificateProviderMap[certificateProviderProvidedDetails.LpaID]; ok {
-				entry.CertificateProviderTasks = certificateProviderProvidedDetails.Tasks
-				certificateProviderMap[certificateProviderProvidedDetails.LpaID] = entry
+			if entry, ok := certificateProviderMap[lpaID]; ok {
+				entry.CertificateProvider = certificateProviderProvidedDetails
+				certificateProviderMap[lpaID] = entry
 			}
 		}
 	}

--- a/internal/app/dashboard_store_test.go
+++ b/internal/app/dashboard_store_test.go
@@ -89,7 +89,7 @@ func TestDashboardStoreGetAll(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, []page.LpaAndActorTasks{{Lpa: lpa123}, {Lpa: lpa0}}, donor)
-			assert.Equal(t, []page.LpaAndActorTasks{{Lpa: lpa456, CertificateProviderTasks: actor.CertificateProviderTasks{ConfirmYourDetails: actor.TaskCompleted}}}, certificateProvider)
+			assert.Equal(t, []page.LpaAndActorTasks{{Lpa: lpa456, CertificateProvider: lpa456CpProvidedDetails}}, certificateProvider)
 			assert.Equal(t, []page.LpaAndActorTasks{{Lpa: lpa789, Attorney: lpa789AttorneyProvidedDetails}}, attorney)
 		})
 	}

--- a/internal/page/attorney/mock_AttorneyStore_test.go
+++ b/internal/page/attorney/mock_AttorneyStore_test.go
@@ -67,6 +67,32 @@ func (_m *mockAttorneyStore) Get(_a0 context.Context) (*actor.AttorneyProvidedDe
 	return r0, r1
 }
 
+// GetAny provides a mock function with given fields: _a0
+func (_m *mockAttorneyStore) GetAny(_a0 context.Context) ([]*actor.AttorneyProvidedDetails, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*actor.AttorneyProvidedDetails
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]*actor.AttorneyProvidedDetails, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []*actor.AttorneyProvidedDetails); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*actor.AttorneyProvidedDetails)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Put provides a mock function with given fields: _a0, _a1
 func (_m *mockAttorneyStore) Put(_a0 context.Context, _a1 *actor.AttorneyProvidedDetails) error {
 	ret := _m.Called(_a0, _a1)

--- a/internal/page/attorney/progress.go
+++ b/internal/page/attorney/progress.go
@@ -1,0 +1,41 @@
+package attorney
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/validation"
+)
+
+type progressData struct {
+	App             page.AppData
+	Errors          validation.List
+	Lpa             *page.Lpa
+	Signed          bool
+	AttorneysSigned bool
+}
+
+func Progress(tmpl template.Template, attorneyStore AttorneyStore, donorStore DonorStore) Handler {
+	return func(appData page.AppData, w http.ResponseWriter, r *http.Request, attorneyProvidedDetails *actor.AttorneyProvidedDetails) error {
+		lpa, err := donorStore.GetAny(r.Context())
+		if err != nil {
+			return err
+		}
+
+		attorneys, err := attorneyStore.GetAny(r.Context())
+		if err != nil {
+			return err
+		}
+
+		data := &progressData{
+			App:             appData,
+			Lpa:             lpa,
+			Signed:          attorneyProvidedDetails.Signed(lpa.SignedAt),
+			AttorneysSigned: lpa.AllAttorneysSigned(attorneys),
+		}
+
+		return tmpl(w, data)
+	}
+}

--- a/internal/page/attorney/progress_test.go
+++ b/internal/page/attorney/progress_test.go
@@ -1,0 +1,133 @@
+package attorney
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
+	"github.com/ministryofjustice/opg-modernising-lpa/internal/page"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgress(t *testing.T) {
+	lpaSignedAt := time.Now()
+	attorneySignedAt := lpaSignedAt.Add(time.Second)
+
+	testcases := map[string]struct {
+		attorney        *actor.AttorneyProvidedDetails
+		attorneys       []*actor.AttorneyProvidedDetails
+		signed          bool
+		attorneysSigned bool
+	}{
+		"unsigned": {
+			attorney: &actor.AttorneyProvidedDetails{},
+		},
+		"attorney signed": {
+			attorney: &actor.AttorneyProvidedDetails{
+				LpaSignedAt: lpaSignedAt,
+				Confirmed:   attorneySignedAt,
+			},
+			attorneys: []*actor.AttorneyProvidedDetails{{}},
+			signed:    true,
+		},
+		"all signed": {
+			attorney: &actor.AttorneyProvidedDetails{},
+			attorneys: []*actor.AttorneyProvidedDetails{{
+				LpaSignedAt: lpaSignedAt,
+				Confirmed:   attorneySignedAt,
+			}},
+			attorneysSigned: true,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+			lpa := &page.Lpa{
+				SignedAt:  lpaSignedAt,
+				Attorneys: actor.Attorneys{Attorneys: []actor.Attorney{{}}},
+			}
+
+			donorStore := newMockDonorStore(t)
+			donorStore.
+				On("GetAny", r.Context()).
+				Return(lpa, nil)
+
+			attorneyStore := newMockAttorneyStore(t)
+			attorneyStore.
+				On("GetAny", r.Context()).
+				Return(tc.attorneys, nil)
+
+			template := newMockTemplate(t)
+			template.
+				On("Execute", w, &progressData{App: testAppData, Lpa: lpa, Signed: tc.signed, AttorneysSigned: tc.attorneysSigned}).
+				Return(nil)
+
+			err := Progress(template.Execute, attorneyStore, donorStore)(testAppData, w, r, tc.attorney)
+			resp := w.Result()
+
+			assert.Nil(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+func TestProgressWhenAttorneyStoreErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	donorStore := newMockDonorStore(t)
+	donorStore.
+		On("GetAny", r.Context()).
+		Return(&page.Lpa{}, nil)
+
+	attorneyStore := newMockAttorneyStore(t)
+	attorneyStore.
+		On("GetAny", r.Context()).
+		Return(nil, expectedError)
+
+	err := Progress(nil, attorneyStore, donorStore)(testAppData, w, r, &actor.AttorneyProvidedDetails{})
+	assert.Equal(t, expectedError, err)
+}
+
+func TestProgressWhenDonorStoreErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	lpa := &page.Lpa{}
+
+	donorStore := newMockDonorStore(t)
+	donorStore.
+		On("GetAny", r.Context()).
+		Return(lpa, expectedError)
+
+	err := Progress(nil, nil, donorStore)(testAppData, w, r, &actor.AttorneyProvidedDetails{})
+	assert.Equal(t, expectedError, err)
+}
+
+func TestProgressWhenTemplateErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	donorStore := newMockDonorStore(t)
+	donorStore.
+		On("GetAny", r.Context()).
+		Return(&page.Lpa{}, nil)
+
+	attorneyStore := newMockAttorneyStore(t)
+	attorneyStore.
+		On("GetAny", r.Context()).
+		Return([]*actor.AttorneyProvidedDetails{}, nil)
+
+	template := newMockTemplate(t)
+	template.
+		On("Execute", w, &progressData{App: testAppData, Lpa: &page.Lpa{}}).
+		Return(expectedError)
+
+	err := Progress(template.Execute, attorneyStore, donorStore)(testAppData, w, r, &actor.AttorneyProvidedDetails{})
+	assert.Equal(t, expectedError, err)
+}

--- a/internal/page/attorney/register.go
+++ b/internal/page/attorney/register.go
@@ -71,6 +71,7 @@ type CertificateProviderStore interface {
 type AttorneyStore interface {
 	Create(context.Context, string, string, bool, bool) (*actor.AttorneyProvidedDetails, error)
 	Get(context.Context) (*actor.AttorneyProvidedDetails, error)
+	GetAny(context.Context) ([]*actor.AttorneyProvidedDetails, error)
 	Put(context.Context, *actor.AttorneyProvidedDetails) error
 }
 
@@ -125,6 +126,8 @@ func Register(
 		WouldLikeSecondSignatory(tmpls.Get("attorney_would_like_second_signatory.gohtml"), attorneyStore))
 	handleAttorney(page.Paths.Attorney.WhatHappensNext, RequireAttorney,
 		Guidance(tmpls.Get("attorney_what_happens_next.gohtml"), donorStore))
+	handleAttorney(page.Paths.Attorney.Progress, RequireAttorney,
+		Progress(tmpls.Get("attorney_progress.gohtml"), attorneyStore, donorStore))
 }
 
 type handleOpt byte

--- a/internal/page/attorney/sign.go
+++ b/internal/page/attorney/sign.go
@@ -113,9 +113,11 @@ func Sign(tmpl template.Template, donorStore DonorStore, certificateProviderStor
 						LastName:          data.Form.LastName,
 						ProfessionalTitle: data.Form.ProfessionalTitle,
 						Confirmed:         now(),
+						LpaSignedAt:       lpa.SignedAt,
 					}
 				} else {
 					attorneyProvidedDetails.Confirmed = now()
+					attorneyProvidedDetails.LpaSignedAt = lpa.SignedAt
 				}
 
 				if err := attorneyStore.Put(r.Context(), attorneyProvidedDetails); err != nil {

--- a/internal/page/attorney/sign_test.go
+++ b/internal/page/attorney/sign_test.go
@@ -297,6 +297,7 @@ func TestGetSignOnTemplateError(t *testing.T) {
 }
 
 func TestPostSign(t *testing.T) {
+	lpaSignedAt := time.Now().Add(-time.Minute)
 	now := time.Now()
 
 	testcases := map[string]struct {
@@ -311,13 +312,14 @@ func TestPostSign(t *testing.T) {
 			appData: testAppData,
 			form:    url.Values{"confirm": {"1"}},
 			lpa: &page.Lpa{
-				SignedAt:  now,
+				SignedAt:  lpaSignedAt,
 				Attorneys: actor.Attorneys{Attorneys: []actor.Attorney{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
-				LpaID:     "lpa-id",
-				Confirmed: now,
-				Tasks:     actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
+				LpaID:       "lpa-id",
+				LpaSignedAt: lpaSignedAt,
+				Confirmed:   now,
+				Tasks:       actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
 			},
 			redirect: page.Paths.Attorney.WhatHappensNext,
 		},
@@ -325,13 +327,14 @@ func TestPostSign(t *testing.T) {
 			appData: testReplacementAppData,
 			form:    url.Values{"confirm": {"1"}},
 			lpa: &page.Lpa{
-				SignedAt:             now,
+				SignedAt:             lpaSignedAt,
 				ReplacementAttorneys: actor.Attorneys{Attorneys: []actor.Attorney{{ID: "attorney-id", FirstNames: "Bob", LastName: "Smith"}}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
-				LpaID:     "lpa-id",
-				Confirmed: now,
-				Tasks:     actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
+				LpaID:       "lpa-id",
+				LpaSignedAt: lpaSignedAt,
+				Confirmed:   now,
+				Tasks:       actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
 			},
 			redirect: page.Paths.Attorney.WhatHappensNext,
 		},
@@ -344,7 +347,7 @@ func TestPostSign(t *testing.T) {
 				"confirm":            {"1"},
 			},
 			lpa: &page.Lpa{
-				SignedAt:  now,
+				SignedAt:  lpaSignedAt,
 				Attorneys: actor.Attorneys{TrustCorporation: actor.TrustCorporation{Name: "Corp"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
@@ -353,6 +356,7 @@ func TestPostSign(t *testing.T) {
 					FirstNames:        "a",
 					LastName:          "b",
 					ProfessionalTitle: "c",
+					LpaSignedAt:       lpaSignedAt,
 					Confirmed:         now,
 				}},
 				Tasks: actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
@@ -368,7 +372,7 @@ func TestPostSign(t *testing.T) {
 				"confirm":            {"1"},
 			},
 			lpa: &page.Lpa{
-				SignedAt:             now,
+				SignedAt:             lpaSignedAt,
 				ReplacementAttorneys: actor.Attorneys{TrustCorporation: actor.TrustCorporation{Name: "Corp"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
@@ -378,6 +382,7 @@ func TestPostSign(t *testing.T) {
 					LastName:          "b",
 					ProfessionalTitle: "c",
 					Confirmed:         now,
+					LpaSignedAt:       lpaSignedAt,
 				}},
 				Tasks: actor.AttorneyTasks{SignTheLpa: actor.TaskCompleted},
 			},
@@ -393,7 +398,7 @@ func TestPostSign(t *testing.T) {
 				"confirm":            {"1"},
 			},
 			lpa: &page.Lpa{
-				SignedAt:  now,
+				SignedAt:  lpaSignedAt,
 				Attorneys: actor.Attorneys{TrustCorporation: actor.TrustCorporation{Name: "Corp"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
@@ -402,6 +407,7 @@ func TestPostSign(t *testing.T) {
 					FirstNames:        "a",
 					LastName:          "b",
 					ProfessionalTitle: "c",
+					LpaSignedAt:       lpaSignedAt,
 					Confirmed:         now,
 				}},
 				Tasks: actor.AttorneyTasks{SignTheLpaSecond: actor.TaskCompleted},
@@ -418,7 +424,7 @@ func TestPostSign(t *testing.T) {
 				"confirm":            {"1"},
 			},
 			lpa: &page.Lpa{
-				SignedAt:             now,
+				SignedAt:             lpaSignedAt,
 				ReplacementAttorneys: actor.Attorneys{TrustCorporation: actor.TrustCorporation{Name: "Corp"}},
 			},
 			updatedAttorney: &actor.AttorneyProvidedDetails{
@@ -427,6 +433,7 @@ func TestPostSign(t *testing.T) {
 					FirstNames:        "a",
 					LastName:          "b",
 					ProfessionalTitle: "c",
+					LpaSignedAt:       lpaSignedAt,
 					Confirmed:         now,
 				}},
 				Tasks: actor.AttorneyTasks{SignTheLpaSecond: actor.TaskCompleted},

--- a/internal/page/dashboard.go
+++ b/internal/page/dashboard.go
@@ -15,9 +15,9 @@ type DashboardStore interface {
 }
 
 type LpaAndActorTasks struct {
-	Lpa                      *Lpa
-	CertificateProviderTasks actor.CertificateProviderTasks
-	Attorney                 *actor.AttorneyProvidedDetails
+	Lpa                 *Lpa
+	CertificateProvider *actor.CertificateProviderProvidedDetails
+	Attorney            *actor.AttorneyProvidedDetails
 }
 
 type dashboardData struct {

--- a/internal/page/data.go
+++ b/internal/page/data.go
@@ -338,7 +338,7 @@ func (l *Lpa) Progress(certificateProvider *actor.CertificateProviderProvidedDet
 	p.CertificateProviderSigned = actor.TaskCompleted
 	p.AttorneysSigned = actor.TaskInProgress
 
-	if !l.allAttorneysSigned(certificateProvider.Certificate.Agreed, attorneys) {
+	if !l.AllAttorneysSigned(attorneys) {
 		return p
 	}
 
@@ -362,8 +362,8 @@ func (l *Lpa) Progress(certificateProvider *actor.CertificateProviderProvidedDet
 	return p
 }
 
-func (l *Lpa) allAttorneysSigned(after time.Time, attorneys []*actor.AttorneyProvidedDetails) bool {
-	if l == nil || after.IsZero() || l.Attorneys.Len() == 0 {
+func (l *Lpa) AllAttorneysSigned(attorneys []*actor.AttorneyProvidedDetails) bool {
+	if l == nil || l.SignedAt.IsZero() || l.Attorneys.Len() == 0 {
 		return false
 	}
 
@@ -375,7 +375,7 @@ func (l *Lpa) allAttorneysSigned(after time.Time, attorneys []*actor.AttorneyPro
 	)
 
 	for _, a := range attorneys {
-		if !a.Signed(after) {
+		if !a.Signed(l.SignedAt) {
 			continue
 		}
 

--- a/internal/page/paths.go
+++ b/internal/page/paths.go
@@ -49,6 +49,7 @@ type AttorneyPaths struct {
 	CodeOfConduct             AttorneyPath
 	ConfirmYourDetails        AttorneyPath
 	MobileNumber              AttorneyPath
+	Progress                  AttorneyPath
 	ReadTheLpa                AttorneyPath
 	RightsAndResponsibilities AttorneyPath
 	Sign                      AttorneyPath
@@ -236,16 +237,17 @@ var Paths = AppPaths{
 	},
 
 	Attorney: AttorneyPaths{
+		CodeOfConduct:             "/code-of-conduct",
+		ConfirmYourDetails:        "/confirm-your-details",
 		EnterReferenceNumber:      "/attorney-enter-reference-number",
 		Login:                     "/attorney-login",
 		LoginCallback:             "/attorney-login-callback",
-		Start:                     "/attorney-start",
-		CodeOfConduct:             "/code-of-conduct",
-		ConfirmYourDetails:        "/confirm-your-details",
 		MobileNumber:              "/mobile-number",
+		Progress:                  "/progress",
 		ReadTheLpa:                "/read-the-lpa",
 		RightsAndResponsibilities: "/legal-rights-and-responsibilities",
 		Sign:                      "/sign",
+		Start:                     "/attorney-start",
 		TaskList:                  "/task-list",
 		WhatHappensNext:           "/what-happens-next",
 		WhatHappensWhenYouSign:    "/what-happens-when-you-sign-the-lpa",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -883,5 +883,8 @@
     "howWouldYouLikeToSendUsYourEvidenceContent": "<p class=\"govuk-body\">Welsh</p>",
     "howYouWouldLikeToSendUsYourEvidence": "Welsh",
     "uploadItOnline" : "Welsh",
-    "sendItByPost" : "Welsh"
+    "sendItByPost" : "Welsh",
+    "theirLpa": "{{.FullNamePossessive}} {{.LpaType}} Welsh",
+    "allAttorneysHaveSignedTheLpa": "Welsh",
+    "youveSignedTheLpa": "Welsh"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -833,5 +833,8 @@
     "howWouldYouLikeToSendUsYourEvidenceContent": "<p class=\"govuk-body\">You can upload your supporting evidence on the next page, or you can send it to us in the post.</p>",
     "howYouWouldLikeToSendUsYourEvidence": "how you would like to send us your evidence",
     "uploadItOnline" : "Upload it online",
-    "sendItByPost" : "Send it by post"
+    "sendItByPost" : "Send it by post",
+    "theirLpa": "{{.FullNamePossessive}} {{.LpaType}} LPA",
+    "allAttorneysHaveSignedTheLpa": "All attorneys have signed the LPA",
+    "youveSignedTheLpa": "You’ve signed the LPA"
 }

--- a/web/template/attorney_fixtures.gohtml
+++ b/web/template/attorney_fixtures.gohtml
@@ -60,14 +60,20 @@
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-progress-3" name="progress" type="radio" value="submitted">
+                <input class="govuk-radios__input" id="f-progress-3" name="progress" type="radio" value="signedByAllAttorneys">
                 <label class="govuk-label govuk-radios__label" for="f-progress-3">
+                  Signed by all attorneys
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-progress-4" name="progress" type="radio" value="submitted">
+                <label class="govuk-label govuk-radios__label" for="f-progress-4">
                   Submitted
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-progress-4" name="progress" type="radio" value="registered">
-                <label class="govuk-label govuk-radios__label" for="f-progress-4">
+                <input class="govuk-radios__input" id="f-progress-5" name="progress" type="radio" value="registered">
+                <label class="govuk-label govuk-radios__label" for="f-progress-5">
                   Registered
                 </label>
               </div>

--- a/web/template/attorney_progress.gohtml
+++ b/web/template/attorney_progress.gohtml
@@ -1,0 +1,40 @@
+{{ template "page" . }}
+
+{{ define "pageTitle" }}
+  {{ trFormat .App "theirLpa" "FullNamePossessive" (possessive .App .Lpa.Donor.FullName) "LpaType" (tr .App .Lpa.Type.LegalTermTransKey) }}
+{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ template "pageTitle" . }}</h1>
+      <div class="govuk-body">
+        <span><strong>{{ tr .App "applicationNumber" }}:</strong> {{ .Lpa.ID }}</span>
+      </div>
+
+      <div class="app-progress-bar">
+        <ol class="app-progress-bar__list">
+          <li class="app-progress-bar__item" {{ if not .Signed }}aria-current="step"{{ end }}>
+            <span class="app-progress-bar__icon {{ if .Signed }}app-progress-bar__icon--complete{{ end }}"></span>
+            <span class="app-progress-bar__label">
+              {{ tr .App "youveSignedTheLpa" }}<span class="govuk-visually-hidden"> {{ if .Signed }}{{ tr .App "completed" }}{{ else }}{{ tr .App "inProgress" }}{{ end }}</span>
+            </span>
+          </li>
+          <li class="app-progress-bar__item" {{ if and .Signed (not .AttorneysSigned) }}aria-current="step"{{ end }}>
+            <span class="app-progress-bar__icon {{ if .AttorneysSigned }}app-progress-bar__icon--complete{{ end }}"></span>
+            <span class="app-progress-bar__label">
+              {{ tr .App "allAttorneysHaveSignedTheLpa" }}<span class="govuk-visually-hidden"> {{ if .AttorneysSigned }}{{ tr .App "completed" }}{{ else if .Signed }}{{ tr .App "inProgress" }}{{ else }}{{ tr .App "notStarted" }}{{ end }}</span>
+            </span>
+          </li>
+        </ol>
+      </div>
+
+      <a class="govuk-button" href="{{ link .App .App.Paths.Dashboard.Format }}">{{ tr .App "backToDashboard" }}</a>
+
+      <h2 class="govuk-heading-m">{{ tr .App "lpaDecisions"}}</h2>
+
+      {{ template "lpa-decisions" . }}
+      {{ template "people-named-on-lpa" (peopleNamedOnLpa .App .Lpa 0) }}
+    </div>
+  </div>
+{{ end }}

--- a/web/template/dashboard.gohtml
+++ b/web/template/dashboard.gohtml
@@ -62,7 +62,7 @@
           <strong class="govuk-tag app-tag--black">{{ tr .App "registered" }}</strong>
         {{ else if not .Item.Lpa.SubmittedAt.IsZero }}
           <strong class="govuk-tag govuk-tag--green">{{ tr .App "submittedToOpg" }}</strong>
-        {{ else if .Item.Attorney.Signed }}
+        {{ else if .Item.Attorney.Signed .Item.Lpa.SignedAt }}
           <strong class="govuk-tag govuk-tag--blue">{{ tr .App "inProgress" }}</strong>
         {{ else }}
           <strong class="govuk-tag govuk-tag--yellow">{{ tr .App "readyToSign" }}</strong>
@@ -84,10 +84,10 @@
           <a class="govuk-link" href="#">{{ tr .App "use" }}</a>
         {{ else if not .Item.Lpa.SubmittedAt.IsZero }}
           <a class="govuk-button" href="#">{{ tr .App "viewLpa" }}</a>
-          <a class="govuk-button govuk-button--secondary" href="#">{{ tr .App "trackLpaProgress" }}</a>
-        {{ else if .Item.Attorney.Signed }}
+          <a class="govuk-button govuk-button--secondary" href="{{ link .App (.App.Paths.Attorney.Progress.Format .Item.Lpa.ID) }}">{{ tr .App "trackLpaProgress" }}</a>
+        {{ else if .Item.Attorney.Signed .Item.Lpa.SignedAt }}
           <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.TaskList.Format .Item.Lpa.ID) }}">{{ tr .App "goToTaskList" }}</a>
-          <a class="govuk-button govuk-button--secondary" href="#">{{ tr .App "trackLpaProgress" }}</a>
+          <a class="govuk-button govuk-button--secondary" href="{{ link .App (.App.Paths.Attorney.Progress.Format .Item.Lpa.ID) }}">{{ tr .App "trackLpaProgress" }}</a>
         {{ else }}
           <a class="govuk-button" href="{{ link .App (.App.Paths.Attorney.TaskList.Format .Item.Lpa.ID) }}">{{ tr .App "goToTaskList" }}</a>
         {{ end }}
@@ -104,7 +104,7 @@
         <span class="govuk-!-font-weight-regular">{{ .Item.Lpa.Donor.FirstNames }} {{ .Item.Lpa.Donor.LastName }}</span>
       </h3>
       <div>
-        {{ if and .Item.CertificateProviderTasks.ReadTheLpa.Completed (not .Item.Lpa.SignedAt.IsZero) .Item.Lpa.Tasks.PayForLpa.IsCompleted }}
+        {{ if and .Item.CertificateProvider.Tasks.ReadTheLpa.Completed (not .Item.Lpa.SignedAt.IsZero) .Item.Lpa.Tasks.PayForLpa.IsCompleted }}
           <strong class="govuk-tag govuk-tag--yellow">{{ tr .App "readyToSign" }}</strong>
         {{ else }}
           <strong class="govuk-tag govuk-tag--blue">{{ tr .App "inProgress" }}</strong>


### PR DESCRIPTION
I needed a way to check on the dashboard that the attorney signed after the certificate provider (after the donor), since getting the certificate provider signed at is difficult/impossible with the way the data is set up I came up with the solution of storing `LpaSignedAt` on the attorney data and checking that matches the current one. It's a bit weird, but hopefully makes sense.