### PR TITLE
MLPAB-1062 - add opsitems notifications to cloudwatch application insights

### DIFF
--- a/terraform/environment/region/cloudwatch_application_insights.tf
+++ b/terraform/environment/region/cloudwatch_application_insights.tf
@@ -1,9 +1,11 @@
+
 resource "aws_applicationinsights_application" "environment" {
-  count               = var.cloudwatch_application_insights_enabled ? 1 : 0
-  resource_group_name = aws_resourcegroups_group.environment.name
-  auto_config_enabled = true
-  cwe_monitor_enabled = true
-  ops_center_enabled  = false
+  count                  = var.cloudwatch_application_insights_enabled ? 1 : 0
+  resource_group_name    = aws_resourcegroups_group.environment.name
+  auto_config_enabled    = true
+  cwe_monitor_enabled    = true
+  ops_center_enabled     = true
+  ops_item_sns_topic_arn = data.aws_sns_topic.cloudwatch_application_insights.arn
   depends_on = [
     aws_ecs_cluster.main,
     module.app,

--- a/terraform/environment/region/pagerduty.tf
+++ b/terraform/environment/region/pagerduty.tf
@@ -19,3 +19,21 @@ resource "aws_sns_topic_subscription" "ecs_autoscaling_alarms" {
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.ecs_autoscaling_alarms.integration_key}/enqueue"
   provider               = aws.region
 }
+
+data "aws_sns_topic" "cloudwatch_application_insights" {
+  name = "cloudwatch_application_insights"
+}
+
+resource "pagerduty_service_integration" "cloudwatch_application_insights" {
+  name    = "Modernising LPA ${data.aws_default_tags.current.tags.environment-name} ${data.aws_region.current.name} Cloudwatch Application Insights Ops Item Alarm"
+  service = data.pagerduty_service.main.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_application_insights" {
+  topic_arn              = data.aws_sns_topic.cloudwatch_application_insights.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.ecs_autoscaling_alarms.integration_key}/enqueue"
+  provider               = aws.region
+}

--- a/terraform/environment/region/pagerduty.tf
+++ b/terraform/environment/region/pagerduty.tf
@@ -21,7 +21,8 @@ resource "aws_sns_topic_subscription" "ecs_autoscaling_alarms" {
 }
 
 data "aws_sns_topic" "cloudwatch_application_insights" {
-  name = "cloudwatch_application_insights"
+  name     = "cloudwatch_application_insights"
+  provider = aws.region
 }
 
 resource "pagerduty_service_integration" "cloudwatch_application_insights" {

--- a/terraform/environment/region/pagerduty.tf
+++ b/terraform/environment/region/pagerduty.tf
@@ -26,12 +26,14 @@ data "aws_sns_topic" "cloudwatch_application_insights" {
 }
 
 resource "pagerduty_service_integration" "cloudwatch_application_insights" {
+  count   = var.cloudwatch_application_insights_enabled ? 1 : 0
   name    = "Modernising LPA ${data.aws_default_tags.current.tags.environment-name} ${data.aws_region.current.name} Cloudwatch Application Insights Ops Item Alarm"
   service = data.pagerduty_service.main.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_application_insights" {
+  count                  = var.cloudwatch_application_insights_enabled ? 1 : 0
   topic_arn              = data.aws_sns_topic.cloudwatch_application_insights.arn
   protocol               = "https"
   endpoint_auto_confirms = true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -20,7 +20,7 @@
         },
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": true
+        "cloudwatch_application_insights_enabled": false
       },
       "mock_onelogin_enabled": false,
       "uid_service": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -20,7 +20,7 @@
         },
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": false
+        "cloudwatch_application_insights_enabled": true
       },
       "mock_onelogin_enabled": false,
       "uid_service": {


### PR DESCRIPTION
# Purpose

Notify team when there are opsitems generated for cloudwatch application insights

Fixes MLPAB-1062

## Approach

- add opsitems and sns topic
- sub pagerduty to sns topic

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/applicationinsights_application
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic
