### PR TITLE
MLPAB-1991 - Fix AV Scan lambda function

### DIFF
--- a/terraform/environment/region/modules/s3_antivirus/iam.tf
+++ b/terraform/environment/region/modules/s3_antivirus/iam.tf
@@ -18,6 +18,18 @@ data "aws_iam_policy_document" "lambda" {
   }
 
   statement {
+    sid       = "allowLoggingEncryption"
+    effect    = "Allow"
+    resources = [data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn]
+    actions = [
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+  }
+
+  statement {
     sid       = "allowS3Tagging"
     effect    = "Allow"
     resources = [var.data_store_bucket.arn, "${var.data_store_bucket.arn}/*"]

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -24,6 +24,11 @@ resource "aws_lambda_function" "lambda_function" {
     mode = "Active"
   }
 
+  logging_config {
+    log_group  = aws_cloudwatch_log_group.lambda.name
+    log_format = "JSON"
+  }
+
   vpc_config {
     subnet_ids = var.aws_subnet_ids
     security_group_ids = [


### PR DESCRIPTION
# Purpose

Use the correct log group (and improve initialisation times)

Fixes MLPAB-1991

## Approach

- set up logging config for av scan lambda function

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
