### PR TITLE
MLPAB-1579 - Expire objects that have been replicated

### DIFF
--- a/terraform/environment/region/modules/uploads_s3_bucket/s3_bucket_lifecycles.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/s3_bucket_lifecycles.tf
@@ -18,5 +18,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "main" {
     status = "Enabled"
   }
 
+  rule {
+    id = "delete-objects-replicated-to-sirius"
+
+    filter {
+      tag {
+        key   = "replicate"
+        value = "true"
+      }
+    }
+
+    expiration {
+      days = "30"
+    }
+
+    status = "Enabled"
+  }
+
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Keep storage down and only hold documents as long as we need them

Fixes MLPAB-1579

## Approach

- add rule to expire objects with `replicate=true` after 30 days

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html
