### PR TITLE
MLPAB-1506 - Fix events recevied triggering from object tagging events

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -5,20 +5,22 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.22.0"
   constraints = "~> 5.22.0"
   hashes = [
-    "h1:+txIES2xSzEPYg8sQYtJaZwvOKSQLji+juxuYXwoaC8=",
-    "h1:/qHuMnVQtV9kWeERCLjbEwf+1MTT/3jySXgCe9eGA8U=",
-    "h1:4oAjE3Fn/vXruaORPWH1lH7q/+oPEqxNm6+KjOMeMrI=",
-    "h1:IhWpZTNTPvJ0TpFjlFksXk4ESBgCiZoGIspyCk4fZaI=",
-    "h1:MqEHvwLEUS/kIQQStNuupXv4NduuZ0+91+W2k0VWvTI=",
-    "h1:N0jHwvdmN49BAxQaSRrefGLTkTztTyEKb/pOjS93ppI=",
-    "h1:XKXLHDDEFwViBJBHjdwIKAaOPkobAm3mHlwBrzUHyQc=",
-    "h1:XeMTnwj40DQAqAgIPWa/pZYr3/PfKB1afMjxMYMXnFE=",
     "h1:XuU3tsGzElMt4Ti8SsM05pFllNMwSC4ScUxcfsOS140=",
-    "h1:bNRGSiw+XvdXgU94N0fto22cwPY3tfxdrqC/19X0RVw=",
-    "h1:f0z3lC8l8EOnFzppf+MPOho036x/wPJTcittL7nCjvc=",
-    "h1:q8JCm3r/lVFQPhTPNMB0O1qEuLx/RNeJdY3gTTLwFh8=",
-    "h1:s5D2g7z2dt8mqIwnQAjyE6NZWEirfRxt7kLsmslY5Ls=",
-    "h1:ucoUpPuJUrtC5PxO3TpES2yQ7cMWZlfIQCbIbEwen94=",
+    "zh:09b8475cd519c945423b1e1183b71a4209dd2927e0d289a88c5abeecb53c1753",
+    "zh:2448e0c3ce9b991a5dd70f6a42d842366a6a2460cf63b31fb9bc5d2cc92ced19",
+    "zh:3b9fc2bf6714a9a9ab25eae3e56cead3d3917bc1b6d8b9fb3111c4198a790c72",
+    "zh:4fbd28ad5380529a36c54d7a96c9768df1288c625d28b8fa3a50d4fc2176ef0f",
+    "zh:54d550f190702a7edc2d459952d025e259a8c0b0ff7df3f15bbcc148539214bf",
+    "zh:638f406d084ac96f3a0b0a5ce8aa71a5a2a781a56ba96e3a235d3982b89eef0d",
+    "zh:69d4c175b13b6916b5c9398172cc384e7af46cb737b45870ab9907f12e82a28a",
+    "zh:81edec181a67255d25caf5e7ffe6d5e8f9373849b9e8f5e0705f277640abb18e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a66efb2b3cf7be8116728ae5782d7550f23f3719da2ed3c10228d29c44b7dc84",
+    "zh:ae754478d0bfa42195d16cf46091fab7c1c075ebc965d919338e36aed45add78",
+    "zh:e0603ad0061c43aa1cb52740b1e700b8afb55667d7ee01c1cc1ceb6f983d4c9d",
+    "zh:e4cb701d0185884eed0492a66eff17251f5b4971d30e81acd5e0a55627059fc8",
+    "zh:f7db2fcf69679925dde1ae326526242fd61ba1f83f614b1f6d9d68c925417e51",
+    "zh:fef331b9b62bc26d900ae937cc662281ff30794edf48aebfe8997d0e16835f6d",
   ]
 }
 
@@ -43,20 +45,21 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "3.0.2"
-  constraints = ">= 2.16.0"
+  constraints = ">= 2.16.0, ~> 3.0.0"
   hashes = [
-    "h1:0nIw8U6qb62EmZIWKoFTEW/zBu6DI1qpTjTkxAIkLf8=",
-    "h1:E42oozIhqWGv4LjTpI33dFvSYlcAPXenIqSeRrg0Rvg=",
     "h1:G3tv8Dpkp4K+/C57ZSiynDSt28YMcjsSq2p4X7DyF/Q=",
-    "h1:JEozx9d5PEnujcMnfpICHMD1W/qiV/fdAUmS9FKK2SU=",
-    "h1:JptyjHueQzEKiMRH7vRVmtIISzatIf6SBilPtP+LNyY=",
-    "h1:O5jgDugXLb3TN45BaTkE0NKYk7fePJVfGIwroxo42rg=",
-    "h1:ZI5a9q1Ym3fNHr01tEvSPed2G8I5b1nArFfi74NwKmQ=",
-    "h1:h/34cP1zp2GfgoKjUAUcFiEhZFXSJmq1RxhIDLnwybo=",
-    "h1:mTfSMXMzI6QHG/HBffRqtzS7teOwgbApxHyu4ky/NGI=",
-    "h1:sXROdaFzkbF2/Mt2lSXncjt/mYtFFMIglgWs62BJ+Qc=",
-    "h1:t1KtHaHQE0WAbUc61QWgFZr28XcRLf0LuBMHwOpTuvw=",
-    "h1:vGF8y2QQNorYPSWLtnrraz5awpEHpS5iWWhN9aiLG0A=",
-    "h1:xca19WFxcUHack3v8okgo5G97G5kSnH0CMaOwK1CISU=",
+    "zh:007de8fe963c3d70d2718e86e3e3acfaa891fb5fa935ec6b671d4927ac031694",
+    "zh:17e0e381a903832b3e4c07631e2f0c26815c1aaf78c8bf9ac1858a1cdead058d",
+    "zh:23bb3cb85a81be5feee7e629f400b88f414d6192eb8b2cb1da8fe5ccb9347ebb",
+    "zh:27b4abfaaf93028a1a4bbada5ebfb4a5ee9f01a353d3ceebda9cd0061d5ea8e8",
+    "zh:5b21d05712d8bf069ca85863b788562ff60d69b5e565301e1a3f21ef4008a096",
+    "zh:65c2886af6a70b244b27ee5ad74f740b7f14e8e75aa6f10ecb9be8c5731c00ff",
+    "zh:6c173650d8855f210cec289e7782877c5206c357c4e8bc7c7bf334e3a0448e1a",
+    "zh:7e1f16d3db2a7c948aba633194f299893bfd502be2b4d4363e2ab9982d3b808d",
+    "zh:9bd9e8aef498023de41c88607d12ca06f7146a7f16aaa2790744585f4f87ae2a",
+    "zh:b83eabdf62e883066c69176c73ca68ed2f67ae12df4ccee47233441daaaf43a8",
+    "zh:bc0af4a94a26ab772e58e2ca800ed5a5457353c9716fa5a2e758576344732176",
+    "zh:c7d46136d12dce052f1ad985db8c6bf2a83914c035c7ee0ff9c2489f2cad1584",
+    "zh:e40e59291032e67cf25e0d27fc0154b98014f4bf45248d71e1a205c0fcea1c57",
   ]
 }

--- a/terraform/environment/region/modules/event_received/lambda.tf
+++ b/terraform/environment/region/modules/event_received/lambda.tf
@@ -38,29 +38,6 @@ resource "aws_cloudwatch_event_target" "receive_events" {
   provider       = aws.region
 }
 
-resource "aws_cloudwatch_event_rule" "s3_object_tags_added" {
-  name           = "${data.aws_default_tags.current.tags.environment-name}-s3-object-tags-added"
-  description    = "S3 Object Tags Added"
-  event_bus_name = "default"
-
-  event_pattern = jsonencode({
-    source      = ["aws.s3"],
-    detail-type = ["Object Tags Added"],
-    detail = {
-      bucketName = [var.uploads_bucket.bucket]
-    }
-  })
-  provider = aws.region
-}
-
-resource "aws_cloudwatch_event_target" "s3_object_tags_added" {
-  target_id      = "${data.aws_default_tags.current.tags.environment-name}-s3-object-tags-added"
-  event_bus_name = "default"
-  rule           = aws_cloudwatch_event_rule.s3_object_tags_added.name
-  arn            = module.event_received.lambda.arn
-  provider       = aws.region
-}
-
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_event_received" {
   statement_id   = "AllowExecutionFromCloudWatch"
   action         = "lambda:InvokeFunction"

--- a/terraform/environment/region/modules/event_received/outputs.tf
+++ b/terraform/environment/region/modules/event_received/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_function" {
+  value = module.event_received.lambda
+}

--- a/terraform/environment/region/modules/s3_antivirus/s3.tf
+++ b/terraform/environment/region/modules/s3_antivirus/s3.tf
@@ -1,11 +1,18 @@
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  count  = var.enable_autoscan ? 1 : 0
-  bucket = var.data_store_bucket.id
+  count       = var.enable_autoscan ? 1 : 0
+  bucket      = var.data_store_bucket.id
+  eventbridge = true
 
   lambda_function {
     id                  = "bucket-av-scan"
     lambda_function_arn = aws_lambda_function.lambda_function.arn
     events              = ["s3:ObjectCreated:Put"]
+  }
+
+  lambda_function {
+    id                  = "av-object-tagging"
+    lambda_function_arn = var.events_received_lambda_function_arn
+    events              = ["s3:ObjectTagging:Put"]
   }
 
   depends_on = [

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -34,3 +34,7 @@ variable "environment_variables" {
 variable "lambda_task_role" {
   description = "Execution role for Lambda"
 }
+
+variable "events_received_lambda_function_arn" {
+  description = "Lambda function ARN for events received"
+}

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -15,14 +15,15 @@ data "aws_s3_bucket" "antivirus_definitions" {
 }
 
 module "s3_antivirus" {
-  source              = "./modules/s3_antivirus"
-  alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
-  aws_subnet_ids      = data.aws_subnet.application.*.id
-  data_store_bucket   = module.uploads_s3_bucket.bucket
-  definition_bucket   = data.aws_s3_bucket.antivirus_definitions
-  ecr_image_uri       = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
-  enable_autoscan     = true
-  lambda_task_role    = var.iam_roles.s3_antivirus
+  source                              = "./modules/s3_antivirus"
+  alarm_sns_topic_arn                 = data.aws_sns_topic.custom_cloudwatch_alarms.arn
+  aws_subnet_ids                      = data.aws_subnet.application.*.id
+  data_store_bucket                   = module.uploads_s3_bucket.bucket
+  definition_bucket                   = data.aws_s3_bucket.antivirus_definitions
+  ecr_image_uri                       = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
+  enable_autoscan                     = true
+  lambda_task_role                    = var.iam_roles.s3_antivirus
+  events_received_lambda_function_arn = module.event_received.lambda_function.arn
 
   environment_variables = {
     ANTIVIRUS_DEFINITIONS_BUCKET = data.aws_s3_bucket.antivirus_definitions.id


### PR DESCRIPTION
# Purpose

Events were not making it to the lambda function through eventbridge

Fixes MLPAB-1506

## Approach

- Pass events received lambda function into S3 antivirus config
- Add notification for object logging to events received lambda

I will later on evaluate refactoring the notification into the bucket module itself

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification#trigger-multiple-lambda-functions