### PR TITLE
MLPAB-2067 - Only deploy OpenSearch Ingestion Pipeline when needed

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -467,10 +467,6 @@ locals {
         {
           name  = "SEARCH_ENDPOINT",
           value = var.search_endpoint == null ? "" : var.search_endpoint
-        },
-        {
-          name  = "SEARCH_INDEXING_DISABLED",
-          value = "1"
         }
       ]
     }


### PR DESCRIPTION
# Purpose

Save build time by not deploying ingestion pipelines when they aren't needed. This will not need to be per environment, but instead will be enabled when dependant work is completed.

Fixes MLPAB-2067

## Approach

- create a flag
- create resources if true
- re-enable app search indexing
