### PR TITLE
MLPAB-2240 - turn off db exports on pipelines for now

### DIFF
--- a/docs/runbooks/rebuilding_the_opensearch_index.md
+++ b/docs/runbooks/rebuilding_the_opensearch_index.md
@@ -44,6 +44,14 @@ tf workspace select <environment name>
 
 (working with preproduction and production environments requires the breakglass role)
 
+uncomment the export block in `terraform/environment/opensearch_ingestion_pipeline.tf`
+
+```yaml
+export:
+  s3_bucket: ${source.tables.s3_bucket_name}
+  s3_sse_kms_key_id: ${source.tables.s3_sse_kms_key_id}
+```
+
 Mark the pipeline for recreation:
 
 ```shell

--- a/terraform/environment/opensearch_pipeline/lpas_stream_pipeline_configuration.yaml.tftpl
+++ b/terraform/environment/opensearch_pipeline/lpas_stream_pipeline_configuration.yaml.tftpl
@@ -5,9 +5,9 @@ dynamodb-pipeline:
       acknowledgments: true
       tables:
         - table_arn: ${source.tables.table_arn}
-          export:
-            s3_bucket: ${source.tables.s3_bucket_name}
-            s3_sse_kms_key_id: ${source.tables.s3_sse_kms_key_id}
+          # export:
+          #   s3_bucket: ${source.tables.s3_bucket_name}
+          #   s3_sse_kms_key_id: ${source.tables.s3_sse_kms_key_id}
           stream:
             start_position: ${source.tables.stream.start_position}
       aws:


### PR DESCRIPTION
# Purpose

At the moment, the export raises an unauthorised error (the pipeline works despite the error)

Fixes MLPAB-2240

## Approach

- Comment out db export block as not needed for any environments
- Add instructions to uncomment the export block
