### PR TITLE
MLPAB-1663 - Continuously monitor dependency health checks

### DIFF
--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -53,7 +53,7 @@ module "app" {
   aws_rum_guest_role_arn                               = data.aws_iam_role.rum_monitor_unauthenticated.arn
   rum_monitor_application_id_secretsmanager_secret_arn = aws_secretsmanager_secret.rum_monitor_application_id.id
   uid_base_url                                         = var.uid_service.base_url
-  lpa_store_base_url = var.lpa_store_service.base_url
+  lpa_store_base_url                                   = var.lpa_store_service.base_url
   mock_onelogin_enabled                                = data.aws_default_tags.current.tags.environment-name != "production" && var.mock_onelogin_enabled
   providers = {
     aws.region = aws.region

--- a/terraform/environment/region/healthcheck.tf
+++ b/terraform/environment/region/healthcheck.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_health_check" "health_check" {
+resource "aws_route53_health_check" "service_health_check" {
   fqdn              = aws_route53_record.app.fqdn
   reference_name    = "${substr(data.aws_default_tags.current.tags.environment-name, 0, 20)}-health-check"
   port              = 443
@@ -10,14 +10,15 @@ resource "aws_route53_health_check" "health_check" {
   regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
   provider          = aws.global
   tags = {
-    Name = "${data.aws_default_tags.current.tags.environment-name}-health-check-${data.aws_region.current.name}"
+    Name = "${data.aws_default_tags.current.tags.environment-name}-service-health-check-${data.aws_region.current.name}"
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "health_check" {
-  alarm_description   = "${data.aws_default_tags.current.tags.environment-name} health check for ${data.aws_region.current.name}}"
-  alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-healthcheck-alarm-${data.aws_region.current.name}"
-  actions_enabled     = false
+resource "aws_cloudwatch_metric_alarm" "service_health_check" {
+  alarm_description   = "${data.aws_default_tags.current.tags.environment-name} service health check for ${data.aws_region.current.name}}"
+  alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-health-check-alarm-${data.aws_region.current.name}"
+  alarm_actions       = [aws_sns_topic_subscription.service_health_check]
+  ok_actions          = [aws_sns_topic_subscription.service_health_check]
   comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = 1
   evaluation_periods  = 1
@@ -27,8 +28,72 @@ resource "aws_cloudwatch_metric_alarm" "health_check" {
   statistic           = "Minimum"
   threshold           = 1
   dimensions = {
-    HealthCheckId = aws_route53_health_check.health_check.id
+    HealthCheckId = aws_route53_health_check.service_health_check.id
   }
 
   provider = aws.global
+}
+
+resource "aws_route53_health_check" "dependency_health_check" {
+  fqdn              = aws_route53_record.app.fqdn
+  reference_name    = "${substr(data.aws_default_tags.current.tags.environment-name, 0, 20)}-dependency-health-check"
+  port              = 443
+  type              = "HTTPS"
+  failure_threshold = 1
+  request_interval  = 30
+  resource_path     = "/health-check/dependency"
+  measure_latency   = true
+  regions           = ["us-east-1", "eu-west-1", "ap-southeast-1"]
+  provider          = aws.global
+  tags = {
+    Name = "${data.aws_default_tags.current.tags.environment-name}-dependency-health-check-${data.aws_region.current.name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "dependency_health_check" {
+  alarm_description   = "${data.aws_default_tags.current.tags.environment-name} dependency health check for ${data.aws_region.current.name}}"
+  alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-dependency-health-check-alarm-${data.aws_region.current.name}"
+  alarm_actions       = [aws_sns_topic_subscription.dependency_health_check]
+  ok_actions          = [aws_sns_topic_subscription.dependency_health_check]
+  comparison_operator = "LessThanThreshold"
+  datapoints_to_alarm = 1
+  evaluation_periods  = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.dependency_health_check.id
+  }
+
+  provider = aws.global
+}
+
+resource "pagerduty_service_integration" "service_health_check" {
+  name    = "Modernising LPA ${data.aws_default_tags.current.tags.environment-name} ${data.aws_region.current.name} Service Health Check Alarm"
+  service = data.pagerduty_service.main.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "aws_sns_topic_subscription" "service_health_check" {
+  topic_arn              = data.aws_sns_topic.service_health_check.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.service_health_check.integration_key}/enqueue"
+  provider               = aws.region
+}
+
+resource "pagerduty_service_integration" "dependency_health_check" {
+  name    = "Modernising LPA ${data.aws_default_tags.current.tags.environment-name} ${data.aws_region.current.name} Service Health Check Alarm"
+  service = data.pagerduty_service.main.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "aws_sns_topic_subscription" "dependency_health_check" {
+  topic_arn              = data.aws_sns_topic.service_health_check.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.service_health_check.integration_key}/enqueue"
+  provider               = aws.region
 }


### PR DESCRIPTION
# Purpose

Let the team know when our service cannot reach it's dependencies

Fixes MLPAB-1663

## Approach

- create dependency alarms
- forward service alarms to pagerduty
- forward dependency alarms to pagerduty
- TODO: decide which environments should have alarm actions enabled

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
