### PR TITLE
MLPAB-1696 - add naming to terraform environment workflow

### DIFF
--- a/.github/workflows/terraform_account_job.yml
+++ b/.github/workflows/terraform_account_job.yml
@@ -16,6 +16,7 @@ on:
         required: true
 jobs:
   terraform_account_workflow:
+    name: "${{ inputs.workspace_name }} account deployment"
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.bump_version.outputs.tag }}

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -57,6 +57,7 @@ permissions:
 
 jobs:
   terraform_environment_workflow:
+    name: "${{ inputs.workspace_name }} environment deployment"
     runs-on: ubuntu-latest
     outputs:
       terraform_workspace_name: ${{ steps.terraform_outputs.outputs.workspace_name }}


### PR DESCRIPTION
# Purpose

Naming on production deploy job was wrong

Fixes MLPAB-1696

## Approach

- Name Production and Demo deploy job correctly
- Use environment name in terraform_environment_workflow
