### PR TITLE
MLPAB-1657 - Notify team when a lambda function has unepected errors

### DIFF
--- a/terraform/environment/region/modules/lambda/alarms.tf
+++ b/terraform/environment/region/modules/lambda/alarms.tf
@@ -1,0 +1,21 @@
+data "aws_sns_topic" "custom_cloudwatch_alarms" {
+  name     = "custom_cloudwatch_alarms"
+  provider = aws.region
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_function_failures" {
+  alarm_name          = "${var.lambda_name}-${var.environment}-failures"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "This metric monitors the number of errors that occur in the lambda function"
+  alarm_actions       = [data.aws_sns_topic.custom_cloudwatch_alarms.arn]
+  dimensions = {
+    FunctionName = "${var.lambda_name}-${var.environment}"
+  }
+  provider = aws.region
+}


### PR DESCRIPTION
# Purpose

If lambda functions the service depends on fail, the team need to know. 

Fixes MLPAB-1657

## Approach

- Create a metric alarm for lambda function errors
- set the threshold low due to low use of features in environments
- Use custom cloudwatch alarms sns topic to forward alert via pagerduty to team