### PR TITLE
Add security group ingress rule for port :80, to allow ALB to handle redirections for publicly accessible services

### DIFF
--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -200,6 +200,19 @@ resource "aws_security_group_rule" "app_loadbalancer_public_access_ingress" {
   provider          = aws.region
 }
 
+# this has a listener rule in the alb to redirect to :443
+resource "aws_security_group_rule" "app_loadbalancer_public_access_ingress_port_80" {
+  count             = var.public_access_enabled ? 1 : 0
+  description       = "Port 80 production public ingress to the application load balancer"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sgr - open ingress for production
+  security_group_id = aws_security_group.app_loadbalancer.id
+  provider          = aws.region
+}
+
 resource "aws_security_group_rule" "app_loadbalancer_egress" {
   description       = "Allow any egress from service load balancer"
   type              = "egress"


### PR DESCRIPTION
# Purpose

This pull request fixes an issue with the security group configuration. The application load balancer is configured to redirect `http`/`:80` to `https`/`:443`, but the application security group doesn't allow connections via `http`/`:80`.

This work is unticketed.

## Approach

This pull request adds a security group rule to allow connections on `:80` to allow the ALB to handle redirections to `:443`, if public access is enabled (e.g. for the demo app).
