### PR TITLE
MLPAB-1940 MLPAB-1941 - set autoscaling metric for CPU to be Max rather than Avg

### DIFF
--- a/terraform/account/README.md
+++ b/terraform/account/README.md
@@ -91,16 +91,16 @@ For terraform_environment, this will be based on your PR and can be found in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.7.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.36.0 |
-| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.36.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.36.0 |
-| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.36.0 |
+| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.37.0 |
+| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.37.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.37.0 |
+| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.37.0 |
 
 ## Modules
 

--- a/terraform/account/region/README.md
+++ b/terraform/account/region/README.md
@@ -4,16 +4,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.36.0 |
-| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.36.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.37.0 |
+| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.37.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/account/region/modules/antivirus_definitions/README.md
+++ b/terraform/account/region/modules/antivirus_definitions/README.md
@@ -8,13 +8,13 @@ This module creates a S3 bucket for antivirus definitions, and a Lambda function
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/account/region/modules/dns_firewall/README.md
+++ b/terraform/account/region/modules/dns_firewall/README.md
@@ -8,13 +8,13 @@ This module creates a DNS Firewall rule group and  rule group associations.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/account/region/modules/s3_batch_manifests/README.md
+++ b/terraform/account/region/modules/s3_batch_manifests/README.md
@@ -8,13 +8,13 @@ This module creates a S3 bucket for S3 Batch Job Manifests.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/account/region/modules/s3_bucket_event_notifications/README.md
+++ b/terraform/account/region/modules/s3_bucket_event_notifications/README.md
@@ -8,13 +8,13 @@ This module creates a S3 bucket event notifications and event notification filte
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/README.md
+++ b/terraform/environment/README.md
@@ -114,18 +114,18 @@ For terraform_environment, this will be based on your PR and can be found in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.7.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | 3.7.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.36.0 |
-| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.36.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.36.0 |
-| <a name="provider_aws.management_eu_west_1"></a> [aws.management\_eu\_west\_1](#provider\_aws.management\_eu\_west\_1) | 5.36.0 |
-| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.36.0 |
+| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.37.0 |
+| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.37.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.37.0 |
+| <a name="provider_aws.management_eu_west_1"></a> [aws.management\_eu\_west\_1](#provider\_aws.management\_eu\_west\_1) | 5.37.0 |
+| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/global/README.md
+++ b/terraform/environment/global/README.md
@@ -58,15 +58,15 @@ No modules.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | 3.7.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/README.md
+++ b/terraform/environment/region/README.md
@@ -8,17 +8,17 @@ This module creates the regional resources for an environment.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | 3.7.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.36.0 |
-| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.36.0 |
-| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | ~> 5.36.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.37.0 |
+| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.37.0 |
+| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | ~> 5.37.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 | <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | 3.7.1 |
 
 ## Modules

--- a/terraform/environment/region/modules/app/README.md
+++ b/terraform/environment/region/modules/app/README.md
@@ -8,14 +8,14 @@ The module creates an ECS service for the Modernising LPA application, and assoc
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -26,6 +26,9 @@ resource "aws_ecs_service" "app" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   timeouts {

--- a/terraform/environment/region/modules/application_logs/README.md
+++ b/terraform/environment/region/modules/application_logs/README.md
@@ -8,13 +8,13 @@ The module creates a cloudwatch log group and useful log queries for application
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/ecs_autoscaling/README.md
+++ b/terraform/environment/region/modules/ecs_autoscaling/README.md
@@ -8,13 +8,13 @@ This module creates the autoscaling resources for an ECS service.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -75,7 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/ECS"
       period      = "60"
-      stat        = "Average"
+      stat        = "Maximum"
 
       dimensions = {
         ServiceName = var.aws_ecs_service_name

--- a/terraform/environment/region/modules/event_bus/README.md
+++ b/terraform/environment/region/modules/event_bus/README.md
@@ -18,14 +18,14 @@ aws-vault exec mlpa-dev -- aws events put-events --entries file://reduced_fees_u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/event_received/README.md
+++ b/terraform/environment/region/modules/event_received/README.md
@@ -8,14 +8,14 @@ This module creates the resources required to receive and process events from th
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.36.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.37.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/fault_injection_simulator_experiments/README.md
+++ b/terraform/environment/region/modules/fault_injection_simulator_experiments/README.md
@@ -22,7 +22,9 @@ No modules.
 |------|------|
 | [aws_cloudwatch_log_group.fis_app_ecs_tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.fis_app_ecs_tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
-| [aws_fis_experiment_template.ecs_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.ecs_app_cpu_stress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.ecs_app_io_stress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.ecs_app_stop_tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
 | [aws_iam_role_policy.fis_role_log_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |

--- a/terraform/environment/region/modules/fault_injection_simulator_experiments/README.md
+++ b/terraform/environment/region/modules/fault_injection_simulator_experiments/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
+++ b/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
@@ -144,7 +144,7 @@ resource "aws_fis_experiment_template" "ecs_app" {
     action_id   = "aws:ecs:task-cpu-stress"
     description = null
     name        = "cpu_stress_100_percent_10_mins"
-    start_after = ["stop_tasks"]
+    start_after = ["stop_two_tasks"]
     parameter {
       key   = "duration"
       value = "PT10M"

--- a/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
+++ b/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
@@ -129,22 +129,23 @@ resource "aws_fis_experiment_template" "ecs_app" {
     Name = "${data.aws_default_tags.current.tags.environment-name} - APP ECS Task Experiments"
   }
 
-  action {
-    action_id   = "aws:ecs:stop-task"
-    name        = "stop_two_tasks"
-    start_after = []
+  # action {
+  #   action_id   = "aws:ecs:stop-task"
+  #   name        = "stop_two_tasks"
+  #   start_after = []
 
-    target {
-      key   = "Tasks"
-      value = "two-tasks"
-    }
-  }
+  #   target {
+  #     key   = "Tasks"
+  #     value = "two-tasks"
+  #   }
+  # }
 
   action {
     action_id   = "aws:ecs:task-cpu-stress"
     description = null
     name        = "cpu_stress_100_percent_10_mins"
-    start_after = ["stop_two_tasks"]
+    start_after = []
+    # start_after = ["stop_two_tasks"]
     parameter {
       key   = "duration"
       value = "PT10M"

--- a/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
+++ b/terraform/environment/region/modules/fault_injection_simulator_experiments/main.tf
@@ -131,7 +131,7 @@ resource "aws_fis_experiment_template" "ecs_app_stop_tasks" {
 
   action {
     action_id   = "aws:ecs:stop-task"
-    name        = "one-task"
+    name        = "stop-one-task"
     start_after = []
 
     target {

--- a/terraform/environment/region/modules/lambda/README.md
+++ b/terraform/environment/region/modules/lambda/README.md
@@ -8,13 +8,13 @@ This module creates the resources required to deploy an image based Lambda funct
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/mock_onelogin/README.md
+++ b/terraform/environment/region/modules/mock_onelogin/README.md
@@ -8,13 +8,13 @@ This module creates the resources required to mock One Login.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/s3_antivirus/README.md
+++ b/terraform/environment/region/modules/s3_antivirus/README.md
@@ -8,13 +8,13 @@ This module deploys a lambda function that scans S3 objects for viruses on put.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/region/modules/uploads_s3_bucket/README.md
+++ b/terraform/environment/region/modules/uploads_s3_bucket/README.md
@@ -8,13 +8,13 @@ This module creates an S3 bucket for storing uploads, triggers for virus scannin
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.36.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.37.0 |
 
 ## Modules
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,7 +21,7 @@
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false,
         "cloudwatch_application_insights_enabled": false,
-        "fault_injection_experiments_enabled": true
+        "fault_injection_experiments_enabled": false
       },
       "mock_onelogin_enabled": false,
       "uid_service": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,7 +21,7 @@
         "dependency_health_check_alarm_enabled": false,
         "service_health_check_alarm_enabled": false,
         "cloudwatch_application_insights_enabled": false,
-        "fault_injection_experiments_enabled": false
+        "fault_injection_experiments_enabled": true
       },
       "mock_onelogin_enabled": false,
       "uid_service": {


### PR DESCRIPTION
# Purpose

Use a better metric for auto-scaling to make it more responsive

Fixes MLPAB-1940 MLPAB-1941

## Approach

- bump documentation
- use Maximum instead of Average for CPU tracking
- Split FIS experiment into one for each action
- Ignore desired count so after creation, only auto-scaling controls the number of tasks. (this prevents deployments interfering with desired count)