### PR TITLE
Use BaseEndpoint instead of deprecated resolver for aws config 

### DIFF
--- a/cmd/event-logger/main.go
+++ b/cmd/event-logger/main.go
@@ -58,13 +58,7 @@ func main() {
 	}
 
 	cfg.Region = "eu-west-1"
-	cfg.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		return aws.Endpoint{
-			PartitionID:   "aws",
-			URL:           awsBaseURL,
-			SigningRegion: "eu-west-1",
-		}, nil
-	})
+	cfg.BaseEndpoint = aws.String(awsBaseURL)
 
 	client := sqs.NewFromConfig(cfg)
 

--- a/cmd/event-received/main.go
+++ b/cmd/event-received/main.go
@@ -80,13 +80,7 @@ func handler(ctx context.Context, event Event) error {
 	}
 
 	if len(awsBaseURL) > 0 {
-		cfg.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{
-				PartitionID:   "aws",
-				URL:           awsBaseURL,
-				SigningRegion: "eu-west-1",
-			}, nil
-		})
+		cfg.BaseEndpoint = aws.String(awsBaseURL)
 	}
 
 	dynamoClient, err := dynamo.NewClient(cfg, tableName)

--- a/cmd/mlpa/main.go
+++ b/cmd/mlpa/main.go
@@ -189,17 +189,11 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		return fmt.Errorf("unable to load SDK config: %w", err)
 	}
 
-	otelaws.AppendMiddlewares(&cfg.APIOptions)
-
 	if len(awsBaseURL) > 0 {
-		cfg.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{
-				PartitionID:   "aws",
-				URL:           awsBaseURL,
-				SigningRegion: "eu-west-1",
-			}, nil
-		})
+		cfg.BaseEndpoint = aws.String(awsBaseURL)
 	}
+
+	otelaws.AppendMiddlewares(&cfg.APIOptions)
 
 	lpasDynamoClient, err := dynamo.NewClient(cfg, dynamoTableLpas)
 	if err != nil {


### PR DESCRIPTION
This has been annoying me for a while, and I keep forgetting to update