### PR TITLE
MLPAB-1515 - Add provisioned concurrency for S3 AV Lambda

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Briefly describe the purpose of the change, and/or link to the JIRA ticket for context
 
-Fixes MLPAB-####
+Fixes MLPAB-##
 
 ## Approach
 
@@ -11,14 +11,3 @@ Explain how your code addresses the purpose of the change
 ## Learning
 
 Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
-
-## Checklist
-
-* [ ] I have performed a self-review of my own code
-* [ ] I have added relevant logging with appropriate levels to my code
-* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
-* [ ] I have added tests to prove my work
-* [ ] I have added welsh translation tags and updated translation files
-* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
-* [ ] The product team have tested these changes
-* [ ] Changes to Github Actions jobs have been checked for all workflows

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -46,7 +46,7 @@ data "aws_security_group" "lambda_egress" {
 resource "aws_lambda_alias" "lambda_alias" {
   name             = "latest"
   function_name    = aws_lambda_function.lambda_function.function_name
-  function_version = aws_lambda_function.lambda_function.version
+  function_version = "$LATEST"
   provider         = aws.region
 }
 

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -17,6 +17,7 @@ resource "aws_lambda_function" "lambda_function" {
   role          = var.lambda_task_role.arn
   timeout       = 300
   memory_size   = 4096
+  publish       = true
 
   tracing_config {
     mode = "Active"
@@ -46,7 +47,7 @@ data "aws_security_group" "lambda_egress" {
 resource "aws_lambda_alias" "lambda_alias" {
   name             = "latest"
   function_name    = aws_lambda_function.lambda_function.function_name
-  function_version = "$LATEST"
+  function_version = aws_lambda_function.lambda_function.version
   provider         = aws.region
 }
 

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -42,3 +42,10 @@ data "aws_security_group" "lambda_egress" {
   name     = "lambda-egress-${data.aws_region.current.name}"
   provider = aws.region
 }
+
+resource "aws_lambda_provisioned_concurrency_config" "main" {
+  count                             = var.s3_antivirus_provisioned_concurrency > 0 ? 1 : 0
+  function_name                     = aws_lambda_function.lambda_function.function_name
+  provisioned_concurrent_executions = var.s3_antivirus_provisioned_concurrency
+  qualifier                         = aws_lambda_function.lambda_function.function_name
+}

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -43,10 +43,17 @@ data "aws_security_group" "lambda_egress" {
   provider = aws.region
 }
 
+resource "aws_lambda_alias" "test_lambda_alias" {
+  name             = "latest"
+  function_name    = aws_lambda_function.lambda_function.function_name
+  function_version = aws.lambda_function.lambda_function.version
+  provider         = aws.region
+}
+
 resource "aws_lambda_provisioned_concurrency_config" "main" {
   count                             = var.s3_antivirus_provisioned_concurrency > 0 ? 1 : 0
-  function_name                     = aws_lambda_function.lambda_function.function_name
+  function_name                     = aws_lambda_alias.test_lambda_alias.function_name
   provisioned_concurrent_executions = var.s3_antivirus_provisioned_concurrency
-  qualifier                         = aws_lambda_function.lambda_function.function_name
+  qualifier                         = aws_lambda_alias.test_lambda_alias.name
   provider                          = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -43,17 +43,17 @@ data "aws_security_group" "lambda_egress" {
   provider = aws.region
 }
 
-resource "aws_lambda_alias" "test_lambda_alias" {
+resource "aws_lambda_alias" "lambda_alias" {
   name             = "latest"
   function_name    = aws_lambda_function.lambda_function.function_name
-  function_version = aws.lambda_function.lambda_function.version
+  function_version = aws_lambda_function.lambda_function.version
   provider         = aws.region
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "main" {
   count                             = var.s3_antivirus_provisioned_concurrency > 0 ? 1 : 0
-  function_name                     = aws_lambda_alias.test_lambda_alias.function_name
+  function_name                     = aws_lambda_alias.lambda_alias.function_name
   provisioned_concurrent_executions = var.s3_antivirus_provisioned_concurrency
-  qualifier                         = aws_lambda_alias.test_lambda_alias.name
+  qualifier                         = aws_lambda_alias.lambda_alias.name
   provider                          = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -48,4 +48,5 @@ resource "aws_lambda_provisioned_concurrency_config" "main" {
   function_name                     = aws_lambda_function.lambda_function.function_name
   provisioned_concurrent_executions = var.s3_antivirus_provisioned_concurrency
   qualifier                         = aws_lambda_function.lambda_function.function_name
+  provider                          = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -34,3 +34,9 @@ variable "environment_variables" {
 variable "lambda_task_role" {
   description = "Execution role for Lambda"
 }
+
+variable "s3_antivirus_provisioned_concurrency" {
+  description = "Number of concurrent executions to provision for Lambda"
+  type        = number
+  default     = 0
+}

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -38,5 +38,4 @@ variable "lambda_task_role" {
 variable "s3_antivirus_provisioned_concurrency" {
   description = "Number of concurrent executions to provision for Lambda"
   type        = number
-  default     = 0
 }

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -15,14 +15,15 @@ data "aws_s3_bucket" "antivirus_definitions" {
 }
 
 module "s3_antivirus" {
-  source              = "./modules/s3_antivirus"
-  alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
-  aws_subnet_ids      = data.aws_subnet.application.*.id
-  data_store_bucket   = module.uploads_s3_bucket.bucket
-  definition_bucket   = data.aws_s3_bucket.antivirus_definitions
-  ecr_image_uri       = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
-  enable_autoscan     = true
-  lambda_task_role    = var.iam_roles.s3_antivirus
+  source                               = "./modules/s3_antivirus"
+  alarm_sns_topic_arn                  = data.aws_sns_topic.custom_cloudwatch_alarms.arn
+  aws_subnet_ids                       = data.aws_subnet.application.*.id
+  data_store_bucket                    = module.uploads_s3_bucket.bucket
+  definition_bucket                    = data.aws_s3_bucket.antivirus_definitions
+  ecr_image_uri                        = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"
+  enable_autoscan                      = true
+  lambda_task_role                     = var.iam_roles.s3_antivirus
+  s3_antivirus_provisioned_concurrency = var.s3_antivirus_provisioned_concurrency
 
   environment_variables = {
     ANTIVIRUS_DEFINITIONS_BUCKET = data.aws_s3_bucket.antivirus_definitions.id

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -96,3 +96,9 @@ variable "receive_account_ids" {
   description = "IDs of accounts to receive messages from"
   default     = []
 }
+
+variable "s3_antivirus_provisioned_concurrency" {
+  type        = number
+  description = "Number of concurrent executions to provision for Lambda"
+  default     = 0
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -101,4 +101,8 @@ variable "s3_antivirus_provisioned_concurrency" {
   type        = number
   description = "Number of concurrent executions to provision for Lambda"
   default     = 0
+  validation {
+    condition     = var.s3_antivirus_provisioned_concurrency >= 0 && var.s3_antivirus_provisioned_concurrency <= 6
+    error_message = "s3_antivirus_provisioned_concurrency must be between 0 and 6"
+  }
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -34,13 +34,14 @@ module "eu_west_1" {
     destination_account_id                    = local.environment.reduced_fees.destination_account_id
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
-  target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
-  receive_account_ids    = local.environment.event_bus.receive_account_ids
-  app_env_vars           = local.environment.app.env
-  app_allowed_api_arns   = local.environment.app.allowed_api_arns
-  public_access_enabled  = var.public_access_enabled
-  pagerduty_service_name = local.environment.pagerduty_service_name
-  dns_weighting          = 100
+  target_event_bus_arn                 = local.environment.event_bus.target_event_bus_arn
+  receive_account_ids                  = local.environment.event_bus.receive_account_ids
+  app_env_vars                         = local.environment.app.env
+  app_allowed_api_arns                 = local.environment.app.allowed_api_arns
+  public_access_enabled                = var.public_access_enabled
+  pagerduty_service_name               = local.environment.pagerduty_service_name
+  dns_weighting                        = 100
+  s3_antivirus_provisioned_concurrency = local.environment.s3_antivirus_provisioned_concurrency
   providers = {
     aws.region            = aws.eu_west_1
     aws.global            = aws.global
@@ -76,13 +77,14 @@ module "eu_west_2" {
     destination_account_id                    = local.environment.reduced_fees.destination_account_id
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
-  target_event_bus_arn   = local.environment.event_bus.target_event_bus_arn
-  receive_account_ids    = local.environment.event_bus.receive_account_ids
-  app_env_vars           = local.environment.app.env
-  app_allowed_api_arns   = local.environment.app.allowed_api_arns
-  public_access_enabled  = var.public_access_enabled
-  pagerduty_service_name = local.environment.pagerduty_service_name
-  dns_weighting          = 0
+  target_event_bus_arn                 = local.environment.event_bus.target_event_bus_arn
+  receive_account_ids                  = local.environment.event_bus.receive_account_ids
+  app_env_vars                         = local.environment.app.env
+  app_allowed_api_arns                 = local.environment.app.allowed_api_arns
+  public_access_enabled                = var.public_access_enabled
+  pagerduty_service_name               = local.environment.pagerduty_service_name
+  dns_weighting                        = 0
+  s3_antivirus_provisioned_concurrency = local.environment.s3_antivirus_provisioned_concurrency
   providers = {
     aws.region            = aws.eu_west_2
     aws.global            = aws.global

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -57,7 +57,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "testevents": {
       "account_id": "653761790766",
@@ -116,7 +117,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": true
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "demo": {
       "account_id": "653761790766",
@@ -175,7 +177,8 @@
         "target_environment": "integration",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": true
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "ur": {
       "account_id": "653761790766",
@@ -234,7 +237,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "preproduction": {
       "account_id": "792093328875",
@@ -293,7 +297,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "production": {
       "account_id": "313879017102",
@@ -352,7 +357,8 @@
         "target_environment": "dev",
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
-      }
+      },
+      "s3_antivirus_provisioned_concurrency": 0
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
       },
-      "s3_antivirus_provisioned_concurrency": 1
+      "s3_antivirus_provisioned_concurrency": 0
     },
     "testevents": {
       "account_id": "653761790766",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
         "destination_account_id": "288342028542",
         "enable_s3_batch_job_replication_scheduler": false
       },
-      "s3_antivirus_provisioned_concurrency": 0
+      "s3_antivirus_provisioned_concurrency": 1
     },
     "testevents": {
       "account_id": "653761790766",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -79,6 +79,7 @@ variable "environments" {
         destination_account_id                    = string
         enable_s3_batch_job_replication_scheduler = bool
       })
+      s3_antivirus_provisioned_concurrency = number
     })
   )
 }


### PR DESCRIPTION
# Purpose

Reduce the impact of cold starts on users

Fixes MLPAB-1515

## Approach

- Create provisioned concurrency
- add validation to variable so that maximum concurrency isn't accidentally set too high
- Also, remove checklist from PR template

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_provisioned_concurrency_config
- https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html?icmpid=docs_lambda_console
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#publish