### PR TITLE
MLPAB-1470 - Create endpoint policies

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -136,7 +136,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: false
+      smoke: true
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -136,7 +136,7 @@ jobs:
       run_against_image: false
       base_url: "https://${{ needs.pr_deploy.outputs.url }}"
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: true
+      smoke: false
       environment_config_json: ${{ needs.pr_deploy.outputs.environment_config_json }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -56,9 +56,10 @@ resource "aws_vpc_endpoint" "private" {
   tags                = { Name = "${each.value}-private-${data.aws_region.current.name}" }
 }
 
-resource "aws_vpc_endpoint_policy" "ec2" {
+resource "aws_vpc_endpoint_policy" "private" {
   provider        = aws.region
-  vpc_endpoint_id = aws_vpc_endpoint.private["ec2"].id
+  for_each        = local.interface_endpoint
+  vpc_endpoint_id = aws_vpc_endpoint.private[each.value].id
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -66,10 +67,10 @@ resource "aws_vpc_endpoint_policy" "ec2" {
         "Sid" : "AllowAll",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : "*"
+          "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         },
         "Action" : [
-          "ec2:*"
+          "${each.value}:*"
         ],
         "Resource" : "*"
       }

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "s3_vpc_endpoint" {
     actions   = ["*"]
     resources = ["*"]
     principals {
-      type        = "AWS*"
+      type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "dynamodb_vpc_endpoint" {
     actions   = ["*"]
     resources = ["*"]
     principals {
-      type        = "AWS*"
+      type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -70,7 +70,7 @@ resource "aws_vpc_endpoint_policy" "private" {
           "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         },
         "Action" : [
-          "${each.value}:*"
+          "${startswith(each.value, "ecr") ? "ecr" : each.value}:*"
         ],
         "Resource" : "*"
       }

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -102,8 +102,8 @@ data "aws_iam_policy_document" "s3_vpc_endpoint" {
     actions   = ["*"]
     resources = ["*"]
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "AWS*"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
 }
@@ -125,8 +125,8 @@ data "aws_iam_policy_document" "dynamodb_vpc_endpoint" {
     actions   = ["*"]
     resources = ["*"]
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "AWS*"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
 }

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -100,11 +100,16 @@ data "aws_iam_policy_document" "s3_vpc_endpoint" {
   provider = aws.region
   statement {
     sid       = "S3VpcEndpointPolicy"
-    actions   = ["*"]
+    actions   = ["s3:*"]
     resources = ["*"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values   = [data.aws_caller_identity.current.account_id]
     }
   }
 }
@@ -123,11 +128,17 @@ data "aws_iam_policy_document" "dynamodb_vpc_endpoint" {
   provider = aws.region
   statement {
     sid       = "DynamoDBVpcEndpointPolicy"
-    actions   = ["*"]
+    effect    = "Allow"
+    actions   = ["dynamodb:*"]
     resources = ["*"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values   = [data.aws_caller_identity.current.account_id]
     }
   }
 }


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-1470

## Approach

- set the current account as principal on gateway endpoints
- create a basic allow policy for each endpoint limiting access to the account

## Learning

- https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html
