### PR TITLE
MLPAB-2012 - add principals to the opensearch cmk policy

### DIFF
--- a/terraform/account/opensearch_kms.tf
+++ b/terraform/account/opensearch_kms.tf
@@ -48,6 +48,10 @@ data "aws_iam_policy_document" "opensearch_kms" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
     condition {
       test     = "Bool"
       variable = "kms:GrantIsForAWSResource"
@@ -72,6 +76,10 @@ data "aws_iam_policy_document" "opensearch_kms" {
     actions = [
       "kms:ListKeys",
     ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
     condition {
       test     = "Bool"
       variable = "kms:GrantIsForAWSResource"


### PR DESCRIPTION
# Purpose

Fix malformed key policy breaking path to live

Fixes MLPAB-2012

## Approach

- add account root as principal while conditions restrict to opensearch serverless

## Learning

- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
