### PR TITLE
MLPAB-2027 create account level bucket for dynamodb exports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,24 +25,24 @@ repos:
       - id: terraform_tflint
         args:
           - --args=--recursive
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.17.0"
-    hooks:
-      - id: terraform-docs-go
-        name: terraform-docs Environment-root
-        args: ["--config", "terraform/environment/.terraform-docs.yml", "./terraform/environment"]
-      - id: terraform-docs-go
-        name: terraform-docs Environment-region
-        args: ["--config", "terraform/environment/region/.terraform-docs.yml", "./terraform/environment/region"]
-      - id: terraform-docs-go
-        name: terraform-docs Environment-global
-        args: ["--config", "terraform/environment/global/.terraform-docs.yml", "./terraform/environment/global"]
-      - id: terraform-docs-go
-        name: terraform-docs Account-root
-        args: ["--config", "terraform/account/.terraform-docs.yml", "./terraform/account"]
-      - id: terraform-docs-go
-        name: terraform-docs Account-region
-        args: ["--config", "terraform/account/region/.terraform-docs.yml", "./terraform/account/region"]
+  # - repo: https://github.com/terraform-docs/terraform-docs
+  #   rev: "v0.17.0"
+  #   hooks:
+  #     - id: terraform-docs-go
+  #       name: terraform-docs Environment-root
+  #       args: ["--config", "terraform/environment/.terraform-docs.yml", "./terraform/environment"]
+  #     - id: terraform-docs-go
+  #       name: terraform-docs Environment-region
+  #       args: ["--config", "terraform/environment/region/.terraform-docs.yml", "./terraform/environment/region"]
+  #     - id: terraform-docs-go
+  #       name: terraform-docs Environment-global
+  #       args: ["--config", "terraform/environment/global/.terraform-docs.yml", "./terraform/environment/global"]
+  #     - id: terraform-docs-go
+  #       name: terraform-docs Account-root
+  #       args: ["--config", "terraform/account/.terraform-docs.yml", "./terraform/account"]
+  #     - id: terraform-docs-go
+  #       name: terraform-docs Account-region
+  #       args: ["--config", "terraform/account/region/.terraform-docs.yml", "./terraform/account/region"]
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,24 +25,6 @@ repos:
       - id: terraform_tflint
         args:
           - --args=--recursive
-  # - repo: https://github.com/terraform-docs/terraform-docs
-  #   rev: "v0.17.0"
-  #   hooks:
-  #     - id: terraform-docs-go
-  #       name: terraform-docs Environment-root
-  #       args: ["--config", "terraform/environment/.terraform-docs.yml", "./terraform/environment"]
-  #     - id: terraform-docs-go
-  #       name: terraform-docs Environment-region
-  #       args: ["--config", "terraform/environment/region/.terraform-docs.yml", "./terraform/environment/region"]
-  #     - id: terraform-docs-go
-  #       name: terraform-docs Environment-global
-  #       args: ["--config", "terraform/environment/global/.terraform-docs.yml", "./terraform/environment/global"]
-  #     - id: terraform-docs-go
-  #       name: terraform-docs Account-root
-  #       args: ["--config", "terraform/account/.terraform-docs.yml", "./terraform/account"]
-  #     - id: terraform-docs-go
-  #       name: terraform-docs Account-region
-  #       args: ["--config", "terraform/account/region/.terraform-docs.yml", "./terraform/account/region"]
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/terraform/account/README.md
+++ b/terraform/account/README.md
@@ -91,16 +91,16 @@ For terraform_environment, this will be based on your PR and can be found in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.7.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.41.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.41.0 |
-| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.41.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.41.0 |
-| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.41.0 |
+| <a name="provider_aws.eu_west_1"></a> [aws.eu\_west\_1](#provider\_aws.eu\_west\_1) | 5.42.0 |
+| <a name="provider_aws.eu_west_2"></a> [aws.eu\_west\_2](#provider\_aws.eu\_west\_2) | 5.42.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 5.42.0 |
+| <a name="provider_aws.management_global"></a> [aws.management\_global](#provider\_aws.management\_global) | 5.42.0 |
 
 ## Modules
 
@@ -124,6 +124,8 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_kms_alias.cloudwatch_alias_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.dynamodb_alias_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.dynamodb_alias_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_alias_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_alias_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -137,12 +139,14 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_kms_alias.sqs_alias_eu_west_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.dynamodb_exports_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.reduced_fees_uploads_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_replica_key.cloudwatch_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
+| [aws_kms_replica_key.dynamodb_exports_s3_bucket_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
 | [aws_kms_replica_key.dynamodb_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
 | [aws_kms_replica_key.opensearch_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
 | [aws_kms_replica_key.reduced_fees_uploads_s3_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
@@ -168,6 +172,9 @@ For terraform_environment, this will be based on your PR and can be found in the
 | [aws_iam_policy_document.cloudwatch_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_kms_development_account_operator_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_kms_merged](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dynamodb_exports_s3_bucket_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dynamodb_exports_s3_bucket_kms_development_account_operator_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dynamodb_exports_s3_bucket_kms_merged](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dynamodb_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dynamodb_kms_development_account_operator_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dynamodb_kms_merged](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/account/dynamodb_exports_s3_kms.tf
+++ b/terraform/account/dynamodb_exports_s3_kms.tf
@@ -21,13 +21,13 @@ resource "aws_kms_replica_key" "dynamodb_exports_s3_bucket_replica" {
 }
 
 resource "aws_kms_alias" "dynamodb_exports_s3_bucket_alias_eu_west_1" {
-  name          = "alias/${local.default_tags.application}_dynamodb_exports_s3_bucket_encryption"
+  name          = "alias/${local.default_tags.application}-dynamodb-exports-s3-bucket-encryption"
   target_key_id = aws_kms_key.dynamodb_exports_s3_bucket.key_id
   provider      = aws.eu_west_1
 }
 
 resource "aws_kms_alias" "dynamodb_exports_s3_bucket_alias_eu_west_2" {
-  name          = "alias/${local.default_tags.application}_dynamodb_exports_s3_bucket_encryption"
+  name          = "alias/${local.default_tags.application}-dynamodb-exports-s3-bucket-encryption"
   target_key_id = aws_kms_replica_key.dynamodb_exports_s3_bucket_replica.key_id
   provider      = aws.eu_west_2
 }

--- a/terraform/account/dynamodb_exports_s3_kms.tf
+++ b/terraform/account/dynamodb_exports_s3_kms.tf
@@ -1,0 +1,199 @@
+resource "aws_kms_key" "dynamodb_exports_s3_bucket" {
+  description             = "${local.default_tags.application} dynamodb exports s3 bucket encryption key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = local.account.account_name == "development" ? data.aws_iam_policy_document.dynamodb_exports_s3_bucket_kms_merged.json : data.aws_iam_policy_document.dynamodb_exports_s3_bucket_kms.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_replica_key" "dynamodb_exports_s3_bucket_replica" {
+  description             = "${local.default_tags.application} dynamodb exprots s3 Multi-Region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.dynamodb_exports_s3_bucket.arn
+  provider                = aws.eu_west_2
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "dynamodb_exports_s3_bucket_alias_eu_west_1" {
+  name          = "alias/${local.default_tags.application}_dynamodb_exports_s3_bucket_encryption"
+  target_key_id = aws_kms_key.dynamodb_exports_s3_bucket.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "dynamodb_exports_s3_bucket_alias_eu_west_2" {
+  name          = "alias/${local.default_tags.application}_dynamodb_exports_s3_bucket_encryption"
+  target_key_id = aws_kms_replica_key.dynamodb_exports_s3_bucket_replica.key_id
+  provider      = aws.eu_west_2
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "dynamodb_exports_s3_bucket_kms_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.dynamodb_exports_s3_bucket_kms.json,
+    data.aws_iam_policy_document.dynamodb_exports_s3_bucket_kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "dynamodb_exports_s3_bucket_kms" {
+  provider = aws.global
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"]
+    }
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/${local.account.account_name}-app-task-role",
+        aws_iam_role.aws_backup_role.arn,
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+
+      values = [
+        "dynamodb_exports_s3_bucket.*.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:List*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/modernising-lpa-ci",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "dynamodb_exports_s3_bucket_kms_development_account_operator_admin" {
+  provider = aws.global
+  statement {
+    sid    = "Dev Account Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.global.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator"
+      ]
+    }
+  }
+}

--- a/terraform/account/dynamodb_exports_s3_kms.tf
+++ b/terraform/account/dynamodb_exports_s3_kms.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "dynamodb_exports_s3_bucket_kms" {
       variable = "kms:ViaService"
 
       values = [
-        "dynamodb_exports_s3_bucket.*.amazonaws.com"
+        "s3.*.amazonaws.com"
       ]
     }
   }

--- a/terraform/account/reduced_fees_uploads_s3_kms.tf
+++ b/terraform/account/reduced_fees_uploads_s3_kms.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "reduced_fees_uploads_s3_kms" {
       variable = "kms:ViaService"
 
       values = [
-        "reduced_fees_uploads_s3.*.amazonaws.com"
+        "s3.*.amazonaws.com"
       ]
     }
   }

--- a/terraform/account/region/README.md
+++ b/terraform/account/region/README.md
@@ -4,16 +4,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.41.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.41.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.41.0 |
-| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.41.0 |
-| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.41.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.42.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | ~> 5.42.0 |
+| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | ~> 5.42.0 |
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.42.0 |
 
 ## Modules
 
@@ -21,6 +21,7 @@
 |------|--------|---------|
 | <a name="module_antivirus_definitions"></a> [antivirus\_definitions](#module\_antivirus\_definitions) | ./modules/antivirus_definitions | n/a |
 | <a name="module_dns_firewall"></a> [dns\_firewall](#module\_dns\_firewall) | ./modules/dns_firewall | n/a |
+| <a name="module_name"></a> [name](#module\_name) | ./modules/dynamodb_exports_s3_bucket | n/a |
 | <a name="module_network"></a> [network](#module\_network) | github.com/ministryofjustice/opg-terraform-aws-network | v1.3.3 |
 | <a name="module_s3_batch_manifests"></a> [s3\_batch\_manifests](#module\_s3\_batch\_manifests) | ./modules/s3_batch_manifests | n/a |
 | <a name="module_s3_event_notifications"></a> [s3\_event\_notifications](#module\_s3\_event\_notifications) | ./modules/s3_bucket_event_notifications | n/a |

--- a/terraform/account/region/README.md
+++ b/terraform/account/region/README.md
@@ -21,7 +21,7 @@
 |------|--------|---------|
 | <a name="module_antivirus_definitions"></a> [antivirus\_definitions](#module\_antivirus\_definitions) | ./modules/antivirus_definitions | n/a |
 | <a name="module_dns_firewall"></a> [dns\_firewall](#module\_dns\_firewall) | ./modules/dns_firewall | n/a |
-| <a name="module_name"></a> [name](#module\_name) | ./modules/dynamodb_exports_s3_bucket | n/a |
+| <a name="module_dynamodb_exports_s3_bucket"></a> [dynamodb\_exports\_s3\_bucket](#module\_dynamodb\_exports\_s3\_bucket) | ./modules/dynamodb_exports_s3_bucket | n/a |
 | <a name="module_network"></a> [network](#module\_network) | github.com/ministryofjustice/opg-terraform-aws-network | v1.3.3 |
 | <a name="module_s3_batch_manifests"></a> [s3\_batch\_manifests](#module\_s3\_batch\_manifests) | ./modules/s3_batch_manifests | n/a |
 | <a name="module_s3_event_notifications"></a> [s3\_event\_notifications](#module\_s3\_event\_notifications) | ./modules/s3_bucket_event_notifications | n/a |
@@ -101,6 +101,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_log_group_kms_key_alias"></a> [cloudwatch\_log\_group\_kms\_key\_alias](#input\_cloudwatch\_log\_group\_kms\_key\_alias) | The alias of the KMS Key to use when encrypting Cloudwatch log data. | `string` | `null` | no |
+| <a name="input_dynamodb_exports_s3_bucket_server_side_encryption_key_id"></a> [dynamodb\_exports\_s3\_bucket\_server\_side\_encryption\_key\_id](#input\_dynamodb\_exports\_s3\_bucket\_server\_side\_encryption\_key\_id) | The ID of the KMS key to use for server-side encryption of the bucket. | `string` | n/a | yes |
 | <a name="input_network_cidr_block"></a> [network\_cidr\_block](#input\_network\_cidr\_block) | The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv4\_netmask\_length. | `string` | n/a | yes |
 | <a name="input_reduced_fees_uploads_s3_encryption_kms_key_alias"></a> [reduced\_fees\_uploads\_s3\_encryption\_kms\_key\_alias](#input\_reduced\_fees\_uploads\_s3\_encryption\_kms\_key\_alias) | The alias of the KMS key used to encrypt the reduced fees uploads S3 bucket and replication manifests | `string` | n/a | yes |
 | <a name="input_secrets_manager_kms_key_alias"></a> [secrets\_manager\_kms\_key\_alias](#input\_secrets\_manager\_kms\_key\_alias) | The alias of the KMS key used to encrypt Secrets Manager secrets | `string` | n/a | yes |

--- a/terraform/account/region/dynamodb_exports_s3_bucket.tf
+++ b/terraform/account/region/dynamodb_exports_s3_bucket.tf
@@ -1,0 +1,8 @@
+module "dynamodb_exports_s3_bucket" {
+  source                                  = "./modules/dynamodb_exports_s3_bucket"
+  s3_bucket_server_side_encryption_key_id = var.dynamodb_exports_s3_bucket_server_side_encryption_key_id
+  s3_bucket_logging_target_bucket_id      = aws_s3_bucket.access_log.id
+  providers = {
+    aws.region = aws.region
+  }
+}

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/README.md
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.42.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_logging.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_ownership_controls.bucket_object_ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.public_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.bucket_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
+| [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_bucket.access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_s3_bucket_logging_target_bucket_id"></a> [s3\_bucket\_logging\_target\_bucket\_id](#input\_s3\_bucket\_logging\_target\_bucket\_id) | The ID of the S3 bucket to which the access logs should be delivered. | `string` | n/a | yes |
+| <a name="input_s3_bucket_server_side_encryption_key_id"></a> [s3\_bucket\_server\_side\_encryption\_key\_id](#input\_s3\_bucket\_server\_side\_encryption\_key\_id) | The ID of the KMS key to use for server-side encryption of the bucket. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/README.md
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/README.md
@@ -27,11 +27,9 @@ No modules.
 | [aws_s3_bucket_public_access_block.public_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.bucket_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [aws_s3_bucket.access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/data_sources.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/data_sources.tf
@@ -1,0 +1,7 @@
+data "aws_region" "current" {
+  provider = aws.region
+}
+
+data "aws_default_tags" "current" {
+  provider = aws.region
+}

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
@@ -1,0 +1,103 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket        = "dynamodb-exports-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}"
+  force_destroy = true
+  provider      = aws.region
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket_object_ownership" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+  provider = aws.region
+}
+
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+  provider = aws.region
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption_configuration" {
+  bucket = aws_s3_bucket.bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.s3_bucket_server_side_encryption_key_id
+      sse_algorithm     = "aws:kms"
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access_policy" {
+  bucket                  = aws_s3_bucket.bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+  provider                = aws.region
+}
+
+resource "aws_s3_bucket_policy" "bucket" {
+  depends_on = [aws_s3_bucket_public_access_block.public_access_policy]
+  bucket     = aws_s3_bucket.bucket.id
+  policy     = data.aws_iam_policy_document.bucket.json
+  provider   = aws.region
+}
+
+resource "aws_s3_bucket_logging" "bucket" {
+  bucket        = aws_s3_bucket.bucket.id
+  target_bucket = var.s3_bucket_logging_target_bucket_id
+  target_prefix = "log/${aws_s3_bucket.bucket.id}/"
+  provider      = aws.region
+}
+
+data "aws_iam_policy_document" "bucket" {
+  policy_id = "PutObjPolicy"
+
+  statement {
+    sid       = "DenyUnEncryptedObjectUploads"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["aws:kms"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid     = "DenyNonSSLRequests"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.bucket.arn,
+      "${aws_s3_bucket.bucket.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  provider = aws.region
+}

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/variables.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/variables.tf
@@ -1,0 +1,9 @@
+variable "s3_bucket_logging_target_bucket_id" {
+  description = "The ID of the S3 bucket to which the access logs should be delivered."
+  type        = string
+}
+
+variable "s3_bucket_server_side_encryption_key_id" {
+  description = "The ID of the KMS key to use for server-side encryption of the bucket."
+  type        = string
+}

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/versions.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.42.0"
+      configuration_aliases = [
+        aws.region,
+      ]
+    }
+  }
+}

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -23,3 +23,8 @@ variable "reduced_fees_uploads_s3_encryption_kms_key_alias" {
   description = "The alias of the KMS key used to encrypt the reduced fees uploads S3 bucket and replication manifests"
   type        = string
 }
+
+variable "dynamodb_exports_s3_bucket_server_side_encryption_key_id" {
+  description = "The ID of the KMS key to use for server-side encryption of the bucket."
+  type        = string
+}

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,11 +1,12 @@
 module "eu_west_1" {
-  source                                           = "./region"
-  count                                            = contains(local.account.regions, "eu-west-1") ? 1 : 0
-  network_cidr_block                               = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_1.name
-  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_1.name
-  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_1.name
-  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1.name
+  source                                                   = "./region"
+  count                                                    = contains(local.account.regions, "eu-west-1") ? 1 : 0
+  network_cidr_block                                       = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias                       = aws_kms_alias.cloudwatch_alias_eu_west_1.name
+  sns_kms_key_alias                                        = aws_kms_alias.sns_alias_eu_west_1.name
+  secrets_manager_kms_key_alias                            = aws_kms_alias.secrets_manager_alias_eu_west_1.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias         = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1.name
+  dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_1.name
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
@@ -14,13 +15,14 @@ module "eu_west_1" {
 }
 
 module "eu_west_2" {
-  source                                           = "./region"
-  count                                            = contains(local.account.regions, "eu-west-2") ? 1 : 0
-  network_cidr_block                               = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_2.name
-  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_2.name
-  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_2.name
-  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_2.name
+  source                                                   = "./region"
+  count                                                    = contains(local.account.regions, "eu-west-2") ? 1 : 0
+  network_cidr_block                                       = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias                       = aws_kms_alias.cloudwatch_alias_eu_west_2.name
+  sns_kms_key_alias                                        = aws_kms_alias.sns_alias_eu_west_2.name
+  secrets_manager_kms_key_alias                            = aws_kms_alias.secrets_manager_alias_eu_west_2.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias         = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_2.name
+  dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_2.name
   providers = {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2


### PR DESCRIPTION
# Purpose

Create an encrypted S3 bucket for DynamoDB exports used for Opensearch Ingestion Pipelines

Fixes MLPAB-2027

## Approach

- create a KMS key for bucket encryption
- create a bucket for DynamoDB exports
- turn off terraform-docs pre-commit hook (will be replaced with an automation later)
