### PR TITLE
MLPAB-2027 - Don't use CMK for bucket SSE

### DIFF
--- a/terraform/account/region/dynamodb_exports_s3_bucket.tf
+++ b/terraform/account/region/dynamodb_exports_s3_bucket.tf
@@ -1,7 +1,7 @@
 module "dynamodb_exports_s3_bucket" {
-  source                                  = "./modules/dynamodb_exports_s3_bucket"
-  s3_bucket_server_side_encryption_key_id = var.dynamodb_exports_s3_bucket_server_side_encryption_key_id
-  s3_bucket_logging_target_bucket_id      = aws_s3_bucket.access_log.id
+  source = "./modules/dynamodb_exports_s3_bucket"
+  # s3_bucket_server_side_encryption_key_id = var.dynamodb_exports_s3_bucket_server_side_encryption_key_id
+  s3_bucket_logging_target_bucket_id = aws_s3_bucket.access_log.id
   providers = {
     aws.region = aws.region
   }

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
@@ -27,8 +27,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.s3_bucket_server_side_encryption_key_id
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
   provider = aws.region

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/variables.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/variables.tf
@@ -3,7 +3,7 @@ variable "s3_bucket_logging_target_bucket_id" {
   type        = string
 }
 
-variable "s3_bucket_server_side_encryption_key_id" {
-  description = "The ID of the KMS key to use for server-side encryption of the bucket."
-  type        = string
-}
+# variable "s3_bucket_server_side_encryption_key_id" {
+#   description = "The ID of the KMS key to use for server-side encryption of the bucket."
+#   type        = string
+# }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -24,7 +24,7 @@ variable "reduced_fees_uploads_s3_encryption_kms_key_alias" {
   type        = string
 }
 
-variable "dynamodb_exports_s3_bucket_server_side_encryption_key_id" {
-  description = "The ID of the KMS key to use for server-side encryption of the bucket."
-  type        = string
-}
+# variable "dynamodb_exports_s3_bucket_server_side_encryption_key_id" {
+#   description = "The ID of the KMS key to use for server-side encryption of the bucket."
+#   type        = string
+# }

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,12 +1,12 @@
 module "eu_west_1" {
-  source                                                   = "./region"
-  count                                                    = contains(local.account.regions, "eu-west-1") ? 1 : 0
-  network_cidr_block                                       = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias                       = aws_kms_alias.cloudwatch_alias_eu_west_1.name
-  sns_kms_key_alias                                        = aws_kms_alias.sns_alias_eu_west_1.name
-  secrets_manager_kms_key_alias                            = aws_kms_alias.secrets_manager_alias_eu_west_1.name
-  reduced_fees_uploads_s3_encryption_kms_key_alias         = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1.name
-  dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_1.name
+  source                                           = "./region"
+  count                                            = contains(local.account.regions, "eu-west-1") ? 1 : 0
+  network_cidr_block                               = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_1.name
+  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_1.name
+  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_1.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_1.name
+  # dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_1.name
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
@@ -15,14 +15,14 @@ module "eu_west_1" {
 }
 
 module "eu_west_2" {
-  source                                                   = "./region"
-  count                                                    = contains(local.account.regions, "eu-west-2") ? 1 : 0
-  network_cidr_block                                       = "10.162.0.0/16"
-  cloudwatch_log_group_kms_key_alias                       = aws_kms_alias.cloudwatch_alias_eu_west_2.name
-  sns_kms_key_alias                                        = aws_kms_alias.sns_alias_eu_west_2.name
-  secrets_manager_kms_key_alias                            = aws_kms_alias.secrets_manager_alias_eu_west_2.name
-  reduced_fees_uploads_s3_encryption_kms_key_alias         = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_2.name
-  dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_2.name
+  source                                           = "./region"
+  count                                            = contains(local.account.regions, "eu-west-2") ? 1 : 0
+  network_cidr_block                               = "10.162.0.0/16"
+  cloudwatch_log_group_kms_key_alias               = aws_kms_alias.cloudwatch_alias_eu_west_2.name
+  sns_kms_key_alias                                = aws_kms_alias.sns_alias_eu_west_2.name
+  secrets_manager_kms_key_alias                    = aws_kms_alias.secrets_manager_alias_eu_west_2.name
+  reduced_fees_uploads_s3_encryption_kms_key_alias = aws_kms_alias.reduced_fees_uploads_s3_alias_eu_west_2.name
+  # dynamodb_exports_s3_bucket_server_side_encryption_key_id = aws_kms_alias.dynamodb_exports_s3_bucket_alias_eu_west_2.name
   providers = {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2


### PR DESCRIPTION
# Purpose

Create encrypted S3 bucket for DynamoDB exports used by OpenSearch Ingestion Pipelines

Fixes MLPAB-2027

## Approach

- don't use CMK for DynamoDB exports (for now)
