### PR TITLE
MLPAB-1472 - Persist scan results on files

### DIFF
--- a/terraform/environment/region/event_received.tf
+++ b/terraform/environment/region/event_received.tf
@@ -10,6 +10,7 @@ module "event_received" {
   lambda_function_image_tag     = var.app_service_container_version
   event_bus_name                = module.event_bus.event_bus.name
   app_public_url                = aws_route53_record.app.fqdn
+  uploads_bucket_name           = "uploads-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
 
   lpas_table = {
     arn  = var.lpas_table.arn

--- a/terraform/environment/region/modules/event_received/variables.tf
+++ b/terraform/environment/region/modules/event_received/variables.tf
@@ -24,3 +24,7 @@ variable "lpas_table" {
 variable "app_public_url" {
   type = string
 }
+
+variable "uploads_bucket_name" {
+  type = string
+}


### PR DESCRIPTION
# Purpose

Show the user the status of their uploaded documents and if any contain malicious code or viruses

Fixes MLPAB-1472

## Approach

- run lambda when object is tagged 
- allow lambda to get an s3 object's tags

## Learning

- 