### PR TITLE
MLPAB-2085 - Reduce cold start time for S3 antivirus scanning lambda function

### DIFF
--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -5,8 +5,8 @@ data "aws_ecr_repository" "s3_antivirus" {
 
 data "aws_ecr_image" "s3_antivirus" {
   repository_name = data.aws_ecr_repository.s3_antivirus.name
-  image_tag       = "v0.585.0-MLPAB-2085-fix-prerelease.0"
-  # image_tag       = "latest"
+  image_tag       = "v0.586.0-MLPAB-2085-use-an-aws-base-image-for-the-lambda-function.1"
+  # image_tag = "latest"
   provider = aws.management
 }
 

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -5,8 +5,9 @@ data "aws_ecr_repository" "s3_antivirus" {
 
 data "aws_ecr_image" "s3_antivirus" {
   repository_name = data.aws_ecr_repository.s3_antivirus.name
-  image_tag       = "latest"
-  provider        = aws.management
+  image_tag       = "v0.585.0-MLPAB-2085-fix-prerelease.0"
+  # image_tag       = "latest"
+  provider = aws.management
 }
 
 data "aws_s3_bucket" "antivirus_definitions" {


### PR DESCRIPTION
# Purpose

Cold starts for the lambda resulted in up to 6 minutes for a response. This PR compares using the existing lambda image with one build using an amazon linux lambda image from AWS public ECR.

Fixes MLPAB-2085

## Approach

- use an aws based image for the lambda function

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
