### PR TITLE
MLPAB-1993 - Fix PR environment destroy permissions to delete container insights log groups

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -95,6 +95,15 @@ jobs:
       - name: Remove protection for environment workspace
         run: |
           terraform-workspace-manager -register-workspace=${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }} -time-to-protect=0 -aws-account-id=653761790766 -aws-iam-role=modernising-lpa-ci
+      - name: Configure AWS Credentials For AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-role-to-assume: arn:aws:iam::653761790766:role/modernising-lpa-ci
+          aws-region: eu-west-1
+          role-duration-seconds: 3600
+          role-session-name: OPGModernisingLPATerraformGithubAction
       - name: Remove container insights log group
         run: |
           aws logs delete-log-group --log-group-name /aws/ecs/containerinsights/${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}-eu-west-1/performance

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           aws-role-to-assume: arn:aws:iam::653761790766:role/modernising-lpa-github-actions-cloudwatch-log-group-delete
           aws-region: eu-west-1
-          role-duration-seconds: 3600
+          role-duration-seconds: 900
           role-session-name: OPGModernisingLPALogGroupDeleteGithubAction
       - name: Remove container insights log group
         run: |

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -98,12 +98,10 @@ jobs:
       - name: Configure AWS Credentials For AWS CLI
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
-          aws-role-to-assume: arn:aws:iam::653761790766:role/modernising-lpa-ci
+          aws-role-to-assume: arn:aws:iam::653761790766:role/modernising-lpa-github-actions-cloudwatch-log-group-delete
           aws-region: eu-west-1
           role-duration-seconds: 3600
-          role-session-name: OPGModernisingLPATerraformGithubAction
+          role-session-name: OPGModernisingLPALogGroupDeleteGithubAction
       - name: Remove container insights log group
         run: |
           aws logs delete-log-group --log-group-name /aws/ecs/containerinsights/${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}-eu-west-1/performance


### PR DESCRIPTION
# Purpose

Use a new OIDC role that has permission to delete the container insights log group

Fixes MLPAB-1993

## Approach

- Assume OIDC role modernising-lpa-github-actions-cloudwatch-log-group-delete before deleting log group