### PR TITLE
MLPAB-1571 - Run replication job every 20 minutes

### DIFF
--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -66,7 +66,7 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
     mode = "OFF"
   }
 
-  schedule_expression = "rate(2 minutes)"
+  schedule_expression = "rate(20 minutes)"
   state               = var.s3_replication.enable_s3_batch_job_replication_scheduler ? "ENABLED" : "DISABLED"
 
   target {


### PR DESCRIPTION
# Purpose

This is to reduce the cost of S3 batch jobs

Fixes MLPAB-1571

## Approach

- Set schedule that triggers lambda to run every 20 minutes