### PR TITLE
MLPAB-1839 - reinstate account level replicatoin role

### DIFF
--- a/terraform/account/README.md
+++ b/terraform/account/README.md
@@ -117,6 +117,7 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_backup_vault.eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_dynamodb_table.workspace_cleanup_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_iam_role.aws_backup_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.aws_backup_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_service_linked_role.ecs_autoscaling_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_kms_alias.cloudwatch_alias_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -158,6 +159,7 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_ssm_parameter.additional_allowed_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.global](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.global](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
+| [aws_iam_policy_document.assume_replication_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_backup_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_kms_development_account_operator_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/account/s3_replication_role.tf
+++ b/terraform/account/s3_replication_role.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "assume_replication_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "batchoperations.s3.amazonaws.com"
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+  provider = aws.global
+}
+
+resource "aws_iam_role" "replication" {
+  name               = "reduced-fees-uploads-replication"
+  assume_role_policy = data.aws_iam_policy_document.assume_replication_role.json
+  provider           = aws.global
+}

--- a/terraform/environment/region/modules/app/README.md
+++ b/terraform/environment/region/modules/app/README.md
@@ -80,6 +80,7 @@ No modules.
 | <a name="input_ecs_cluster"></a> [ecs\_cluster](#input\_ecs\_cluster) | ARN of an ECS cluster. | `string` | n/a | yes |
 | <a name="input_ecs_execution_role"></a> [ecs\_execution\_role](#input\_ecs\_execution\_role) | ID and ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. | <pre>object({<br>    id  = string<br>    arn = string<br>  })</pre> | n/a | yes |
 | <a name="input_ecs_service_desired_count"></a> [ecs\_service\_desired\_count](#input\_ecs\_service\_desired\_count) | Number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the DAEMON scheduling strategy. | `number` | `0` | no |
+| <a name="input_ecs_task_role"></a> [ecs\_task\_role](#input\_ecs\_task\_role) | ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. | `any` | n/a | yes |
 | <a name="input_event_bus"></a> [event\_bus](#input\_event\_bus) | Name and ARN of the event bus to send events to | <pre>object({<br>    name = string<br>    arn  = string<br>  })</pre> | n/a | yes |
 | <a name="input_ingress_allow_list_cidr"></a> [ingress\_allow\_list\_cidr](#input\_ingress\_allow\_list\_cidr) | List of CIDR ranges permitted to access the service | `list(string)` | n/a | yes |
 | <a name="input_lpa_store_base_url"></a> [lpa\_store\_base\_url](#input\_lpa\_store\_base\_url) | n/a | `string` | n/a | yes |


### PR DESCRIPTION
# Purpose

This role was moved to environment level because we exceeded the limit of policies attached to an IAM role (10). That move has disrupted to configuration of Sirius, and made it quite difficult to tighten up.

I've increased the limit to 20, which should be more than enough.

Fixes MLPAB-1839

## Approach

- Create account level replication role

## Learning

- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
