### PR TITLE
MLPAB-1502 - Fix decrypt permissions for s3 antivirus scanning

### DIFF
--- a/terraform/environment/region/modules/s3_antivirus/data_sources.tf
+++ b/terraform/environment/region/modules/s3_antivirus/data_sources.tf
@@ -10,3 +10,8 @@ data "aws_caller_identity" "current" {
 data "aws_default_tags" "current" {
   provider = aws.region
 }
+
+data "aws_kms_alias" "uploads_encryption_key" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_reduced_fees_uploads_s3_encryption"
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/s3_antivirus/iam.tf
+++ b/terraform/environment/region/modules/s3_antivirus/iam.tf
@@ -30,6 +30,16 @@ data "aws_iam_policy_document" "lambda" {
   }
 
   statement {
+    sid       = "allowS3ObjectDecryption"
+    effect    = "Allow"
+    resources = [data.aws_kms_alias.uploads_encryption_key.target_key_arn]
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+  }
+
+  statement {
     sid       = "allowVirusDefinitions"
     effect    = "Allow"
     resources = [var.definition_bucket.arn, "${var.definition_bucket.arn}/*"]


### PR DESCRIPTION
# Purpose

Prevent malicious code being forwarded from our service

Fixes MLPAB-1502

## Approach

- allow KMS decrypt using uploads bucket encryption key
