### PR TITLE
MLPAB-1333 Deploy mock-onelogin on dev envs

### DIFF
--- a/cmd/mock-onelogin/main.go
+++ b/cmd/mock-onelogin/main.go
@@ -29,7 +29,7 @@ var (
 	publicURL          = env.Get("PUBLIC_URL", "http://localhost:8080")
 	internalURL        = env.Get("INTERNAL_URL", "http://mock-onelogin:8080")
 	clientId           = env.Get("CLIENT_ID", "theClientId")
-	serviceRedirectUrl = env.Get("REDIRECT_RUL", "http://localhost:5050/auth/redirect")
+	serviceRedirectUrl = env.Get("REDIRECT_URL", "http://localhost:5050/auth/redirect")
 
 	signingKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,6 @@ services:
     environment:
       - PUBLIC_URL=http://localhost:7012
       - CLIENT_ID=client-id-value
-      - REDIRECT_URL=http://localhost:5050/auth/redirect
 
   mock-notify:
     build:

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -56,3 +56,27 @@ module "app" {
     aws.region = aws.region
   }
 }
+
+module "mock_onelogin" {
+  source                                  = "./modules/mock_onelogin"
+  ecs_cluster                             = aws_ecs_cluster.main.id
+  ecs_execution_role                      = var.iam_roles.ecs_execution_role
+  ecs_task_role                           = var.iam_roles.app_ecs_task_role
+  ecs_service_desired_count               = var.use_mock_onelogin ? 1 : 0
+  ecs_application_log_group_name          = module.application_logs.cloudwatch_log_group.name
+  ecs_capacity_provider                   = var.ecs_capacity_provider
+  mock_onelogin_service_repository_url    = var.mock_onelogin_service_repository_url
+  mock_onelogin_service_container_version = var.mock_onelogin_service_container_version
+  ingress_allow_list_cidr                 = concat(var.ingress_allow_list_cidr, split(",", data.aws_ssm_parameter.additional_allowed_ingress_cidrs.value))
+  alb_deletion_protection_enabled         = var.alb_deletion_protection_enabled
+  container_port                          = 8080
+  public_access_enabled                   = var.public_access_enabled
+  network = {
+    vpc_id              = data.aws_vpc.main.id
+    application_subnets = data.aws_subnet.application.*.id
+    public_subnets      = data.aws_subnet.public.*.id
+  }
+  providers = {
+    aws.region = aws.region
+  }
+}

--- a/terraform/environment/region/modules/mock_onelogin/access_logging_bucket.tf
+++ b/terraform/environment/region/modules/mock_onelogin/access_logging_bucket.tf
@@ -1,0 +1,4 @@
+data "aws_s3_bucket" "access_log" {
+  bucket   = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-lb-access-logs-${data.aws_region.current.name}"
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/region/modules/mock_onelogin/alb.tf
@@ -1,0 +1,213 @@
+resource "aws_lb_target_group" "app" {
+  name                 = "${data.aws_default_tags.current.tags.environment-name}-app"
+  port                 = 80
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.network.vpc_id
+  deregistration_delay = 0
+  depends_on           = [aws_lb.app]
+
+  health_check {
+    enabled = true
+    path    = "/health-check/service"
+  }
+
+  provider = aws.region
+}
+
+resource "aws_lb" "app" {
+  name                       = "${data.aws_default_tags.current.tags.environment-name}-app"
+  internal                   = false #tfsec:ignore:AWS005 - public alb
+  load_balancer_type         = "application"
+  drop_invalid_header_fields = true
+  subnets                    = var.network.public_subnets
+  enable_deletion_protection = var.alb_deletion_protection_enabled
+  security_groups            = [aws_security_group.app_loadbalancer.id]
+
+  access_logs {
+    bucket  = data.aws_s3_bucket.access_log.bucket
+    prefix  = "app-${data.aws_default_tags.current.tags.environment-name}"
+    enabled = true
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener" "app_loadbalancer_http_redirect" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  provider = aws.region
+}
+
+locals {
+  dev_wildcard = data.aws_default_tags.current.tags.environment-name == "production" ? "" : "*."
+  dev_app_fqdn = "${local.name_prefix}.app.modernising.opg.service.justice.gov.uk"
+}
+
+data "aws_acm_certificate" "certificate_app" {
+  domain   = "${local.dev_wildcard}app.modernising.opg.service.justice.gov.uk"
+  provider = aws.region
+}
+
+resource "aws_lb_listener" "app_loadbalancer" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
+  certificate_arn   = data.aws_acm_certificate.certificate_app.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.app.arn
+    type             = "forward"
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_rule" "app_maintenance" {
+  listener_arn = aws_lb_listener.app_loadbalancer.arn
+  priority     = 101 # Specifically set so that maintenance mode scripts can locate the correct rule to modify
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "maintenance.opg.service.justice.gov.uk"
+      path        = "/en-gb/modernised-make-a-lasting-power-of-attorney" # temporarily the english make a lasting power of attorney maintenance page
+      query       = ""
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/maintenance"]
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to the condition as this is modified by a script
+      # when putting the service into maintenance mode.
+      condition,
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_rule" "app_maintenance_welsh" {
+  listener_arn = aws_lb_listener.app_loadbalancer.arn
+  priority     = 100 # Specifically set so that maintenance mode scripts can locate the correct rule to modify
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "maintenance.opg.service.justice.gov.uk"
+      path        = "/cy/moderneiddio-gwneud-atwrneiaeth-arhosol" # temporarily the welsh use a lasting power of attorney maintenance page
+      query       = ""
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/cy/maintenance"]
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to the condition as this is modified by a script
+      # when putting the service into maintenance mode.
+      condition,
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_certificate" "app_loadbalancer_live_service_certificate" {
+  listener_arn    = aws_lb_listener.app_loadbalancer.arn
+  certificate_arn = data.aws_acm_certificate.certificate_app.arn
+  provider        = aws.region
+}
+
+resource "aws_security_group" "app_loadbalancer" {
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-app-loadbalancer"
+  description = "app service application load balancer"
+  vpc_id      = var.network.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+data "aws_ip_ranges" "route53_healthchecks" {
+  services = ["route53_healthchecks"]
+  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "ap-southeast-1"]
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "app_loadbalancer_port_80_redirect_ingress" {
+  description       = "Port 80 ingress for redirection to port 443"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}
+
+resource "aws_security_group_rule" "app_loadbalancer_ingress" {
+  description       = "Port 443 ingress from the allow list to the application load balancer"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}
+
+resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
+  description       = "Loadbalancer ingresss from Route53 healthchecks"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "443"
+  to_port           = "443"
+  cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+  ipv6_cidr_blocks  = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}
+
+resource "aws_security_group_rule" "app_loadbalancer_public_access_ingress" {
+  count             = var.public_access_enabled ? 1 : 0
+  description       = "Port 443 production public ingress to the application load balancer"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sgr - open ingress for production
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}
+
+resource "aws_security_group_rule" "app_loadbalancer_egress" {
+  description       = "Allow any egress from service load balancer"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-ec2-no-public-egress-sgr - open egress for load balancers
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}

--- a/terraform/environment/region/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/ecs.tf
@@ -1,0 +1,140 @@
+resource "aws_ecs_service" "mock_onelogin" {
+  name                  = "mock_onelogin"
+  cluser                = var.ecs_cluster
+  task_definition       = aws_ecs_task_definition.mock_onelogin.arn
+  desired_count         = var.ecs_service_desired_count
+  platform_version      = "1.4.0"
+  wait_for_steady_state = true
+  propagate_tags        = "SERVICE"
+
+  capacity_provider_strategy {
+    capacity_provider = var.ecs_capacity_provider
+    weight            = 100
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.mock_onelogin_ecs_service.id]
+    subnets          = var.network.application_subnets
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.mock_onelogin.arn
+    container_name   = "mock_onelogin"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  timeouts {
+    create = "7m"
+    update = "4m"
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group" "mock_onelogin_ecs_service" {
+  name_prefix = "${local.name_prefix}-ecs-service"
+  description = "mock onelogin service security group"
+  vpc_id      = var.network.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_ecs_service_ingress" {
+  description              = "Allow Port 80 ingress from the application load balancer"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.mock_onelogin_ecs_service.id
+  source_security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_ecs_service_egress" {
+  description       = "Allow any egress from service"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-ec2-no-public-egress-sgr - open egress for ECR access
+  security_group_id = aws_security_group.mock_onelogin_ecs_service.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+resource "aws_ecs_task_definition" "mock_onelogin" {
+  family                   = local.name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  container_definitions    = "[${local.mock_onelogin}, ${local.aws_otel_collector}]"
+  task_role_arn            = var.ecs_task_role.arn
+  execution_role_arn       = var.ecs_execution_role.arn
+  provider                 = aws.region
+}
+
+resource "aws_iam_role_policy" "mock_onelogin_task_role" {
+  name     = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}-mock-onelogin-task-role"
+  policy   = data.aws_iam_policy_document.task_role_access_policy.json
+  role     = var.ecs_task_role.name
+  provider = aws.region
+}
+
+locals {
+  mock_onelogin = jsonencode(
+    {
+      cpu                    = 1,
+      essential              = true,
+      image                  = "${var.mock_onelogin_service_repository_url}:${var.mock_onelogin_service_container_version}",
+      mountPoints            = [],
+      readonlyRootFilesystem = true
+      name                   = "mock_onelogin",
+      portMappings = [
+        {
+          containerPort = var.container_port,
+          hostPort      = var.container_port,
+          protocol      = "tcp"
+        }
+      ],
+      volumesFrom = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = var.ecs_application_log_group_name,
+          awslogs-region        = data.aws_region.current.name,
+          awslogs-stream-prefix = data.aws_default_tags.current.tags.environment-name
+        }
+      },
+      environment = [
+        {
+          name  = "PORT",
+          value = tostring(var.container_port)
+        },
+        {
+          name  = "CLIENT_ID",
+          value = "37iOvkzc5BIRKsFSu5l3reZmFlA"
+        },
+        {
+          name  = "PUBLIC_URL",
+          value = var.public_url
+        },
+        {
+          name  = "REDIRECT_URL",
+          value = var.redirect_url
+        }
+      ]
+    }
+  )
+}

--- a/terraform/environment/region/modules/mock_onelogin/outputs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/outputs.tf
@@ -1,0 +1,11 @@
+output "load_balancer" {
+  value = aws_lb.app
+}
+
+output "load_balancer_security_group" {
+  value = aws_security_group.app_loadbalancer
+}
+
+output "ecs_service" {
+  value = aws_ecs_service.app
+}

--- a/terraform/environment/region/modules/mock_onelogin/terraform.tf
+++ b/terraform/environment/region/modules/mock_onelogin/terraform.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5.2"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.region,
+      ]
+    }
+  }
+}
+
+data "aws_region" "current" {
+  provider = aws.region
+}
+
+data "aws_caller_identity" "current" {
+  provider = aws.region
+}
+
+data "aws_default_tags" "current" {
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/region/modules/mock_onelogin/variables.tf
@@ -1,0 +1,75 @@
+locals {
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+}
+
+variable "ecs_execution_role" {
+  type = object({
+    id  = string
+    arn = string
+  })
+  description = "ID and ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+}
+
+variable "ecs_task_role" {
+  type        = any
+  description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
+}
+
+variable "ecs_cluster" {
+  type        = string
+  description = "ARN of an ECS cluster."
+}
+
+variable "ecs_service_desired_count" {
+  type        = number
+  default     = 0
+  description = "Number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the DAEMON scheduling strategy."
+}
+
+variable "network" {
+  type = object({
+    vpc_id              = string
+    application_subnets = list(string)
+    public_subnets      = list(string)
+  })
+  description = "VPC ID, a list of application subnets, and a list of private subnets required to provision the ECS service"
+}
+
+variable "ecs_capacity_provider" {
+  type        = string
+  description = "Name of the capacity provider to use. Valid values are FARGATE_SPOT and FARGATE"
+}
+
+variable "ecs_application_log_group_name" {
+  description = "The AWS Cloudwatch Log Group resource for application logging"
+}
+
+variable "mock_onelogin_service_repository_url" {
+  type        = string
+  description = "(optional) describe your variable"
+}
+
+variable "mock_onelogin_service_container_version" {
+  type        = string
+  description = "(optional) describe your variable"
+}
+
+variable "ingress_allow_list_cidr" {
+  type        = list(string)
+  description = "List of CIDR ranges permitted to access the service"
+}
+
+variable "alb_deletion_protection_enabled" {
+  type        = bool
+  description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port on the container to associate with."
+}
+
+variable "public_access_enabled" {
+  type        = bool
+  description = "Enable access to the Modernising LPA service from the public internet"
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -96,3 +96,7 @@ variable "receive_account_ids" {
   description = "IDs of accounts to receive messages from"
   default     = []
 }
+
+variable "use_mock_onelogin" {
+  type = bool
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -57,7 +57,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "use_mock_onelogin": true
     },
     "testevents": {
       "account_id": "653761790766",
@@ -116,7 +117,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": true
-      }
+      },
+      "use_mock_onelogin": false
     },
     "demo": {
       "account_id": "653761790766",
@@ -175,7 +177,8 @@
         "target_environment": "integration",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": true
-      }
+      },
+      "use_mock_onelogin": false
     },
     "ur": {
       "account_id": "653761790766",
@@ -234,7 +237,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "use_mock_onelogin": false
     },
     "preproduction": {
       "account_id": "792093328875",
@@ -293,7 +297,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "use_mock_onelogin": false
     },
     "production": {
       "account_id": "313879017102",
@@ -352,7 +357,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "use_mock_onelogin": false
     }
   }
 }


### PR DESCRIPTION
I'm thinking that for now it might be most useful on `demo` and `ur`? We'd still have the ability to toggle it off if we needed to test.