### PR TITLE
MLPAB-1478 - Use VPC Endpoints

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -136,7 +136,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: true
+      smoke: false
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -415,11 +415,11 @@ locals {
           name  = "EVENT_BUS_NAME",
           value = var.event_bus.name
         },
-        # {
-        #   # use vpc endpoints
-        #   name  = "AWS_ENDPOINT_URL",
-        #   value = "https://com.amazonaws.${data.aws_region.current.name}"
-        # },
+        {
+          # use vpc endpoints
+          name  = "AWS_BASE_URL",
+          value = "https://com.amazonaws.${data.aws_region.current.name}."
+        },
       ]
     }
   )

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -415,6 +415,11 @@ locals {
           name  = "EVENT_BUS_NAME",
           value = var.event_bus.name
         },
+        # {
+        #   # use vpc endpoints
+        #   name  = "AWS_ENDPOINT_URL",
+        #   value = "https://com.amazonaws.${data.aws_region.current.name}"
+        # },
       ]
     }
   )

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -418,7 +418,7 @@ locals {
         {
           # use vpc endpoints
           name  = "AWS_BASE_URL",
-          value = "https://com.amazonaws.${data.aws_region.current.name}."
+          value = "https://com.amazonaws.${data.aws_region.current.name}"
         },
       ]
     }


### PR DESCRIPTION
# Purpose

Direct requests to AWS services via a VPC endpoint to reduce the egress vector through the internet gateway

Fixes MLPAB-1478

## Approach

- sort list of environment variables alphabetically
- configure AWS SDK to use VPC endpoints base URL as AWS_BASE_URL

## Learning

- https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/
- https://github.com/ministryofjustice/opg-modernising-lpa/blob/main/cmd/event-received/main.go
- https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#EVarSettings
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html

