### PR TITLE
MLPAB-1705 - Split SNS topics for service and dependency checks

### DIFF
--- a/terraform/account/region/sns_topics.tf
+++ b/terraform/account/region/sns_topics.tf
@@ -24,8 +24,29 @@ resource "aws_sns_topic" "ecs_autoscaling_alarms" {
   provider                                 = aws.region
 }
 
-resource "aws_sns_topic" "health_checks_global" {
-  name                                     = "health-checks"
+resource "aws_sns_topic" "service_health_checks_global" {
+  name                                     = "service-health-checks"
+  kms_master_key_id                        = data.aws_kms_alias.sns_kms_key_alias.target_key_id
+  application_failure_feedback_role_arn    = data.aws_iam_role.sns_failure_feedback.arn
+  application_success_feedback_role_arn    = data.aws_iam_role.sns_success_feedback.arn
+  application_success_feedback_sample_rate = 100
+  firehose_failure_feedback_role_arn       = data.aws_iam_role.sns_failure_feedback.arn
+  firehose_success_feedback_role_arn       = data.aws_iam_role.sns_success_feedback.arn
+  firehose_success_feedback_sample_rate    = 100
+  http_failure_feedback_role_arn           = data.aws_iam_role.sns_failure_feedback.arn
+  http_success_feedback_role_arn           = data.aws_iam_role.sns_success_feedback.arn
+  http_success_feedback_sample_rate        = 100
+  lambda_failure_feedback_role_arn         = data.aws_iam_role.sns_failure_feedback.arn
+  lambda_success_feedback_role_arn         = data.aws_iam_role.sns_success_feedback.arn
+  lambda_success_feedback_sample_rate      = 100
+  sqs_failure_feedback_role_arn            = data.aws_iam_role.sns_failure_feedback.arn
+  sqs_success_feedback_role_arn            = data.aws_iam_role.sns_success_feedback.arn
+  sqs_success_feedback_sample_rate         = 100
+  provider                                 = aws.global
+}
+
+resource "aws_sns_topic" "dependency_health_checks_global" {
+  name                                     = "dependency-health-checks"
   kms_master_key_id                        = data.aws_kms_alias.sns_kms_key_alias.target_key_id
   application_failure_feedback_role_arn    = data.aws_iam_role.sns_failure_feedback.arn
   application_success_feedback_role_arn    = data.aws_iam_role.sns_success_feedback.arn


### PR DESCRIPTION
# Purpose

Split alerts for service from alerts for dependencies

Fixes MLPAB-1705

## Approach

- rename service topic
- create dependency topic