### PR TITLE
MLPAB-2181 - add lifecycle policy to dynamodb exports bucket

### DIFF
--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
@@ -33,6 +33,21 @@ resource "aws_s3_bucket_versioning" "bucket_versioning" {
 #   provider = aws.region
 # }
 
+
+resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
+  provider = aws.region
+  bucket   = aws_s3_bucket.bucket.id
+
+  rule {
+    id     = "retain-dynamodb-exports-for-30-days"
+    status = "Enabled"
+    expiration {
+      days = 30
+    }
+
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "public_access_policy" {
   bucket                  = aws_s3_bucket.bucket.id
   block_public_acls       = true


### PR DESCRIPTION
# Purpose

Automatically clear down exports

Fixes MLPAB-2181

## Approach

- add lifecycle to expire objects after 30 days

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration
