### PR TITLE
MLPAB-2193 - grant public access to the development collection

### DIFF
--- a/terraform/account/opensearch.tf
+++ b/terraform/account/opensearch.tf
@@ -61,6 +61,26 @@ resource "aws_opensearchserverless_security_policy" "lpas_collection_network_pol
   provider = aws.eu_west_1
 }
 
+resource "aws_opensearchserverless_security_policy" "lpas_collection_development_network_policy" {
+  count       = local.account_name == "development" ? 1 : 0
+  name        = "development-public-access"
+  type        = "network"
+  description = "Public access for development collection endpoints"
+  policy = jsonencode([
+    {
+      Description = "Public access for development collection endpoint",
+      Rules = [
+        {
+          ResourceType = "collection",
+          Resource     = ["collection/shared-collection-development"]
+        }
+      ],
+      AllowFromPublic = true,
+    },
+  ])
+  provider = aws.eu_west_1
+}
+
 resource "aws_opensearchserverless_access_policy" "team_operator_access" {
   count       = local.account_name == "production" ? 0 : 1
   name        = "team-access-shared-${local.account_name}"


### PR DESCRIPTION
# Purpose

Allow access to programmatically delete PR environment indexes

Fixes MLPAB-2193

## Approach

- Allow from public on the development collection

## Learning

- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-network.html
