### PR TITLE
MLPAB-1966 - use customer managed key for opensearch serverless

### DIFF
--- a/terraform/environment/README.md
+++ b/terraform/environment/README.md
@@ -164,6 +164,7 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_iam_role.sns_success_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_kms_alias.dynamodb_encryption_key_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_kms_alias.dynamodb_encryption_key_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_kms_alias.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_kms_alias.sns_encryption_key_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_vpc_endpoint.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint) | data source |
 

--- a/terraform/environment/opensearch.tf
+++ b/terraform/environment/opensearch.tf
@@ -5,6 +5,11 @@ data "aws_vpc_endpoint" "opensearch" {
   provider = aws.eu_west_1
 }
 
+data "aws_kms_alias" "opensearch" {
+  name     = "alias/${local.default_tags.application}-opensearch-encryption-key"
+  provider = aws.eu_west_1
+}
+
 resource "aws_opensearchserverless_security_policy" "lpas_collection_encryption_policy" {
   name        = "policy-${local.environment_name}"
   type        = "encryption"
@@ -16,7 +21,8 @@ resource "aws_opensearchserverless_security_policy" "lpas_collection_encryption_
         ResourceType = "collection"
       }
     ],
-    AWSOwnedKey = true
+    AWSOwnedKey = false
+    KmsARN      = data.aws_kms_alias.opensearch.target_key_id
   })
   provider = aws.eu_west_1
 }

--- a/terraform/environment/opensearch.tf
+++ b/terraform/environment/opensearch.tf
@@ -22,7 +22,7 @@ resource "aws_opensearchserverless_security_policy" "lpas_collection_encryption_
       }
     ],
     AWSOwnedKey = false
-    KmsARN      = data.aws_kms_alias.opensearch.target_key_id
+    KmsARN      = data.aws_kms_alias.opensearch.target_key_arn
   })
   provider = aws.eu_west_1
 }


### PR DESCRIPTION
# Purpose

Manage encryption

Fixes MLPAB-1966

## Approach

- pull in account level key
- Use CMK in Opensearch Serverless security policy

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-encryption.html