### PR TITLE
MLPAB-1062 - Enable app insights

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.1"
-  constraints = "~> 5.32.0"
+  version     = "5.33.0"
+  constraints = "~> 5.33.0"
   hashes = [
-    "h1:jv1eeMPObgcJOEV6x9BmT1rSUDZ5cX0FBpweCNu4bnc=",
-    "zh:0c603e0ea9ec481f1588ca44d3464fe43ed936a8452e0c70d347c8e71a1b19a4",
-    "zh:0d43c845330ea4aaa152caf35819069215fcf17e4468b9d94c631f7d4178b1ac",
-    "zh:1211275208e8142bfa27987fdeb3eae40075ff569bf198330975f470bc4f5137",
-    "zh:1d8e7e4a2ff45a8b56037d030e2978fc04007941f62f1e265e251801a1d0c3cc",
-    "zh:4f6a8a6c9413b8b9267673cb7fb9dee7dc81946f7cc17d23e2104304f4ec4472",
-    "zh:6d769c74f8157260a37a32a1036b77f9795e21df2df7cadf4c7acc85b2dfd96e",
-    "zh:778fd9bf80424a62ebf5f059dcabfc4a588b0791ba18c1cf727bbdc1aed40351",
-    "zh:7bf1b063065bbe39b71e2a5895915fcbcc0cf7f553f84388e81888506d292fce",
+    "h1:kPm7PkwHh6tZ74pUj5C/QRPtauxdnzrEG2yhCJla/4o=",
+    "zh:10bb683f2a9306e881f51a971ad3b2bb654ac94b54945dd63769876a343b5b04",
+    "zh:3916406db958d5487ea0c2d2320012d1907c29e6d01bf693560fe05e38ee0601",
+    "zh:3cb54b76b2f9e30620f3281ab7fb20633b1e4584fc84cc4ecd5752546252e86f",
+    "zh:513bcfd6971482215c5d64725189f875cbcbd260c6d11f0da4d66321efd93a92",
+    "zh:545a34427ebe7a950056627e7c980c9ba16318bf086d300eb808ffc41c52b7a8",
+    "zh:5a44b90faf1c8e8269f389c04bfac25ad4766d26360e7f7ac371be12a442981c",
+    "zh:64e1ef83162f78538dccad8b035577738851395ba774d6919cb21eb465a21e3a",
+    "zh:7315c70cb6b7f975471ea6129474639a08c58c071afc95a36cfaa41a13ae7fb9",
+    "zh:9806faae58938d638b757f54414400be998dddb45edfd4a29c85e827111dc93d",
+    "zh:997fa2e2db242354d9f772fba7eb17bd6d18d28480291dd93f85a18ca0a67ac2",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b57506c3f46e850543fc1ee9522f231311e8540730db76bbf7a3f4d81777a4bd",
-    "zh:d37c8655b2a31435a116a1af7031f2bcdecf4c7e7e74903b88203798fb39043e",
-    "zh:db369802896eb10bbfed00bf3bd568b35fb5d903d3624d555b6574c5c4e2d94e",
-    "zh:e9992bfccf8205c495aebb7da917404496f96b5d3ea4a915a8884994ca8d860c",
-    "zh:ed1e0ef83cde313f1ccb3e18fc9dc63bf6ca473ec07554df5e24c706708a6866",
-    "zh:f0d19ed41352da9be308dff72899ecf5af7a42b592cf37fb98e9064e7622d35e",
+    "zh:9f9e076b7e9752971f39eead6eda69df1c5e890c82ba2ca95f56974af7adfe79",
+    "zh:b1d6af047f96de7f97d38b685654f1aed4356d5060b0e696d87d0270f5d49f75",
+    "zh:bfb0654b6f34398aeffdf907b744af06733d168db610a2c5747263380f817ac7",
+    "zh:e25203ee8cedccf60bf450950d533d3c172509bda8af97dbc3bc817d2a503c57",
   ]
 }
 
@@ -45,7 +45,7 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "3.4.1"
-  constraints = ">= 2.16.0, ~> 3.4.0"
+  constraints = "~> 3.4.0"
   hashes = [
     "h1:ntsWamEgQsmFukTV3vtgj6NFowleLE7V3l6U4dW2nOo=",
     "zh:0ac31f1a07ed501a1d14025b3d1196cfe06f9c96da010da50bc360c5186a514f",

--- a/terraform/environment/global.tf
+++ b/terraform/environment/global.tf
@@ -1,5 +1,6 @@
 module "global" {
-  source = "./global"
+  source                                  = "./global"
+  cloudwatch_application_insights_enabled = local.environment.app.cloudwatch_application_insights_enabled
   providers = {
     aws.global = aws.global
   }

--- a/terraform/environment/global/cloudwatch_application_insights.tf
+++ b/terraform/environment/global/cloudwatch_application_insights.tf
@@ -1,6 +1,6 @@
-# resource "aws_applicationinsights_application" "environment_global" {
-#   resource_group_name = aws_resourcegroups_group.environment_global.name
-#   auto_config_enabled = true
-#   cwe_monitor_enabled = true
-#   provider            = aws.global
-# }
+resource "aws_applicationinsights_application" "environment_global" {
+  resource_group_name = aws_resourcegroups_group.environment_global.name
+  auto_config_enabled = true
+  cwe_monitor_enabled = true
+  provider            = aws.global
+}

--- a/terraform/environment/global/cloudwatch_application_insights.tf
+++ b/terraform/environment/global/cloudwatch_application_insights.tf
@@ -1,4 +1,5 @@
 resource "aws_applicationinsights_application" "environment_global" {
+  count               = var.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = aws_resourcegroups_group.environment_global.name
   auto_config_enabled = true
   cwe_monitor_enabled = true

--- a/terraform/environment/global/variables.tf
+++ b/terraform/environment/global/variables.tf
@@ -1,0 +1,4 @@
+variable "cloudwatch_application_insights_enabled" {
+  type        = bool
+  description = "Enable CloudWatch Application Insights"
+}

--- a/terraform/environment/global/versions.tf
+++ b/terraform/environment/global/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.global,
       ]

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,7 +1,7 @@
 resource "aws_applicationinsights_application" "environment" {
   count               = var.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = aws_resourcegroups_group.environment.name
-  auto_config_enabled = true # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
+  auto_config_enabled = true
   cwe_monitor_enabled = true
   ops_center_enabled  = false
   depends_on = [

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,4 +1,5 @@
 resource "aws_applicationinsights_application" "environment" {
+  count               = var.cloudwatch_application_insights_enabled ? 1 : 0
   resource_group_name = aws_resourcegroups_group.environment.name
   auto_config_enabled = true # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
   cwe_monitor_enabled = true

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,6 +1,6 @@
 resource "aws_applicationinsights_application" "environment" {
   resource_group_name = aws_resourcegroups_group.environment.name
-  auto_config_enabled = false # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
+  auto_config_enabled = true # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
   cwe_monitor_enabled = true
   ops_center_enabled  = false
   depends_on = [

--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,11 +1,11 @@
-# resource "aws_applicationinsights_application" "environment" {
-#   resource_group_name = aws_resourcegroups_group.environment.name
-#   auto_config_enabled = false # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
-#   cwe_monitor_enabled = true
-#   ops_center_enabled  = false
-#   depends_on = [
-#     aws_ecs_cluster.main,
-#     module.app,
-#   ]
-#   provider = aws.region
-# }
+resource "aws_applicationinsights_application" "environment" {
+  resource_group_name = aws_resourcegroups_group.environment.name
+  auto_config_enabled = false # temporarily disabled until the bug int he provider is resolved https://github.com/hashicorp/terraform-provider-aws/issues/27277
+  cwe_monitor_enabled = true
+  ops_center_enabled  = false
+  depends_on = [
+    aws_ecs_cluster.main,
+    module.app,
+  ]
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/app/versions.tf
+++ b/terraform/environment/region/modules/app/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/application_logs/versions.tf
+++ b/terraform/environment/region/modules/application_logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/ecs_autoscaling/versions.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/event_bus/versions.tf
+++ b/terraform/environment/region/modules/event_bus/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/event_received/versions.tf
+++ b/terraform/environment/region/modules/event_received/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/lambda/version.tf
+++ b/terraform/environment/region/modules/lambda/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/mock_onelogin/versions.tf
+++ b/terraform/environment/region/modules/mock_onelogin/versions.tf
@@ -4,11 +4,10 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]
     }
   }
 }
-

--- a/terraform/environment/region/modules/s3_antivirus/versions.tf
+++ b/terraform/environment/region/modules/s3_antivirus/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/modules/uploads_s3_bucket/versions.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -141,3 +141,8 @@ variable "service_health_check_alarm_enabled" {
   description = "Enable the service health check alert actions"
   default     = false
 }
+
+variable "cloudwatch_application_insights_enabled" {
+  type        = bool
+  description = "Enable CloudWatch Application Insights"
+}

--- a/terraform/environment/region/versions.tf
+++ b/terraform/environment/region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
       configuration_aliases = [
         aws.region,
         aws.global,

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -56,9 +56,10 @@ module "eu_west_1" {
     base_url = local.environment.lpa_store_service.base_url
     api_arns = local.environment.lpa_store_service.api_arns
   }
-  mock_onelogin_enabled                 = local.environment.mock_onelogin_enabled
-  dependency_health_check_alarm_enabled = local.environment.app.dependency_health_check_alarm_enabled
-  service_health_check_alarm_enabled    = local.environment.app.service_health_check_alarm_enabled
+  mock_onelogin_enabled                   = local.environment.mock_onelogin_enabled
+  dependency_health_check_alarm_enabled   = local.environment.app.dependency_health_check_alarm_enabled
+  service_health_check_alarm_enabled      = local.environment.app.service_health_check_alarm_enabled
+  cloudwatch_application_insights_enabled = local.environment.app.cloudwatch_application_insights_enabled
   providers = {
     aws.region            = aws.eu_west_1
     aws.global            = aws.global
@@ -111,9 +112,10 @@ module "eu_west_2" {
     base_url = local.environment.lpa_store_service.base_url
     api_arns = local.environment.lpa_store_service.api_arns
   }
-  mock_onelogin_enabled                 = local.environment.mock_onelogin_enabled
-  dependency_health_check_alarm_enabled = local.environment.app.dependency_health_check_alarm_enabled
-  service_health_check_alarm_enabled    = local.environment.app.service_health_check_alarm_enabled
+  mock_onelogin_enabled                   = local.environment.mock_onelogin_enabled
+  dependency_health_check_alarm_enabled   = local.environment.app.dependency_health_check_alarm_enabled
+  service_health_check_alarm_enabled      = local.environment.app.service_health_check_alarm_enabled
+  cloudwatch_application_insights_enabled = local.environment.app.cloudwatch_application_insights_enabled
   providers = {
     aws.region            = aws.eu_west_2
     aws.global            = aws.global

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -20,7 +20,7 @@
         },
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": true
+        "cloudwatch_application_insights_enabled": false
       },
       "mock_onelogin_enabled": false,
       "uid_service": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -19,7 +19,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false
+        "service_health_check_alarm_enabled": false,
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": false,
       "uid_service": {
@@ -93,7 +94,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": true,
-        "service_health_check_alarm_enabled": true
+        "service_health_check_alarm_enabled": true,
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": true,
       "uid_service": {
@@ -167,7 +169,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false
+        "service_health_check_alarm_enabled": false,
+        "cloudwatch_application_insights_enabled": false
       },
       "mock_onelogin_enabled": true,
       "uid_service": {
@@ -241,7 +244,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false
+        "service_health_check_alarm_enabled": false,
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": true,
       "uid_service": {
@@ -315,7 +319,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false
+        "service_health_check_alarm_enabled": false,
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": false,
       "uid_service": {
@@ -389,7 +394,8 @@
           "maximum": 3
         },
         "dependency_health_check_alarm_enabled": true,
-        "service_health_check_alarm_enabled": true
+        "service_health_check_alarm_enabled": true,
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": false,
       "uid_service": {

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -43,8 +43,9 @@ variable "environments" {
           minimum = number
           maximum = number
         })
-        dependency_health_check_alarm_enabled = bool
-        service_health_check_alarm_enabled    = bool
+        dependency_health_check_alarm_enabled   = bool
+        service_health_check_alarm_enabled      = bool
+        cloudwatch_application_insights_enabled = bool
       })
       mock_onelogin_enabled = bool
       uid_service = object({

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32.0"
+      version = "~> 5.33.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"


### PR DESCRIPTION
# Purpose

Monitor the services used by the app and raise alerts to the team for abnormalities

Fixes MLPAB-1962

## Approach

- enable app insights and check auto-configure is working
- enable for specific environments
- ~route alarms to Pagerduty~ I'm going to start a new PR for alerts to pagerduty

~Note: turn off for default (terraform/environment/terraform.tfvars.json) before merging~ done

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/applicationinsights_application