### PR TITLE
MLPAB-1420 - Change max upload size to match Sirius WAF

### DIFF
--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -118,7 +118,7 @@ resource "aws_wafv2_web_acl" "main" {
     statement {
       size_constraint_statement {
         comparison_operator = "GT"
-        size                = 33554432
+        size                = 104857600
 
         field_to_match {
           body {


### PR DESCRIPTION
# Purpose

Allow total maximum upload size at WAF (5 documents x 20MB each)

Fixes MLPAB-1420

## Approach

- set size constraint to 100 megabytes (in bytes)

## Learning

- https://docs.aws.amazon.com/waf/latest/developerguide/waf-oversize-request-components.html
- https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-size-constraint-match.html