### PR TITLE
MLPAB-1628 - Don't run destroy job when weblate PRs close

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - '!weblate-pr'
     types:
       - closed
 


### PR DESCRIPTION
# Purpose

The Weblate environment shouldn't be destroyed. When Weblate PRs close the destroy environment workflow runs and fails because the calculated name for environment it tries to destroy doesn't exist, and the Weblate environment is protected.

Fixes MLPAB-1628

## Approach

- Don't run the workflow when the weblate pr closes

## Learning

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-branches
