### PR TITLE
MLPAB-1945 - additional endpoints for ssm with fargate in a private subnet

### DIFF
--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -39,6 +39,8 @@ locals {
     "rum",
     "secretsmanager",
     "ssm",
+    "ec2Messages",
+    "ssmmessages",
     "xray",
   ])
 }


### PR DESCRIPTION
# Purpose

SSM Run Command fails with undeliverable when carrying out Fault Injection Simulator CPU stress documents. This previously worked (see MLPAB-1570)

Fixes MLPAB-1945

## Approach

- add ssmmessages and ec2messages

## Learning

- https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html
