### PR TITLE
MLPAB-2074 S3 antivirus doesnt need VPC access

### DIFF
--- a/terraform/environment/region/modules/s3_antivirus/data_sources.tf
+++ b/terraform/environment/region/modules/s3_antivirus/data_sources.tf
@@ -1,8 +1,3 @@
-
-# data "aws_region" "current" {
-#   provider = aws.region
-# }
-
 data "aws_caller_identity" "current" {
   provider = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/data_sources.tf
+++ b/terraform/environment/region/modules/s3_antivirus/data_sources.tf
@@ -1,7 +1,7 @@
 
-data "aws_region" "current" {
-  provider = aws.region
-}
+# data "aws_region" "current" {
+#   provider = aws.region
+# }
 
 data "aws_caller_identity" "current" {
   provider = aws.region
@@ -13,5 +13,10 @@ data "aws_default_tags" "current" {
 
 data "aws_kms_alias" "uploads_encryption_key" {
   name     = "alias/${data.aws_default_tags.current.tags.application}_reduced_fees_uploads_s3_encryption"
+  provider = aws.region
+}
+
+data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_cloudwatch_application_logs_encryption"
   provider = aws.region
 }

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -36,13 +36,6 @@ resource "aws_lambda_function" "lambda_function" {
     log_format = "JSON"
   }
 
-  # vpc_config {
-  #   subnet_ids = var.aws_subnet_ids
-  #   security_group_ids = [
-  #     data.aws_security_group.lambda_egress.id
-  #   ]
-  # }
-
   dynamic "environment" {
     for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
     content {
@@ -51,11 +44,6 @@ resource "aws_lambda_function" "lambda_function" {
   }
   provider = aws.region
 }
-
-# data "aws_security_group" "lambda_egress" {
-#   name     = "lambda-egress-${data.aws_region.current.name}"
-#   provider = aws.region
-# }
 
 resource "aws_lambda_alias" "lambda_alias" {
   name             = "latest"

--- a/terraform/environment/region/modules/s3_antivirus/main.tf
+++ b/terraform/environment/region/modules/s3_antivirus/main.tf
@@ -1,8 +1,3 @@
-data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
-  name     = "alias/${data.aws_default_tags.current.tags.application}_cloudwatch_application_logs_encryption"
-  provider = aws.region
-}
-
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/s3-antivirus-${data.aws_default_tags.current.tags.environment-name}"
   kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
@@ -41,12 +36,12 @@ resource "aws_lambda_function" "lambda_function" {
     log_format = "JSON"
   }
 
-  vpc_config {
-    subnet_ids = var.aws_subnet_ids
-    security_group_ids = [
-      data.aws_security_group.lambda_egress.id
-    ]
-  }
+  # vpc_config {
+  #   subnet_ids = var.aws_subnet_ids
+  #   security_group_ids = [
+  #     data.aws_security_group.lambda_egress.id
+  #   ]
+  # }
 
   dynamic "environment" {
     for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
@@ -57,10 +52,10 @@ resource "aws_lambda_function" "lambda_function" {
   provider = aws.region
 }
 
-data "aws_security_group" "lambda_egress" {
-  name     = "lambda-egress-${data.aws_region.current.name}"
-  provider = aws.region
-}
+# data "aws_security_group" "lambda_egress" {
+#   name     = "lambda-egress-${data.aws_region.current.name}"
+#   provider = aws.region
+# }
 
 resource "aws_lambda_alias" "lambda_alias" {
   name             = "latest"

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -3,11 +3,6 @@ variable "alarm_sns_topic_arn" {
   type        = string
 }
 
-# variable "aws_subnet_ids" {
-#   type        = list(string)
-#   description = "List of Sirius private subnet Ids"
-# }
-
 variable "data_store_bucket" {
   type        = any
   description = "Data store bucket to scan for viruses"

--- a/terraform/environment/region/modules/s3_antivirus/variables.tf
+++ b/terraform/environment/region/modules/s3_antivirus/variables.tf
@@ -3,10 +3,10 @@ variable "alarm_sns_topic_arn" {
   type        = string
 }
 
-variable "aws_subnet_ids" {
-  type        = list(string)
-  description = "List of Sirius private subnet Ids"
-}
+# variable "aws_subnet_ids" {
+#   type        = list(string)
+#   description = "List of Sirius private subnet Ids"
+# }
 
 variable "data_store_bucket" {
   type        = any

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -15,9 +15,8 @@ data "aws_s3_bucket" "antivirus_definitions" {
 }
 
 module "s3_antivirus" {
-  source              = "./modules/s3_antivirus"
-  alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
-  # aws_subnet_ids                       = data.aws_subnet.application[*].id
+  source                               = "./modules/s3_antivirus"
+  alarm_sns_topic_arn                  = data.aws_sns_topic.custom_cloudwatch_alarms.arn
   data_store_bucket                    = module.uploads_s3_bucket.bucket
   definition_bucket                    = data.aws_s3_bucket.antivirus_definitions
   ecr_image_uri                        = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -15,9 +15,9 @@ data "aws_s3_bucket" "antivirus_definitions" {
 }
 
 module "s3_antivirus" {
-  source                               = "./modules/s3_antivirus"
-  alarm_sns_topic_arn                  = data.aws_sns_topic.custom_cloudwatch_alarms.arn
-  aws_subnet_ids                       = data.aws_subnet.application[*].id
+  source              = "./modules/s3_antivirus"
+  alarm_sns_topic_arn = data.aws_sns_topic.custom_cloudwatch_alarms.arn
+  # aws_subnet_ids                       = data.aws_subnet.application[*].id
   data_store_bucket                    = module.uploads_s3_bucket.bucket
   definition_bucket                    = data.aws_s3_bucket.antivirus_definitions
   ecr_image_uri                        = "${data.aws_ecr_repository.s3_antivirus.repository_url}@${data.aws_ecr_image.s3_antivirus.image_digest}"


### PR DESCRIPTION
# Purpose

Remove VPC config as lambda function doesn't need to access VPC resources

Fixes MLPAB-2074

## Approach

- remove vpc config from lambda function

## Learning

- https://docs.aws.amazon.com/lambda/latest/dg/foundation-networking.html#foundation-nw-connecting
