### PR TITLE
MLPAB-1585 - Use CMK for SQS

### DIFF
--- a/terraform/account/sqs_kms.tf
+++ b/terraform/account/sqs_kms.tf
@@ -52,9 +52,9 @@ data "aws_iam_policy_document" "sqs_kms" {
     ]
 
     principals {
-      type = "AWS"
+      type = "Service"
       identifiers = [
-        aws_iam_role.aws_backup_role.arn,
+        "events.amazonaws.com"
       ]
     }
   }

--- a/terraform/account/sqs_kms.tf
+++ b/terraform/account/sqs_kms.tf
@@ -74,7 +74,8 @@ data "aws_iam_policy_document" "sqs_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "sqs.amazonaws.com"
+        "sqs.amazonaws.com",
+        "events.amazonaws.com"
       ]
     }
   }

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -11,9 +11,14 @@ resource "aws_cloudwatch_event_archive" "main" {
   provider         = aws.region
 }
 
+data "aws_kms_alias" "sqs" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_sqs_secret_encryption_key"
+  provider = aws.region
+}
+
 resource "aws_sqs_queue" "event_bus_dead_letter_queue" {
   name                              = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
-  kms_master_key_id                 = "alias/aws/sqs" #tfsec:ignore:aws-sqs-queue-encryption-use-cmk
+  kms_master_key_id                 = data.aws_kms_alias.sqs.target_key_id
   kms_data_key_reuse_period_seconds = 300
   policy                            = data.aws_iam_policy_document.sqs.json
   provider                          = aws.region


### PR DESCRIPTION
# Purpose

Use customer managed encryption for better control over usage

Fixes MLPAB-1585

## Approach

- Use CMK for SQS

## Learning

- https://aquasecurity.github.io/tfsec/v1.28.4/checks/aws/sqs/queue-encryption-use-cmk/