### PR TITLE
MLPAB-1585 - Create customer managed encryption key for sqs

### DIFF
--- a/terraform/account/sqs_kms.tf
+++ b/terraform/account/sqs_kms.tf
@@ -1,0 +1,169 @@
+resource "aws_kms_key" "sqs" {
+  description             = "${local.default_tags.application} SQS encryption key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.sns_kms_merged.json : data.aws_iam_policy_document.sns_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+}
+
+resource "aws_kms_replica_key" "sqs_replica" {
+  description             = "${local.default_tags.application} SQS multi-region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.sqs.arn
+  provider                = aws.eu_west_2
+}
+
+resource "aws_kms_alias" "sqs_alias_eu_west_1" {
+  name          = "alias/${local.default_tags.application}_sqs_secret_encryption_key"
+  target_key_id = aws_kms_key.sqs.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "sqs_alias_eu_west_2" {
+  name          = "alias/${local.default_tags.application}_sqs_secret_encryption_key"
+  target_key_id = aws_kms_replica_key.sqs_replica.key_id
+  provider      = aws.eu_west_2
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "sqs_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.sqs_kms.json,
+    data.aws_iam_policy_document.sqs_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "sqs_kms" {
+  provider = aws.global
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_iam_role.aws_backup_role.arn,
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "sqs.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:List*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sqs_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid    = "Dev Account Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Purpose

Use customer managed encryption for better control over usage

Fixes MLPAB-1585

## Approach

- create cmk for SQS

## Learning

https://aquasecurity.github.io/tfsec/v1.28.4/checks/aws/sqs/queue-encryption-use-cmk/