### PR TITLE
Remove Certificate Provider email when changing to paper channel

### DIFF
--- a/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
+++ b/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role.go
@@ -58,9 +58,14 @@ type howWouldCertificateProviderPreferToCarryOutTheirRoleForm struct {
 func readHowWouldCertificateProviderPreferToCarryOutTheirRole(r *http.Request) *howWouldCertificateProviderPreferToCarryOutTheirRoleForm {
 	carryOutBy, err := actor.ParseCertificateProviderCarryOutBy(page.PostFormString(r, "carry-out-by"))
 
+	email := page.PostFormString(r, "email")
+	if carryOutBy.IsPaper() {
+		email = ""
+	}
+
 	return &howWouldCertificateProviderPreferToCarryOutTheirRoleForm{
 		CarryOutBy: carryOutBy,
-		Email:      page.PostFormString(r, "email"),
+		Email:      email,
 		Error:      err,
 	}
 }

--- a/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
+++ b/internal/page/donor/how_would_certificate_provider_prefer_to_carry_out_their_role_test.go
@@ -191,46 +191,46 @@ func TestReadHowWouldCertificateProviderPreferToCarryOutTheirRoleForm(t *testing
 	testcases := map[string]struct {
 		carryOutBy   actor.CertificateProviderCarryOutBy
 		email        string
+		formValues   url.Values
 		expectedForm *howWouldCertificateProviderPreferToCarryOutTheirRoleForm
 	}{
 		"online with email": {
-			carryOutBy: actor.Online,
-			email:      "a@b.com",
+			formValues: url.Values{
+				"carry-out-by": {actor.Online.String()},
+				"email":        {"a@b.com"},
+			},
 			expectedForm: &howWouldCertificateProviderPreferToCarryOutTheirRoleForm{
 				CarryOutBy: actor.Online,
 				Email:      "a@b.com",
 			},
 		},
 		"paper": {
-			carryOutBy: actor.Paper,
+			formValues: url.Values{
+				"carry-out-by": {actor.Paper.String()},
+			},
 			expectedForm: &howWouldCertificateProviderPreferToCarryOutTheirRoleForm{
 				CarryOutBy: actor.Paper,
-				Email:      "a@b.com",
 			},
 		},
 		"paper with email": {
-			carryOutBy: actor.Paper,
-			email:      "a@b.com",
+			formValues: url.Values{
+				"carry-out-by": {actor.Paper.String()},
+				"email":        {"a@b.com"},
+			},
 			expectedForm: &howWouldCertificateProviderPreferToCarryOutTheirRoleForm{
 				CarryOutBy: actor.Paper,
 			},
 		},
 	}
 
-	for name, testcases := range testcases {
+	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			form := url.Values{
-				"carry-out-by": {actor.Online.String()},
-				"email":        {"someone@example.com"},
-			}
-
-			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+			r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tc.formValues.Encode()))
 			r.Header.Add("Content-Type", page.FormUrlEncoded)
 
 			result := readHowWouldCertificateProviderPreferToCarryOutTheirRole(r)
 
-			assert.Equal(t, actor.Online, result.CarryOutBy)
-			assert.Equal(t, "someone@example.com", result.Email)
+			assert.Equal(t, tc.expectedForm, result)
 		})
 	}
 }


### PR DESCRIPTION
# Purpose

As we [validate](https://github.com/ministryofjustice/opg-data-lpa-store/blob/main/lambda/create/validate.go#L25) on this field not being present in the lpa store.