### PR TITLE
Add `channel` to LPAs returned from LPA Store

### DIFF
--- a/internal/lpastore/client_test.go
+++ b/internal/lpastore/client_test.go
@@ -800,6 +800,7 @@ func TestClientServiceContract(t *testing.T) {
 					"uid":     matchers.Regex("M-0000-1111-2222", "M(-[A-Z0-9]{4}){3}"),
 					"status":  matchers.String("processing"),
 					"lpaType": matchers.String("personal-welfare"),
+					"channel": matchers.String("online"),
 					"donor": matchers.Like(map[string]any{
 						"firstNames":  matchers.String("Homer"),
 						"lastName":    matchers.String("Zoller"),
@@ -861,8 +862,9 @@ func TestClientServiceContract(t *testing.T) {
 			}
 
 			assert.Equal(t, &Lpa{
-				LpaUID: "M-0000-1111-2222",
-				Type:   actor.LpaTypePersonalWelfare,
+				LpaUID:  "M-0000-1111-2222",
+				Type:    actor.LpaTypePersonalWelfare,
+				Channel: actor.ChannelOnline,
 				Donor: actor.Donor{
 					FirstNames:  "Homer",
 					LastName:    "Zoller",
@@ -929,6 +931,7 @@ func TestClientServiceContract(t *testing.T) {
 						"uid":     matchers.Regex("M-0000-1111-2222", "M(-[A-Z0-9]{4}){3}"),
 						"status":  matchers.String("processing"),
 						"lpaType": matchers.String("personal-welfare"),
+						"channel": matchers.String("online"),
 						"donor": matchers.Like(map[string]any{
 							"firstNames":  matchers.String("Homer"),
 							"lastName":    matchers.String("Zoller"),
@@ -991,8 +994,9 @@ func TestClientServiceContract(t *testing.T) {
 			}
 
 			assert.Equal(t, []*Lpa{{
-				LpaUID: "M-0000-1111-2222",
-				Type:   actor.LpaTypePersonalWelfare,
+				LpaUID:  "M-0000-1111-2222",
+				Type:    actor.LpaTypePersonalWelfare,
+				Channel: actor.ChannelOnline,
 				Donor: actor.Donor{
 					FirstNames:  "Homer",
 					LastName:    "Zoller",

--- a/internal/lpastore/lpa.go
+++ b/internal/lpastore/lpa.go
@@ -301,6 +301,7 @@ func (c CertificateProvider) FullName() string {
 type lpaResponse struct {
 	LpaType                                     actor.LpaType                    `json:"lpaType"`
 	Donor                                       lpaRequestDonor                  `json:"donor"`
+	Channel                                     actor.Channel                    `json:"channel"`
 	Attorneys                                   []lpaResponseAttorney            `json:"attorneys"`
 	TrustCorporations                           []lpaResponseTrustCorporation    `json:"trustCorporations,omitempty"`
 	CertificateProvider                         CertificateProvider              `json:"certificateProvider"`
@@ -372,6 +373,7 @@ type Lpa struct {
 	PerfectAt                                  time.Time
 	UpdatedAt                                  time.Time
 	Type                                       actor.LpaType
+	Channel                                    actor.Channel
 	Donor                                      actor.Donor
 	Attorneys                                  Attorneys
 	ReplacementAttorneys                       Attorneys
@@ -485,6 +487,7 @@ func lpaResponseToLpa(l lpaResponse) *Lpa {
 		RegisteredAt: l.RegistrationDate,
 		UpdatedAt:    l.UpdatedAt,
 		Type:         l.LpaType,
+		Channel:      l.Channel,
 		Donor: actor.Donor{
 			UID:         l.Donor.UID,
 			FirstNames:  l.Donor.FirstNames,

--- a/internal/lpastore/lpa_test.go
+++ b/internal/lpastore/lpa_test.go
@@ -382,8 +382,9 @@ func TestClientLpa(t *testing.T) {
 	}{
 		"minimal": {
 			donor: &Lpa{
-				LpaUID: "M-0000-1111-2222",
-				Type:   actor.LpaTypePropertyAndAffairs,
+				LpaUID:  "M-0000-1111-2222",
+				Type:    actor.LpaTypePropertyAndAffairs,
+				Channel: actor.ChannelOnline,
 				Donor: actor.Donor{
 					UID:         donorUID,
 					FirstNames:  "John Johnson",
@@ -440,8 +441,9 @@ func TestClientLpa(t *testing.T) {
 		},
 		"everything": {
 			donor: &Lpa{
-				LpaUID: "M-0000-1111-2222",
-				Type:   actor.LpaTypePersonalWelfare,
+				LpaUID:  "M-0000-1111-2222",
+				Type:    actor.LpaTypePersonalWelfare,
+				Channel: actor.ChannelOnline,
 				Donor: actor.Donor{
 					UID:         donorUID,
 					FirstNames:  "John Johnson",
@@ -746,8 +748,9 @@ func TestClientLpas(t *testing.T) {
 		"minimal": {
 			lpas: []*Lpa{
 				{
-					LpaUID: "M-0000-1111-2222",
-					Type:   actor.LpaTypePropertyAndAffairs,
+					LpaUID:  "M-0000-1111-2222",
+					Type:    actor.LpaTypePropertyAndAffairs,
+					Channel: actor.ChannelOnline,
 					Donor: actor.Donor{
 						UID:         donorUID,
 						FirstNames:  "John Johnson",
@@ -806,8 +809,9 @@ func TestClientLpas(t *testing.T) {
 		"everything": {
 			lpas: []*Lpa{
 				{
-					LpaUID: "M-0000-1111-2222",
-					Type:   actor.LpaTypePersonalWelfare,
+					LpaUID:  "M-0000-1111-2222",
+					Type:    actor.LpaTypePersonalWelfare,
+					Channel: actor.ChannelOnline,
 					Donor: actor.Donor{
 						UID:         donorUID,
 						FirstNames:  "John Johnson",


### PR DESCRIPTION
# Purpose

To be used in CP opt-out.

Fixes MLPAB-1535

## Approach

The property is already in the LPA Store, so this just adds it to structs, testing and Pact contract.

