### PR TITLE
MLPAB-1807 - raise major prs immediately after stability days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
         "Dependencies",
         "Renovate"
     ],
-    "prCreation": "not-pending",
+    "prCreation": "immediate",
     "stabilityDays": 3,
     "prPriority": 0
   },


### PR DESCRIPTION
# Purpose

Automate dependency upgrade PRs for major versions

Fixes MLPAB-1807

## Approach

- set prCreation to immediate

## Learning

- https://docs.renovatebot.com/configuration-options/
