### PR TITLE
MLPAB-2020: Protect against linking LPA to more than one donor

### DIFF
--- a/internal/app/donor_store.go
+++ b/internal/app/donor_store.go
@@ -129,6 +129,13 @@ func (s *donorStore) Link(ctx context.Context, shareCode actor.ShareCodeData) er
 		return errors.New("donorStore.Link requires SessionID")
 	}
 
+	var link lpaLink
+	if err := s.dynamoClient.OneByPartialSK(ctx, lpaKey(shareCode.LpaID), subKey(""), &link); err != nil && !errors.Is(err, dynamo.NotFoundError{}) {
+		return err
+	} else if link.ActorType == actor.TypeDonor {
+		return errors.New("a donor link already exists for " + shareCode.LpaID)
+	}
+
 	if err := s.dynamoClient.Create(ctx, lpaReference{
 		PK:           lpaKey(shareCode.LpaID),
 		SK:           donorKey(data.SessionID),


### PR DESCRIPTION
# Purpose

This isn't currently possible via the supporter UI but this adds some protection for our future selves making changes to store code or the design that could inadvertently allow this.

Fixes MLPAB-2020