### PR TITLE
MLPAB-1906 - Fix destroy environment job for Weblate PRs

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -87,6 +87,7 @@ jobs:
         run: terraform init -input=false
         working-directory: ./terraform/environment
       - name: Destroy PR environment and Terraform workspace
+        if: github.ref != 'refs/heads/weblate-pr'
         working-directory: ./terraform/environment
         env:
           TF_VAR_pagerduty_api_key:  ${{ secrets.PAGERDUTY_API_KEY }}

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - '!weblate-pr'
     types:
       - closed
 

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -59,14 +59,6 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
-      - name: Extend protection for environment workspace
-        if: github.ref != 'refs/heads/main'
-        run: |
-          wget https://github.com/TomTucka/terraform-workspace-manager/releases/download/v0.3.1/terraform-workspace-manager_Linux_x86_64.tar.gz -O $HOME/terraform-workspace-manager.tar.gz
-          sudo tar -xvf $HOME/terraform-workspace-manager.tar.gz -C /usr/local/bin
-          sudo chmod +x /usr/local/bin/terraform-workspace-manager
-          terraform-workspace-manager -register-workspace=${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }} -time-to-protect=1 -aws-account-id=653761790766 -aws-iam-role=modernising-lpa-ci
-        working-directory: ./terraform/environment
       - name: Parse terraform version
         id: tf_version_setup
         working-directory: ./terraform/environment


### PR DESCRIPTION
# Purpose

The Weblate environment is persistent and protected from destruction. The job wasn't correctly skipping destroy steps for the environment and generating a workspace name that never existed, causing the job to fail.

Fixes MLPAB-1906

## Approach

- Don't run destroy step if the closing branch is `weblate-pr`
- remove unused step for protecting workspaces
- remove branch ignore condition (as we don't merge to `weblate-pr`)

## Learning

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
