### PR TITLE
MLPAB-1513 - Do not allow End of Workflow to be skipped

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -157,7 +157,6 @@ jobs:
 
   end_of_pr_workflow:
     name: End of PR Workflow
-    if: success(needs.ui_tests_pr_env)
     runs-on: ubuntu-latest
     environment:
       name: "dev_${{ needs.create_tags.outputs.environment_workspace_name }}"

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -170,8 +170,8 @@ jobs:
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
           if
-            echo needs.ui_tests_pr_env.result
-            needs.ui_tests_pr_env.result == 'success'
+            echo ${{ needs.ui_tests_pr_env.result }}
+            ${{ needs.ui_tests_pr_env.result }} == 'success'
           then
             echo "PR environment tested, built and deployed"
             exit 0

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -170,10 +170,11 @@ jobs:
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
           if
-            echo ${{ needs.ui_tests_pr_env.result }}
             ${{ needs.ui_tests_pr_env.result }} == 'success'
           then
             echo "PR environment tested, built and deployed"
             exit 0
+          else
+            echo "PR environment tested, built and deployed but UI tests failed"
+            exit 1
           fi
-          exit 1

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -170,6 +170,7 @@ jobs:
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
           if
+            echo needs.ui_tests_pr_env.result
             needs.ui_tests_pr_env.result == 'success'
           then
             echo "PR environment tested, built and deployed"

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -169,7 +169,7 @@ jobs:
           echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
-          if true
+          if ${{ contains(needs.ui_tests_pr_env.result,'success') }}
           then
             echo "PR environment tested, built and deployed"
             exit 0

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -169,7 +169,7 @@ jobs:
           echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
-          if [${{ needs.ui_tests_pr_env.result }}  == 'success' ]
+          if true
           then
             echo "PR environment tested, built and deployed"
             exit 0

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -158,9 +158,7 @@ jobs:
   end_of_pr_workflow:
     name: End of PR Workflow
     if: always() &&
-      needs.pr_deploy.result == 'success' &&
-      needs.create_tags.result == 'success' &&
-      needs.ui_tests_pr_env.result == 'success'
+      success(ui_tests_pr_env)
     runs-on: ubuntu-latest
     environment:
       name: "dev_${{ needs.create_tags.outputs.environment_workspace_name }}"

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -96,7 +96,7 @@ jobs:
     with:
       run_against_image: true
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      smoke: ${{ contains(fromJSON('["MLPAB-1419-use-a-single-persistent-environment-for-weblate-changes-optimise-workflow", "weblate-pr"]'), github.head_ref) }}
+      smoke: ${{ contains(fromJSON('["weblate-pr"]'), github.head_ref) }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -157,8 +157,7 @@ jobs:
 
   end_of_pr_workflow:
     name: End of PR Workflow
-    if: always() &&
-      success(ui_tests_pr_env)
+    if: success(ui_tests_pr_env)
     runs-on: ubuntu-latest
     environment:
       name: "dev_${{ needs.create_tags.outputs.environment_workspace_name }}"

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -157,7 +157,7 @@ jobs:
 
   end_of_pr_workflow:
     name: End of PR Workflow
-    if: success(ui_tests_pr_env)
+    if: success(needs.ui_tests_pr_env)
     runs-on: ubuntu-latest
     environment:
       name: "dev_${{ needs.create_tags.outputs.environment_workspace_name }}"

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -169,8 +169,7 @@ jobs:
           echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
-          if
-            ${{ needs.ui_tests_pr_env.result }} == 'success'
+          if [${{ needs.ui_tests_pr_env.result }}  == 'success' ]
           then
             echo "PR environment tested, built and deployed"
             exit 0

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -169,4 +169,10 @@ jobs:
           echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
+          if
+            needs.ui_tests_pr_env.result == 'success'
+          then
+            echo "PR environment tested, built and deployed"
+            exit 0
+          fi
           exit 1

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -158,6 +158,7 @@ jobs:
   end_of_pr_workflow:
     name: End of PR Workflow
     runs-on: ubuntu-latest
+    if: always()
     environment:
       name: "dev_${{ needs.create_tags.outputs.environment_workspace_name }}"
       url: "https://${{ needs.pr_deploy.outputs.url }}"
@@ -168,3 +169,4 @@ jobs:
           echo "${{ needs.pr_deploy.outputs.terraform_workspace_name }} PR environment tested, built and deployed"
           echo "Tag Deployed: ${{ needs.pr_deploy.outputs.terraform_container_version }}"
           echo "URL: https://${{ needs.pr_deploy.outputs.url }}"
+          exit 1

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -1,5 +1,5 @@
 {
-    "cookiesOn": "Cwcis ar Gwneud atwrneiaeth arhosol'",
+    "cookiesOn": "Cwcis ar Gwneud atwrneiaeth arhosol",
     "cookiesContent": "<p class=\"govuk-body\">Rydym yn defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.</p><p class=\"govuk-body\">Hoffem hefyd ddefnyddio cwcis dadansoddeg i ddeall sut rydych yn defnyddio’r gwasanaeth a gwneud gwelliannau.</p>",
     "acceptCookies": "Derbyn cwcis dadansoddeg",
     "rejectCookies": "Gwrthod cwcis dadansoddol",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -1,5 +1,5 @@
 {
-    "cookiesOn": "Cwcis ar Gwneud atwrneiaeth arhosol",
+    "cookiesOn": "Cwcis ar Gwneud atwrneiaeth arhosol'",
     "cookiesContent": "<p class=\"govuk-body\">Rydym yn defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.</p><p class=\"govuk-body\">Hoffem hefyd ddefnyddio cwcis dadansoddeg i ddeall sut rydych yn defnyddio’r gwasanaeth a gwneud gwelliannau.</p>",
     "acceptCookies": "Derbyn cwcis dadansoddeg",
     "rejectCookies": "Gwrthod cwcis dadansoddol",


### PR DESCRIPTION
# Purpose

If the End of Workflow job gets a status of skipped, it will count as successful and allow a PR to be merged

Fixes MLPAB-1513

## Approach

- Use success of the preceding important job
- Exit 0 if successful
- Exit 1 if not

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
