### PR TITLE
MLPAB-2014 - Fix failed ECS deployments after implementing CMK

### DIFF
--- a/terraform/environment/region/modules/app/README.md
+++ b/terraform/environment/region/modules/app/README.md
@@ -53,6 +53,7 @@ No modules.
 | [aws_iam_policy_document.task_role_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_ip_ranges.route53_healthchecks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ip_ranges) | data source |
 | [aws_kms_alias.dynamodb_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_kms_alias.opensearch_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_kms_alias.reduced_fees_uploads_s3_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_kms_alias.secrets_manager_secret_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -130,6 +130,11 @@ data "aws_kms_alias" "reduced_fees_uploads_s3_encryption" {
   provider = aws.region
 }
 
+data "aws_kms_alias" "opensearch_encryption_key" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}-opensearch-encryption-key"
+  provider = aws.region
+}
+
 data "aws_secretsmanager_secret" "private_jwt_key" {
   name     = "private-jwt-key-base64"
   provider = aws.region
@@ -213,6 +218,21 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
     resources = [
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
+    ]
+  }
+
+  statement {
+    sid    = "${local.policy_region_prefix}OpensearchEncryptionAccess"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [
+      data.aws_kms_alias.opensearch_encryption_key.target_key_arn,
     ]
   }
 


### PR DESCRIPTION
# Purpose

After implementing CMK encryption for Opensearch serverless, app deployments fail to create an index as part of the service startup. In addition, we expected deployment failure alarms to trigger for the environment

Fixes MLPAB-2014

## Approach

- allow ecs to create the index
TODO
Fix deployment failure alarms

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
