### PR TITLE
MLAB-1501 - Use a dead letter queue for failed put-events to Sirius

### DIFF
--- a/terraform/environment/region/modules/event_bus/data_sources.tf
+++ b/terraform/environment/region/modules/event_bus/data_sources.tf
@@ -1,0 +1,4 @@
+data "aws_sns_topic" "custom_cloudwatch_alarms" {
+  name     = "custom-cloudwatch-alarms"
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/event_bus/data_sources.tf
+++ b/terraform/environment/region/modules/event_bus/data_sources.tf
@@ -1,4 +1,4 @@
 data "aws_sns_topic" "custom_cloudwatch_alarms" {
-  name     = "custom-cloudwatch-alarms"
+  name     = "custom_cloudwatch_alarms"
   provider = aws.region
 }

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -50,8 +50,8 @@ resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "Alarm if dead letter queue has messages"
-  # alarm_actions       = [aws_sns_topic.event_bus_dead_letter_queue.arn]
-  provider = aws.region
+  alarm_actions       = [data.aws_sns_topic.custom_cloudwatch_alarms.arn]
+  provider            = aws.region
 }
 
 # Send event to remote account event bus

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   period              = 60
   statistic           = "Sum"
   threshold           = 1
-  alarm_description   = "Alarm if dead letter queue has messages"
+  alarm_description   = "${data.aws_default_tags.current.tags.environment-name} event bus dead letter queue has messages"
   alarm_actions       = [data.aws_sns_topic.custom_cloudwatch_alarms.arn]
   provider            = aws.region
 }

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -40,6 +40,10 @@ data "aws_iam_policy_document" "cross_account_put_access" {
   statement {
     sid    = "DeadLetterQueueAccess"
     effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
     actions = [
       "sqs:SendMessage",
     ]

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -11,6 +11,12 @@ resource "aws_cloudwatch_event_archive" "main" {
   provider         = aws.region
 }
 
+resource "aws_sqs_queue" "main" {
+  name                              = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
+  kms_master_key_id                 = "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = 300
+}
+
 # Send event to remote account event bus
 
 resource "aws_iam_role_policy" "cross_account_put" {
@@ -79,4 +85,3 @@ resource "aws_cloudwatch_event_bus_policy" "cross_account_receive" {
   policy         = data.aws_iam_policy_document.cross_account_receive.json
   provider       = aws.region
 }
-

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -11,9 +11,9 @@ resource "aws_cloudwatch_event_archive" "main" {
   provider         = aws.region
 }
 
-resource "aws_sqs_queue" "main" {
+resource "aws_sqs_queue" "event_bus_dead_letter_queue" {
   name                              = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
-  kms_master_key_id                 = "alias/aws/sqs"
+  kms_master_key_id                 = "alias/aws/sqs" #tfsec:ignore:aws-sqs-queue-encryption-use-cmk
   kms_data_key_reuse_period_seconds = 300
   policy                            = data.aws_iam_policy_document.sqs.json
   provider                          = aws.region
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_event_target" "cross_account_put" {
   event_bus_name = aws_cloudwatch_event_bus.main.name
   arn            = var.target_event_bus_arn
   dead_letter_config {
-    arn = aws_sqs_queue.main.arn
+    arn = aws_sqs_queue.event_bus_dead_letter_queue.arn
   }
   rule     = aws_cloudwatch_event_rule.cross_account_put.name
   role_arn = var.iam_role.arn

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -15,6 +15,7 @@ resource "aws_sqs_queue" "main" {
   name                              = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = 300
+  provider                          = aws.region
 }
 
 # Send event to remote account event bus

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -40,6 +40,20 @@ data "aws_iam_policy_document" "sqs" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
+  alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Alarm if dead letter queue has messages"
+  # alarm_actions       = [aws_sns_topic.event_bus_dead_letter_queue.arn]
+  provider = aws.region
+}
+
 # Send event to remote account event bus
 
 resource "aws_iam_role_policy" "cross_account_put" {


### PR DESCRIPTION
# Purpose

Capture failed events so they can be retried

Fixes MLPAB-1501

## Approach

- create a SQS dead letter queue for the environment event bus
- create alarm for more than 1 item (approx) in the queue

## Learning

- https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#dead_letter_config