### PR TITLE
MLPAB-1366 - Use CMK for manifests storage

### DIFF
--- a/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
@@ -15,7 +15,7 @@ data "aws_s3_bucket" "access_logging" {
   provider = aws.region
 }
 
-data "aws_kms_alias" "reduced_fees_uploads_s3_alias" {
+data "aws_kms_alias" "s3_encryption_kms_key_alias" {
   name     = var.s3_encryption_kms_key_alias
   provider = aws.region
 }

--- a/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
@@ -14,3 +14,8 @@ data "aws_s3_bucket" "access_logging" {
   bucket   = "s3-access-logs-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}"
   provider = aws.region
 }
+
+data "aws_kms_alias" "reduced_fees_uploads_s3_alias" {
+  name     = var.reduced_fees_uploads_s3_encryption_kms_key_alias
+  provider = aws.region
+}

--- a/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/data_sources.tf
@@ -16,6 +16,6 @@ data "aws_s3_bucket" "access_logging" {
 }
 
 data "aws_kms_alias" "reduced_fees_uploads_s3_alias" {
-  name     = var.reduced_fees_uploads_s3_encryption_kms_key_alias
+  name     = var.s3_encryption_kms_key_alias
   provider = aws.region
 }

--- a/terraform/account/region/modules/s3_batch_manifests/s3.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/s3.tf
@@ -7,7 +7,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = data.aws_kms_alias.reduced_fees_uploads_s3_alias.target_key_id
     }
   }
   provider = aws.region

--- a/terraform/account/region/modules/s3_batch_manifests/s3.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/s3.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"
-      kms_master_key_id = data.aws_kms_alias.reduced_fees_uploads_s3_alias.target_key_id
+      kms_master_key_id = data.aws_kms_alias.s3_encryption_kms_key_alias.target_key_id
     }
   }
   provider = aws.region

--- a/terraform/account/region/modules/s3_batch_manifests/variables.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/variables.tf
@@ -1,0 +1,4 @@
+variable "s3_encryption_kms_key_alias" {
+  description = "The alias of the KMS key used to encrypt the reduced fees uploads S3 bucket and replication manifests"
+  type        = string
+}

--- a/terraform/account/region/s3_batch_manifests.tf
+++ b/terraform/account/region/s3_batch_manifests.tf
@@ -1,5 +1,6 @@
 module "s3_batch_manifests" {
-  source = "./modules/s3_batch_manifests"
+  source                      = "./modules/s3_batch_manifests"
+  s3_encryption_kms_key_alias = var.reduced_fees_uploads_s3_encryption_kms_key_alias
   providers = {
     aws.region = aws.region
   }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -18,3 +18,8 @@ variable "secrets_manager_kms_key_alias" {
   description = "The alias of the KMS key used to encrypt Secrets Manager secrets"
   type        = string
 }
+
+variable "reduced_fees_uploads_s3_encryption_kms_key_alias" {
+  description = "The alias of the KMS key used to encrypt the reduced fees uploads S3 bucket and replication manifests"
+  type        = string
+}

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,10 +1,11 @@
 module "eu_west_1" {
-  source                             = "./region"
-  count                              = contains(local.account.regions, "eu-west-1") ? 1 : 0
-  network_cidr_block                 = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias = aws_kms_alias.cloudwatch_alias_eu_west_1.name
-  sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_1.name
-  secrets_manager_kms_key_alias      = aws_kms_alias.secrets_manager_alias_eu_west_1.name
+  source                                           = "./region"
+  count                                            = contains(local.account.regions, "eu-west-1") ? 1 : 0
+  network_cidr_block                               = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_1.name
+  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_1.name
+  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_1.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1.name
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
@@ -13,12 +14,13 @@ module "eu_west_1" {
 }
 
 module "eu_west_2" {
-  source                             = "./region"
-  count                              = contains(local.account.regions, "eu-west-2") ? 1 : 0
-  network_cidr_block                 = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias = aws_kms_alias.cloudwatch_alias_eu_west_2.name
-  sns_kms_key_alias                  = aws_kms_alias.sns_alias_eu_west_2.name
-  secrets_manager_kms_key_alias      = aws_kms_alias.secrets_manager_alias_eu_west_2.name
+  source                                           = "./region"
+  count                                            = contains(local.account.regions, "eu-west-2") ? 1 : 0
+  network_cidr_block                               = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_2.name
+  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_2.name
+  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_2.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_2.name
   providers = {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2

--- a/terraform/environment/region/modules/lambda/variables.tf
+++ b/terraform/environment/region/modules/lambda/variables.tf
@@ -62,6 +62,6 @@ variable "kms_key" {
 
 variable "iam_policy_documents" {
   description = "List of IAM policy documents that are merged together. Documents later in the list override earlier ones"
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-1366 MLPAB-1580

## Approach

- MLPAB-1580 format variables file
- Use uploads bucket encryption key to encrypt manifests bucket
