### PR TITLE
MLPAB-2171: Make deleting donor access transactional

### DIFF
--- a/internal/page/supporter/donor_access.go
+++ b/internal/page/supporter/donor_access.go
@@ -54,11 +54,7 @@ func DonorAccess(tmpl template.Template, donorStore DonorStore, shareCodeStore S
 					return errors.New("cannot remove LPA access when donor has paid")
 				}
 
-				if err := shareCodeStore.Delete(r.Context(), shareCodeData); err != nil {
-					return err
-				}
-
-				if err := donorStore.DeleteLink(r.Context(), shareCodeData); err != nil {
+				if err := donorStore.DeleteDonorAccess(r.Context(), shareCodeData); err != nil {
 					return err
 				}
 

--- a/internal/page/supporter/donor_access_test.go
+++ b/internal/page/supporter/donor_access_test.go
@@ -395,9 +395,6 @@ func TestPostDonorAccessRemove(t *testing.T) {
 	shareCodeStore.EXPECT().
 		GetDonor(r.Context()).
 		Return(shareCodeData, nil)
-	shareCodeStore.EXPECT().
-		Delete(r.Context(), shareCodeData).
-		Return(nil)
 
 	donor := &actor.DonorProvidedDetails{SK: dynamo.LpaOwnerKey(dynamo.DonorKey("donor-session-id"))}
 
@@ -406,7 +403,7 @@ func TestPostDonorAccessRemove(t *testing.T) {
 		Get(r.Context()).
 		Return(donor, nil)
 	donorStore.EXPECT().
-		DeleteLink(r.Context(), shareCodeData).
+		DeleteDonorAccess(r.Context(), shareCodeData).
 		Return(nil)
 
 	err := DonorAccess(nil, donorStore, shareCodeStore, nil, "http://whatever", testRandomStringFn)(testLpaAppData, w, r, &actor.Organisation{}, &actor.Member{})
@@ -450,35 +447,6 @@ func TestPostDonorAccessRemoveWhenDonorHasPaid(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestPostDonorAccessRemoveWhenDeleteError(t *testing.T) {
-	form := url.Values{"action": {"remove"}}
-
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", page.FormUrlEncoded)
-
-	shareCodeStore := newMockShareCodeStore(t)
-	shareCodeStore.EXPECT().
-		GetDonor(mock.Anything).
-		Return(actor.ShareCodeData{}, nil)
-	shareCodeStore.EXPECT().
-		Delete(mock.Anything, mock.Anything).
-		Return(expectedError)
-
-	donor := &actor.DonorProvidedDetails{SK: dynamo.LpaOwnerKey(dynamo.DonorKey("donor-session-id"))}
-
-	donorStore := newMockDonorStore(t)
-	donorStore.EXPECT().
-		Get(mock.Anything).
-		Return(donor, nil)
-
-	err := DonorAccess(nil, donorStore, shareCodeStore, nil, "http://whatever", testRandomStringFn)(testLpaAppData, w, r, &actor.Organisation{}, &actor.Member{})
-	resp := w.Result()
-
-	assert.Equal(t, expectedError, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestPostDonorAccessRemoveWhenDeleteLinkError(t *testing.T) {
 	form := url.Values{"action": {"remove"}}
 
@@ -490,9 +458,6 @@ func TestPostDonorAccessRemoveWhenDeleteLinkError(t *testing.T) {
 	shareCodeStore.EXPECT().
 		GetDonor(mock.Anything).
 		Return(actor.ShareCodeData{}, nil)
-	shareCodeStore.EXPECT().
-		Delete(mock.Anything, mock.Anything).
-		Return(nil)
 
 	donor := &actor.DonorProvidedDetails{SK: dynamo.LpaOwnerKey(dynamo.DonorKey("donor-session-id"))}
 
@@ -501,7 +466,7 @@ func TestPostDonorAccessRemoveWhenDeleteLinkError(t *testing.T) {
 		Get(mock.Anything).
 		Return(donor, nil)
 	donorStore.EXPECT().
-		DeleteLink(mock.Anything, mock.Anything).
+		DeleteDonorAccess(mock.Anything, mock.Anything).
 		Return(expectedError)
 
 	err := DonorAccess(nil, donorStore, shareCodeStore, nil, "http://whatever", testRandomStringFn)(testLpaAppData, w, r, &actor.Organisation{}, &actor.Member{})

--- a/internal/page/supporter/mock_DonorStore_test.go
+++ b/internal/page/supporter/mock_DonorStore_test.go
@@ -25,12 +25,12 @@ func (_m *mockDonorStore) EXPECT() *mockDonorStore_Expecter {
 	return &mockDonorStore_Expecter{mock: &_m.Mock}
 }
 
-// DeleteLink provides a mock function with given fields: ctx, shareCodeData
-func (_m *mockDonorStore) DeleteLink(ctx context.Context, shareCodeData actor.ShareCodeData) error {
+// DeleteDonorAccess provides a mock function with given fields: ctx, shareCodeData
+func (_m *mockDonorStore) DeleteDonorAccess(ctx context.Context, shareCodeData actor.ShareCodeData) error {
 	ret := _m.Called(ctx, shareCodeData)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DeleteLink")
+		panic("no return value specified for DeleteDonorAccess")
 	}
 
 	var r0 error
@@ -43,31 +43,31 @@ func (_m *mockDonorStore) DeleteLink(ctx context.Context, shareCodeData actor.Sh
 	return r0
 }
 
-// mockDonorStore_DeleteLink_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteLink'
-type mockDonorStore_DeleteLink_Call struct {
+// mockDonorStore_DeleteDonorAccess_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteDonorAccess'
+type mockDonorStore_DeleteDonorAccess_Call struct {
 	*mock.Call
 }
 
-// DeleteLink is a helper method to define mock.On call
+// DeleteDonorAccess is a helper method to define mock.On call
 //   - ctx context.Context
 //   - shareCodeData actor.ShareCodeData
-func (_e *mockDonorStore_Expecter) DeleteLink(ctx interface{}, shareCodeData interface{}) *mockDonorStore_DeleteLink_Call {
-	return &mockDonorStore_DeleteLink_Call{Call: _e.mock.On("DeleteLink", ctx, shareCodeData)}
+func (_e *mockDonorStore_Expecter) DeleteDonorAccess(ctx interface{}, shareCodeData interface{}) *mockDonorStore_DeleteDonorAccess_Call {
+	return &mockDonorStore_DeleteDonorAccess_Call{Call: _e.mock.On("DeleteDonorAccess", ctx, shareCodeData)}
 }
 
-func (_c *mockDonorStore_DeleteLink_Call) Run(run func(ctx context.Context, shareCodeData actor.ShareCodeData)) *mockDonorStore_DeleteLink_Call {
+func (_c *mockDonorStore_DeleteDonorAccess_Call) Run(run func(ctx context.Context, shareCodeData actor.ShareCodeData)) *mockDonorStore_DeleteDonorAccess_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(actor.ShareCodeData))
 	})
 	return _c
 }
 
-func (_c *mockDonorStore_DeleteLink_Call) Return(_a0 error) *mockDonorStore_DeleteLink_Call {
+func (_c *mockDonorStore_DeleteDonorAccess_Call) Return(_a0 error) *mockDonorStore_DeleteDonorAccess_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *mockDonorStore_DeleteLink_Call) RunAndReturn(run func(context.Context, actor.ShareCodeData) error) *mockDonorStore_DeleteLink_Call {
+func (_c *mockDonorStore_DeleteDonorAccess_Call) RunAndReturn(run func(context.Context, actor.ShareCodeData) error) *mockDonorStore_DeleteDonorAccess_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/page/supporter/register.go
+++ b/internal/page/supporter/register.go
@@ -48,7 +48,7 @@ type MemberStore interface {
 }
 
 type DonorStore interface {
-	DeleteLink(ctx context.Context, shareCodeData actor.ShareCodeData) error
+	DeleteDonorAccess(ctx context.Context, shareCodeData actor.ShareCodeData) error
 	Get(ctx context.Context) (*actor.DonorProvidedDetails, error)
 	GetByKeys(ctx context.Context, keys []dynamo.Keys) ([]actor.DonorProvidedDetails, error)
 	Put(ctx context.Context, donor *actor.DonorProvidedDetails) error


### PR DESCRIPTION
# Purpose

To protect against errors between writes.

Fixes MLPAB-2171
