### PR TITLE
MLPAB-2040 - Rightsize mock ECS resources to save costs

### DIFF
--- a/terraform/environment/region/modules/event_received/lambda.tf
+++ b/terraform/environment/region/modules/event_received/lambda.tf
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_event_rule" "receive_events_sirius" {
   event_bus_name = var.event_bus_name
 
   event_pattern = jsonencode({
-    source      = ["opg.poas.sirius"],
+    source = ["opg.poas.sirius"],
     detail-type = [
       "certificate-provider-submission-completed",
       "donor-submission-completed",

--- a/terraform/environment/region/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/ecs.tf
@@ -122,8 +122,8 @@ resource "aws_ecs_task_definition" "mock_onelogin" {
   family                   = "${local.name_prefix}-mock-onelogin"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = 256
+  memory                   = 512
   container_definitions    = "[${local.mock_onelogin}]"
   task_role_arn            = var.ecs_task_role.arn
   execution_role_arn       = var.ecs_execution_role.arn

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,7 +24,7 @@
         "fault_injection_experiments_enabled": false,
         "real_user_monitoring_cw_logs_enabled": false
       },
-      "mock_onelogin_enabled": true,
+      "mock_onelogin_enabled": false,
       "uid_service": {
         "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
         "api_arns": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,7 +24,7 @@
         "fault_injection_experiments_enabled": false,
         "real_user_monitoring_cw_logs_enabled": false
       },
-      "mock_onelogin_enabled": false,
+      "mock_onelogin_enabled": true,
       "uid_service": {
         "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
         "api_arns": [


### PR DESCRIPTION
# Purpose

AWS cost optimisation has recommended assigning smaller resources for the mock login ECS task.

Fixes MLPAB-2040

## Approach

- assign half the memory and cpu to the ECS task based on cost optimisation recommendation