### PR TITLE
MLPAB-1906- create missing workspaces so that the destroy job never fails

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           TF_VAR_pagerduty_api_key:  ${{ secrets.PAGERDUTY_API_KEY }}
         run: |
-          terraform workspace select ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
+          terraform workspace select -or-create=true ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}
           terraform destroy -auto-approve
           terraform workspace select default
           terraform workspace delete ${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}


### PR DESCRIPTION
# Purpose

Prevent the PR environment destroy job failing when a workspace doesn't exist

## Approach

- Create a workspace if it doesn't exist

This lets the rest of the job pass very quickly