### PR TITLE
support multiple invites associated with one email

### DIFF
--- a/cypress/e2e/supporter/start.cy.js
+++ b/cypress/e2e/supporter/start.cy.js
@@ -14,6 +14,8 @@ describe('Start', () => {
 
     if (Cypress.config().baseUrl.includes('localhost')) {
       cy.url().should('contain', '/authorize')
+
+      cy.get('#f-email').type(Math.random() + '@example.org')
       cy.contains('button', 'Sign in').click();
 
       cy.url().should('contain', '/enter-the-name-of-your-organisation-or-company')

--- a/internal/app/member_store.go
+++ b/internal/app/member_store.go
@@ -116,22 +116,22 @@ func (s *memberStore) InvitedMembers(ctx context.Context) ([]*actor.MemberInvite
 	return invitedMembers, nil
 }
 
-func (s *memberStore) InvitedMember(ctx context.Context) (*actor.MemberInvite, error) {
+func (s *memberStore) InvitedMembersByEmail(ctx context.Context) ([]*actor.MemberInvite, error) {
 	data, err := page.SessionDataFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if data.Email == "" {
-		return nil, errors.New("memberStore.InvitedMember requires Email")
+		return nil, errors.New("memberStore.InvitedMembersByEmail requires Email")
 	}
 
-	var invitedMember *actor.MemberInvite
-	if err := s.dynamoClient.OneBySK(ctx, memberInviteKey(data.Email), &invitedMember); err != nil {
+	var invitedMembers []*actor.MemberInvite
+	if err := s.dynamoClient.AllBySK(ctx, memberInviteKey(data.Email), &invitedMembers); err != nil {
 		return nil, err
 	}
 
-	return invitedMember, nil
+	return invitedMembers, nil
 }
 
 func (s *memberStore) GetAll(ctx context.Context) ([]*actor.Member, error) {

--- a/internal/page/supporter/login_callback.go
+++ b/internal/page/supporter/login_callback.go
@@ -43,19 +43,6 @@ func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh
 		sessionData := &page.SessionData{SessionID: loginSession.SessionID(), Email: loginSession.Email}
 		ctx := page.ContextWithSessionData(r.Context(), sessionData)
 
-		invites, err := memberStore.InvitedMembersByEmail(ctx)
-		if err != nil {
-			return err
-		}
-
-		if len(invites) > 0 {
-			if err := sesh.SetLoginSession(sessionStore, r, w, loginSession); err != nil {
-				return err
-			}
-
-			return page.Paths.Supporter.EnterReferenceNumber.Redirect(w, r, appData)
-		}
-
 		organisation, err := organisationStore.Get(ctx)
 		if err == nil {
 			loginSession.OrganisationID = organisation.ID
@@ -88,6 +75,15 @@ func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh
 			}
 		} else {
 			return err
+		}
+
+		invites, err := memberStore.InvitedMembersByEmail(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(invites) > 0 {
+			return page.Paths.Supporter.EnterReferenceNumber.Redirect(w, r, appData)
 		}
 
 		return page.Paths.Supporter.EnterOrganisationName.Redirect(w, r, appData)

--- a/internal/page/supporter/login_callback.go
+++ b/internal/page/supporter/login_callback.go
@@ -43,8 +43,12 @@ func LoginCallback(oneLoginClient LoginCallbackOneLoginClient, sessionStore sesh
 		sessionData := &page.SessionData{SessionID: loginSession.SessionID(), Email: loginSession.Email}
 		ctx := page.ContextWithSessionData(r.Context(), sessionData)
 
-		_, err = memberStore.InvitedMember(ctx)
-		if err == nil {
+		invites, err := memberStore.InvitedMembersByEmail(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(invites) > 0 {
 			if err := sesh.SetLoginSession(sessionStore, r, w, loginSession); err != nil {
 				return err
 			}

--- a/internal/page/supporter/login_callback_test.go
+++ b/internal/page/supporter/login_callback_test.go
@@ -95,8 +95,8 @@ func TestLoginCallback(t *testing.T) {
 
 			memberStore := newMockMemberStore(t)
 			memberStore.EXPECT().
-				InvitedMember(mock.Anything).
-				Return(nil, expectedError)
+				InvitedMembersByEmail(mock.Anything).
+				Return([]*actor.MemberInvite{}, nil)
 
 			organisationStore := newMockOrganisationStore(t)
 			organisationStore.EXPECT().
@@ -150,8 +150,8 @@ func TestLoginCallbackWhenNoOrganisationAndSetLoginSessionError(t *testing.T) {
 
 	memberStore := newMockMemberStore(t)
 	memberStore.EXPECT().
-		InvitedMember(mock.Anything).
-		Return(nil, expectedError)
+		InvitedMembersByEmail(mock.Anything).
+		Return([]*actor.MemberInvite{}, nil)
 
 	organisationStore := newMockOrganisationStore(t)
 	organisationStore.EXPECT().
@@ -234,8 +234,8 @@ func TestLoginCallbackIsOrganisationMember(t *testing.T) {
 
 			memberStore := newMockMemberStore(t)
 			memberStore.EXPECT().
-				InvitedMember(mock.Anything).
-				Return(nil, expectedError)
+				InvitedMembersByEmail(mock.Anything).
+				Return([]*actor.MemberInvite{}, nil)
 
 			memberStore.EXPECT().
 				Get(page.ContextWithSessionData(r.Context(), &page.SessionData{SessionID: loginSession.SessionID(), Email: loginSession.Email, OrganisationID: "org-id"})).
@@ -327,8 +327,8 @@ func TestLoginCallbackIsOrganisationMemberErrors(t *testing.T) {
 
 			memberStore := newMockMemberStore(t)
 			memberStore.EXPECT().
-				InvitedMember(mock.Anything).
-				Return(nil, expectedError)
+				InvitedMembersByEmail(mock.Anything).
+				Return([]*actor.MemberInvite{}, nil)
 
 			memberStore.EXPECT().
 				Get(mock.Anything).
@@ -402,8 +402,8 @@ func TestLoginCallbackWhenEmailHasInvite(t *testing.T) {
 
 	memberStore := newMockMemberStore(t)
 	memberStore.EXPECT().
-		InvitedMember(mock.Anything).
-		Return(nil, nil)
+		InvitedMembersByEmail(mock.Anything).
+		Return([]*actor.MemberInvite{{}}, nil)
 
 	err := LoginCallback(client, sessionStore, nil, testNowFn, memberStore)(page.AppData{}, w, r)
 
@@ -461,8 +461,8 @@ func TestLoginCallbackWhenEmailHasInviteWhenSetLoginSessionError(t *testing.T) {
 
 	memberStore := newMockMemberStore(t)
 	memberStore.EXPECT().
-		InvitedMember(mock.Anything).
-		Return(nil, nil)
+		InvitedMembersByEmail(mock.Anything).
+		Return([]*actor.MemberInvite{{}}, nil)
 
 	err := LoginCallback(client, sessionStore, nil, testNowFn, memberStore)(page.AppData{}, w, r)
 
@@ -604,8 +604,8 @@ func TestLoginCallbackWhenSessionError(t *testing.T) {
 
 	memberStore := newMockMemberStore(t)
 	memberStore.EXPECT().
-		InvitedMember(mock.Anything).
-		Return(nil, expectedError)
+		InvitedMembersByEmail(mock.Anything).
+		Return([]*actor.MemberInvite{}, nil)
 
 	organisationStore := newMockOrganisationStore(t)
 	organisationStore.EXPECT().

--- a/internal/page/supporter/mock_MemberStore_test.go
+++ b/internal/page/supporter/mock_MemberStore_test.go
@@ -345,64 +345,6 @@ func (_c *mockMemberStore_GetByID_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
-// InvitedMember provides a mock function with given fields: ctx
-func (_m *mockMemberStore) InvitedMember(ctx context.Context) (*actor.MemberInvite, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for InvitedMember")
-	}
-
-	var r0 *actor.MemberInvite
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*actor.MemberInvite, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) *actor.MemberInvite); ok {
-		r0 = rf(ctx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*actor.MemberInvite)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// mockMemberStore_InvitedMember_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvitedMember'
-type mockMemberStore_InvitedMember_Call struct {
-	*mock.Call
-}
-
-// InvitedMember is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *mockMemberStore_Expecter) InvitedMember(ctx interface{}) *mockMemberStore_InvitedMember_Call {
-	return &mockMemberStore_InvitedMember_Call{Call: _e.mock.On("InvitedMember", ctx)}
-}
-
-func (_c *mockMemberStore_InvitedMember_Call) Run(run func(ctx context.Context)) *mockMemberStore_InvitedMember_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *mockMemberStore_InvitedMember_Call) Return(_a0 *actor.MemberInvite, _a1 error) *mockMemberStore_InvitedMember_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *mockMemberStore_InvitedMember_Call) RunAndReturn(run func(context.Context) (*actor.MemberInvite, error)) *mockMemberStore_InvitedMember_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // InvitedMembers provides a mock function with given fields: ctx
 func (_m *mockMemberStore) InvitedMembers(ctx context.Context) ([]*actor.MemberInvite, error) {
 	ret := _m.Called(ctx)
@@ -457,6 +399,64 @@ func (_c *mockMemberStore_InvitedMembers_Call) Return(_a0 []*actor.MemberInvite,
 }
 
 func (_c *mockMemberStore_InvitedMembers_Call) RunAndReturn(run func(context.Context) ([]*actor.MemberInvite, error)) *mockMemberStore_InvitedMembers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InvitedMembersByEmail provides a mock function with given fields: ctx
+func (_m *mockMemberStore) InvitedMembersByEmail(ctx context.Context) ([]*actor.MemberInvite, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InvitedMembersByEmail")
+	}
+
+	var r0 []*actor.MemberInvite
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]*actor.MemberInvite, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []*actor.MemberInvite); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*actor.MemberInvite)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// mockMemberStore_InvitedMembersByEmail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvitedMembersByEmail'
+type mockMemberStore_InvitedMembersByEmail_Call struct {
+	*mock.Call
+}
+
+// InvitedMembersByEmail is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *mockMemberStore_Expecter) InvitedMembersByEmail(ctx interface{}) *mockMemberStore_InvitedMembersByEmail_Call {
+	return &mockMemberStore_InvitedMembersByEmail_Call{Call: _e.mock.On("InvitedMembersByEmail", ctx)}
+}
+
+func (_c *mockMemberStore_InvitedMembersByEmail_Call) Run(run func(ctx context.Context)) *mockMemberStore_InvitedMembersByEmail_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *mockMemberStore_InvitedMembersByEmail_Call) Return(_a0 []*actor.MemberInvite, _a1 error) *mockMemberStore_InvitedMembersByEmail_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *mockMemberStore_InvitedMembersByEmail_Call) RunAndReturn(run func(context.Context) ([]*actor.MemberInvite, error)) *mockMemberStore_InvitedMembersByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/page/supporter/register.go
+++ b/internal/page/supporter/register.go
@@ -31,7 +31,7 @@ type MemberStore interface {
 	Get(ctx context.Context) (*actor.Member, error)
 	GetAll(ctx context.Context) ([]*actor.Member, error)
 	GetByID(ctx context.Context, memberID string) (*actor.Member, error)
-	InvitedMember(ctx context.Context) (*actor.MemberInvite, error)
+	InvitedMembersByEmail(ctx context.Context) ([]*actor.MemberInvite, error)
 	InvitedMembers(ctx context.Context) ([]*actor.MemberInvite, error)
 	Put(ctx context.Context, member *actor.Member) error
 }


### PR DESCRIPTION
# Purpose

During UR we saw some instances where the journey was routed to `/enter-organisation-name` rather than the expected `/enter-reference-number`. After investigation, this is because we assume there will only ever be one invite associated with an email address so we only route to `/enter-reference-number` if errors are nil when getting the invite (multiple invites results in an error).

This change relaxes the rules slightly to allow for multiple invites, and to account for an endless loop of `/enter-reference-code` if the user has multiple invites but already belongs to an org, we now check for org membership before getting invites. 
