### PR TITLE
MLPAB-1866 - include all targets for public access toggling

### DIFF
--- a/.github/workflows/dispatch_manage_public_access_ur_environment.yml
+++ b/.github/workflows/dispatch_manage_public_access_ur_environment.yml
@@ -69,5 +69,7 @@ jobs:
           terraform apply -lock-timeout=300s  -input=false -auto-approve -var public_access_enabled=${{ inputs.public_access_enabled }} \
             -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress[0]' \
             -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress_port_80[0]' \
-            -target 'module.eu_west_1[0].module.mock_onelogin[0].aws_security_group_rule.mock_onelogin_loadbalancer_public_access_ingress[0]' \
+            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_port_80_redirect_ingress[0]' \
+            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_ingress[0]' \
+            -target 'module.eu_west_1[0].module.mock_onelogin[0].aws_security_group_rule.mock_onelogin_loadbalancer_public_access_ingress[0]'
         working-directory: ./terraform/environment


### PR DESCRIPTION
# Purpose

Toggling public access was failing because the rule limit was exceeded. This was because it wasn't removing private ingress rules while adding public ingress rules, due to missing targets in the targeted terraform apply

Fixes MLPAB-1866

## Approach

- include all targets required for toggling access
