### PR TITLE
MLPAB-1712: Work out why CPs on demo are being redirected to the dashboard

### DIFF
--- a/cmd/mock-onelogin/main.go
+++ b/cmd/mock-onelogin/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-go-common/env"
 )
 
@@ -146,7 +147,7 @@ func authorize() http.HandlerFunc {
 
 		sub := r.FormValue("sub")
 		if sub == "" {
-			sub = randomString("sub-", 12)
+			sub = "sub-" + uuid.New().String()
 		}
 
 		sessions[code] = sessionData{

--- a/internal/page/fixtures/attorney.go
+++ b/internal/page/fixtures/attorney.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/date"
@@ -64,7 +65,7 @@ func Attorney(
 		)
 
 		if attorneySub == "" {
-			attorneySub = random.String(16)
+			attorneySub = "sub-" + uuid.New().String()
 		}
 
 		if r.Method != http.MethodPost && !r.URL.Query().Has("redirect") {

--- a/internal/page/fixtures/certificate_provider.go
+++ b/internal/page/fixtures/certificate_provider.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/date"
@@ -49,7 +50,7 @@ func CertificateProvider(
 		)
 
 		if certificateProviderSub == "" {
-			certificateProviderSub = random.String(16)
+			certificateProviderSub = "sub-" + uuid.New().String()
 		}
 
 		if r.Method != http.MethodPost && !r.URL.Query().Has("redirect") {

--- a/internal/page/fixtures/donor.go
+++ b/internal/page/fixtures/donor.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/event"
@@ -81,7 +82,7 @@ func Donor(
 		)
 
 		if donorSub == "" {
-			donorSub = random.String(16)
+			donorSub = "sub-" + uuid.New().String()
 		}
 
 		if r.Method != http.MethodPost && !r.URL.Query().Has("redirect") {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,7 +21,7 @@
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false
       },
-      "mock_onelogin_enabled": true,
+      "mock_onelogin_enabled": false,
       "uid_service": {
         "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
         "api_arns": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,7 +21,7 @@
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false
       },
-      "mock_onelogin_enabled": false,
+      "mock_onelogin_enabled": true,
       "uid_service": {
         "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
         "api_arns": [


### PR DESCRIPTION
# Purpose

I've not been able to test this on a PR env due to the redirect timing out (assuming there were some env vars I failed to update) but testing this again on demo and on starting the CP journey and leaving the sub value empty in the mock is now consistently landing on the reference number page. 

My hunch was the randomness was potentially not as random as we needed so I've upgraded to subs to uuids as some protection against this.

Fixes MLPAB-1712 (maybe?) 
