### PR TITLE
MLPAB-2069 Add versioning to hashes and exclude some fields from CheckedHash

### DIFF
--- a/cmd/event-received/handlers.go
+++ b/cmd/event-received/handlers.go
@@ -54,13 +54,9 @@ func handleObjectTagsAdded(ctx context.Context, dynamodbClient dynamodbClient, e
 
 func putDonor(ctx context.Context, donor *actor.DonorProvidedDetails, now func() time.Time, client dynamodbClient) error {
 	donor.UpdatedAt = now()
-
-	hash, err := donor.GenerateHash()
-	if err != nil {
+	if err := donor.UpdateHash(); err != nil {
 		return err
 	}
-
-	donor.Hash = hash
 
 	return client.Put(ctx, donor)
 }

--- a/cmd/event-received/lpastore_event_handler_test.go
+++ b/cmd/event-received/lpastore_event_handler_test.go
@@ -32,7 +32,7 @@ func TestLpaStoreEventHandlerHandleLpaUpdated(t *testing.T) {
 		PerfectAt: testNow,
 		UpdatedAt: testNow,
 	}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.
@@ -91,7 +91,7 @@ func TestLpaStoreEventHandlerHandleLpaUpdatedWhenDynamoGetErrors(t *testing.T) {
 		PerfectAt: testNow,
 		UpdatedAt: testNow,
 	}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.
@@ -120,7 +120,7 @@ func TestLpaStoreEventHandlerHandleLpaUpdatedWhenDynamoPutErrors(t *testing.T) {
 		PerfectAt: testNow,
 		UpdatedAt: testNow,
 	}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.

--- a/cmd/event-received/sirius_event_handler_test.go
+++ b/cmd/event-received/sirius_event_handler_test.go
@@ -163,7 +163,7 @@ func TestHandleFeeApproved(t *testing.T) {
 	now := time.Now()
 
 	updatedDonorProvided := completedDonorProvided
-	updatedDonorProvided.Hash, _ = updatedDonorProvided.GenerateHash()
+	updatedDonorProvided.UpdateHash()
 	updatedDonorProvided.UpdatedAt = now
 
 	client.EXPECT().
@@ -229,7 +229,7 @@ func TestHandleFeeApprovedWhenNotSigned(t *testing.T) {
 
 	updatedDonorProvided := donorProvided
 	updatedDonorProvided.Tasks.PayForLpa = actor.PaymentTaskCompleted
-	updatedDonorProvided.Hash, _ = updatedDonorProvided.GenerateHash()
+	updatedDonorProvided.UpdateHash()
 	updatedDonorProvided.UpdatedAt = now
 
 	client.EXPECT().
@@ -398,7 +398,7 @@ func TestHandleFurtherInfoRequested(t *testing.T) {
 
 	now := time.Now()
 	updated := &actor.DonorProvidedDetails{PK: dynamo.LpaKey("123"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("456")), Tasks: actor.DonorTasks{PayForLpa: actor.PaymentTaskMoreEvidenceRequired}, UpdatedAt: now}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.
@@ -475,7 +475,7 @@ func TestHandleFurtherInfoRequestedWhenPutError(t *testing.T) {
 
 	now := time.Now()
 	updated := &actor.DonorProvidedDetails{PK: dynamo.LpaKey("123"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("456")), Tasks: actor.DonorTasks{PayForLpa: actor.PaymentTaskMoreEvidenceRequired}, UpdatedAt: now}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.
@@ -508,7 +508,7 @@ func TestHandleFeeDenied(t *testing.T) {
 
 	now := time.Now()
 	updated := &actor.DonorProvidedDetails{PK: dynamo.LpaKey("123"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("456")), Tasks: actor.DonorTasks{PayForLpa: actor.PaymentTaskDenied}, FeeType: pay.FullFee, UpdatedAt: now}
-	updated.Hash, _ = updated.GenerateHash()
+	updated.UpdateHash()
 
 	client := newMockDynamodbClient(t)
 	client.

--- a/internal/actor/donor_provided.go
+++ b/internal/actor/donor_provided.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"errors"
 	"slices"
 	"strings"
 	"time"
@@ -13,6 +14,11 @@ import (
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/pay"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/place"
 	"github.com/mitchellh/hashstructure/v2"
+)
+
+const (
+	currentHashVersion        uint8 = 0
+	currentCheckedHashVersion uint8 = 0
 )
 
 type DonorTasks struct {
@@ -37,6 +43,8 @@ type DonorProvidedDetails struct {
 	SK dynamo.LpaOwnerKeyType `hash:"-"`
 	// Hash is used to determine whether the Lpa has been changed since last read
 	Hash uint64 `hash:"-"`
+	// HashVersion is used to determine the fields used to calculate Hash
+	HashVersion uint8 `hash:"-"`
 	// LpaID identifies the LPA being drafted
 	LpaID string
 	// LpaUID is a unique identifier created after sending basic LPA details to the UID service
@@ -100,6 +108,8 @@ type DonorProvidedDetails struct {
 	CheckedAt time.Time
 	// CheckedHash is the Hash value of the LPA when last checked
 	CheckedHash uint64 `hash:"-"`
+	// CheckedHashVersion is used to determine the fields used to calculate CheckedHash
+	CheckedHashVersion uint8 `hash:"-"`
 	// SignedAt is when the donor submitted their signature
 	SignedAt time.Time
 	// SubmittedAt is when the Lpa was sent to the OPG
@@ -134,12 +144,86 @@ type DonorProvidedDetails struct {
 	HasSentApplicationUpdatedEvent bool `hash:"-"`
 }
 
+func (d *DonorProvidedDetails) HashInclude(field string, _ any) (bool, error) {
+	if d.HashVersion > currentHashVersion {
+		return false, errors.New("HashVersion too high")
+	}
+
+	return true, nil
+}
+
+// toCheck filters the fields used for hashing further, for the use of
+// determining whether the LPA data has changed since it was checked by the
+// donor.
+type toCheck DonorProvidedDetails
+
+func (c toCheck) HashInclude(field string, _ any) (bool, error) {
+	if c.CheckedHashVersion > currentCheckedHashVersion {
+		return false, errors.New("CheckedHashVersion too high")
+	}
+
+	// The following fields don't contain LPA data, so aren't part of what gets
+	// checked.
+	switch field {
+	case "CheckedAt",
+		"Tasks",
+		"PaymentDetails",
+		"DonorIdentityUserData",
+		"WantToApplyForLpa",
+		"WantToSignLpa",
+		"SignedAt",
+		"SubmittedAt",
+		"WithdrawnAt",
+		"PerfectAt",
+		"CertificateProviderCodes",
+		"WitnessedByCertificateProviderAt",
+		"IndependentWitnessCodes",
+		"WitnessedByIndependentWitnessAt",
+		"WitnessCodeLimiter",
+		"FeeType",
+		"EvidenceDelivery",
+		"PreviousApplicationNumber",
+		"PreviousFee":
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (l *DonorProvidedDetails) NamesChanged(firstNames, lastName, otherNames string) bool {
 	return l.Donor.FirstNames != firstNames || l.Donor.LastName != lastName || l.Donor.OtherNames != otherNames
 }
 
-func (l *DonorProvidedDetails) GenerateHash() (uint64, error) {
+func (l *DonorProvidedDetails) HashChanged() bool {
+	hash, _ := l.generateHash()
+
+	return hash != l.Hash
+}
+
+func (l *DonorProvidedDetails) UpdateHash() (err error) {
+	l.HashVersion = currentHashVersion
+	l.Hash, err = l.generateHash()
+	return err
+}
+
+func (l *DonorProvidedDetails) generateHash() (uint64, error) {
 	return hashstructure.Hash(l, hashstructure.FormatV2, nil)
+}
+
+func (l *DonorProvidedDetails) CheckedHashChanged() bool {
+	hash, _ := l.generateCheckedHash()
+
+	return hash != l.CheckedHash
+}
+
+func (l *DonorProvidedDetails) UpdateCheckedHash() (err error) {
+	l.CheckedHashVersion = currentCheckedHashVersion
+	l.CheckedHash, err = l.generateCheckedHash()
+	return err
+}
+
+func (l *DonorProvidedDetails) generateCheckedHash() (uint64, error) {
+	return hashstructure.Hash(toCheck(*l), hashstructure.FormatV2, nil)
 }
 
 func (l *DonorProvidedDetails) DonorIdentityConfirmed() bool {

--- a/internal/actor/donor_provided_test.go
+++ b/internal/actor/donor_provided_test.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,19 +21,116 @@ var address = place.Address{
 }
 
 func TestGenerateHash(t *testing.T) {
-	donor := &DonorProvidedDetails{Attorneys: Attorneys{
-		Attorneys: []Attorney{
-			{DateOfBirth: date.New("2000", "1", "2")},
-		},
-	}}
-	hash, err := donor.GenerateHash()
-	assert.Nil(t, err)
-	assert.Equal(t, uint64(0x228526f2932e1744), hash)
+	makeDonor := func(version uint8, hash uint64) *DonorProvidedDetails {
+		return &DonorProvidedDetails{
+			HashVersion: version,
+			Hash:        hash,
+			Attorneys: Attorneys{
+				Attorneys: []Attorney{
+					{DateOfBirth: date.New("2000", "1", "2")},
+				},
+			},
+		}
+	}
 
-	donor.Attorneys.Attorneys[0].DateOfBirth = date.New("2001", "1", "2")
-	hash, err = donor.GenerateHash()
-	assert.Nil(t, err)
-	assert.Equal(t, uint64(0xf07785fd2f4548aa), hash)
+	// DO change this value to match the updates
+	const modified uint64 = 0xf07785fd2f4548aa
+
+	// DO NOT change these initial hash values. If a field has been added/removed
+	// you will need to handle the version gracefully by modifying
+	// (*DonorProvidedDetails).HashInclude and adding another testcase for the new
+	// version.
+	testcases := map[uint8]uint64{
+		0: 0x228526f2932e1744,
+	}
+
+	for version, initial := range testcases {
+		t.Run(fmt.Sprintf("Version%d", version), func(t *testing.T) {
+			donor := makeDonor(version, initial)
+			hash, _ := donor.generateHash()
+
+			assert.Equal(t, donor.Hash, hash)
+			assert.False(t, donor.HashChanged())
+
+			donor.Attorneys.Attorneys[0].DateOfBirth = date.New("2001", "1", "2")
+			assert.True(t, donor.HashChanged())
+
+			err := donor.UpdateHash()
+			assert.Nil(t, err)
+			assert.Equal(t, modified, donor.Hash)
+			assert.Equal(t, uint8(currentHashVersion), donor.HashVersion)
+		})
+	}
+}
+
+func TestGenerateHashVersionTooHigh(t *testing.T) {
+	donor := &DonorProvidedDetails{
+		HashVersion: currentHashVersion + 1,
+		Attorneys: Attorneys{
+			Attorneys: []Attorney{
+				{DateOfBirth: date.New("2000", "1", "2")},
+			},
+		},
+	}
+
+	_, err := donor.generateHash()
+	assert.Error(t, err)
+}
+
+func TestGenerateCheckedHash(t *testing.T) {
+	makeDonor := func(version uint8, hash uint64) *DonorProvidedDetails {
+		return &DonorProvidedDetails{
+			CheckedHashVersion: version,
+			CheckedHash:        hash,
+			Attorneys: Attorneys{
+				Attorneys: []Attorney{
+					{DateOfBirth: date.New("2000", "1", "2")},
+				},
+			},
+		}
+	}
+
+	// DO change this value to match the updates
+	const modified uint64 = 0x158c0832f46fbad9
+
+	// DO NOT change these initial hash values. If a field has been added/removed
+	// you will need to handle the version gracefully by modifying
+	// toCheck.HashInclude and adding another testcase for the new version.
+	testcases := map[uint8]uint64{
+		0: 0x61d5afc9bc5a9de7,
+	}
+
+	for version, initial := range testcases {
+		t.Run(fmt.Sprintf("Version%d", version), func(t *testing.T) {
+			donor := makeDonor(version, initial)
+			hash, _ := donor.generateCheckedHash()
+
+			assert.Equal(t, donor.CheckedHash, hash)
+			assert.False(t, donor.CheckedHashChanged())
+
+			donor.Attorneys.Attorneys[0].DateOfBirth = date.New("2001", "1", "2")
+			assert.True(t, donor.CheckedHashChanged())
+
+			err := donor.UpdateCheckedHash()
+			assert.Nil(t, err)
+			assert.Equal(t, modified, donor.CheckedHash)
+			assert.Equal(t, uint8(currentCheckedHashVersion), donor.CheckedHashVersion)
+		})
+	}
+}
+
+func TestGenerateCheckedHashVersionTooHigh(t *testing.T) {
+	donor := &DonorProvidedDetails{
+		CheckedHashVersion: currentCheckedHashVersion + 1,
+		Attorneys: Attorneys{
+			Attorneys: []Attorney{
+				{DateOfBirth: date.New("2000", "1", "2")},
+			},
+		},
+	}
+
+	_, err := donor.generateCheckedHash()
+	assert.Error(t, err)
 }
 
 func TestIdentityConfirmed(t *testing.T) {

--- a/internal/app/donor_store_test.go
+++ b/internal/app/donor_store_test.go
@@ -340,7 +340,7 @@ func TestDonorStoreGetByKeysWhenDynamoErrors(t *testing.T) {
 
 func TestDonorStorePut(t *testing.T) {
 	saved := &actor.DonorProvidedDetails{PK: dynamo.LpaKey("5"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("an-id")), LpaID: "5", HasSentApplicationUpdatedEvent: true, Donor: actor.Donor{FirstNames: "x", LastName: "y"}}
-	saved.Hash, _ = saved.GenerateHash()
+	saved.UpdateHash()
 
 	dynamoClient := newMockDynamoClient(t)
 	dynamoClient.EXPECT().
@@ -355,7 +355,7 @@ func TestDonorStorePut(t *testing.T) {
 
 func TestDonorStorePutWhenUIDSet(t *testing.T) {
 	saved := &actor.DonorProvidedDetails{PK: dynamo.LpaKey("5"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("an-id")), LpaID: "5", HasSentApplicationUpdatedEvent: true, LpaUID: "M", UpdatedAt: testNow, Donor: actor.Donor{FirstNames: "x", LastName: "y"}}
-	saved.Hash, _ = saved.GenerateHash()
+	saved.UpdateHash()
 
 	dynamoClient := newMockDynamoClient(t)
 	dynamoClient.EXPECT().
@@ -480,7 +480,7 @@ func TestDonorStoreCreate(t *testing.T) {
 					Channel:     actor.ChannelOnline,
 				},
 			}
-			donor.Hash, _ = donor.GenerateHash()
+			donor.UpdateHash()
 
 			dynamoClient := newMockDynamoClient(t)
 			dynamoClient.

--- a/internal/app/organisation_store.go
+++ b/internal/app/organisation_store.go
@@ -110,7 +110,7 @@ func (s *organisationStore) CreateLPA(ctx context.Context) (*actor.DonorProvided
 		},
 	}
 
-	if donor.Hash, err = donor.GenerateHash(); err != nil {
+	if err := donor.UpdateHash(); err != nil {
 		return nil, err
 	}
 

--- a/internal/app/organisation_store_test.go
+++ b/internal/app/organisation_store_test.go
@@ -187,7 +187,7 @@ func TestOrganisationStoreCreateLPA(t *testing.T) {
 			UID: testUID,
 		},
 	}
-	expectedDonor.Hash, _ = expectedDonor.GenerateHash()
+	expectedDonor.UpdateHash()
 
 	dynamoClient := newMockDynamoClient(t)
 	dynamoClient.EXPECT().

--- a/internal/page/donor/check_your_lpa_test.go
+++ b/internal/page/donor/check_your_lpa_test.go
@@ -23,9 +23,10 @@ func TestGetCheckYourLpa(t *testing.T) {
 	template := newMockTemplate(t)
 	template.EXPECT().
 		Execute(w, &checkYourLpaData{
-			App:   testAppData,
-			Form:  &checkYourLpaForm{},
-			Donor: &actor.DonorProvidedDetails{},
+			App:         testAppData,
+			Form:        &checkYourLpaForm{},
+			Donor:       &actor.DonorProvidedDetails{},
+			CanContinue: true,
 		}).
 		Return(nil)
 
@@ -43,6 +44,7 @@ func TestGetCheckYourLpaFromStore(t *testing.T) {
 	donor := &actor.DonorProvidedDetails{
 		CheckedAt: testNow,
 	}
+	donor.UpdateCheckedHash()
 
 	template := newMockTemplate(t)
 	template.EXPECT().
@@ -73,12 +75,11 @@ func TestPostCheckYourLpaWhenNotChanged(t *testing.T) {
 
 	donor := &actor.DonorProvidedDetails{
 		LpaID:               "lpa-id",
-		Hash:                5,
 		CheckedAt:           testNow,
-		CheckedHash:         5,
 		Tasks:               actor.DonorTasks{CheckYourLpa: actor.TaskCompleted},
 		CertificateProvider: actor.CertificateProvider{CarryOutBy: actor.ChannelOnline},
 	}
+	donor.UpdateCheckedHash()
 
 	template := newMockTemplate(t)
 	template.EXPECT().
@@ -130,7 +131,7 @@ func TestPostCheckYourLpaDigitalCertificateProviderOnFirstCheck(t *testing.T) {
 				Tasks:               actor.DonorTasks{CheckYourLpa: actor.TaskCompleted},
 				CertificateProvider: actor.CertificateProvider{UID: uid, FirstNames: "John", LastName: "Smith", Email: "john@example.com", CarryOutBy: actor.ChannelOnline},
 			}
-			updatedDonor.CheckedHash, _ = updatedDonor.GenerateHash()
+			updatedDonor.UpdateCheckedHash()
 
 			shareCodeSender := newMockShareCodeSender(t)
 			shareCodeSender.EXPECT().
@@ -309,7 +310,7 @@ func TestPostCheckYourLpaPaperCertificateProviderOnFirstCheck(t *testing.T) {
 				CertificateProvider: actor.CertificateProvider{CarryOutBy: actor.ChannelPaper, Mobile: "07700900000"},
 				Type:                actor.LpaTypePropertyAndAffairs,
 			}
-			updatedDonor.CheckedHash, _ = updatedDonor.GenerateHash()
+			updatedDonor.UpdateCheckedHash()
 
 			donorStore := newMockDonorStore(t)
 			donorStore.EXPECT().


### PR DESCRIPTION
I think this is the best way to tackle the problem as it allows us to modify how we interpret the hashes, and in a way that each one can drift without affecting the other.