### PR TITLE
MLPAB-1575 - add pagerduty key for ur public access job

### DIFF
--- a/.github/workflows/dispatch_manage_public_access_ur_environment.yml
+++ b/.github/workflows/dispatch_manage_public_access_ur_environment.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Terraform Toggle Public Access for UR
         env:
           TF_WORKSPACE: ur
+          TF_VAR_pagerduty_api_key: ${{ secrets.pagerduty_api_key }}
         run: |
           terraform apply -lock-timeout=300s  -input=false -auto-approve -var public_access_enabled=${{ inputs.public_access_enabled }} -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress[0]'
         working-directory: ./terraform/environment


### PR DESCRIPTION
# Purpose

Toggle public access job fails due to missing pagerduty credentials

Fixes MLPAB-1575

## Approach

- Add pagerduty key
