### PR TITLE
MLPAB-2205 - address buildx version requirement on pipelines

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.3.0
         id: buildx_setup
         with:
-          version: v0.12.0
+          version: v0.15.1
           platforms: linux/amd64,linux/arm64
 
       - name: Build ${{ matrix.ecr_repository }} Image

--- a/internal/build-trigger
+++ b/internal/build-trigger
@@ -1,1 +1,0 @@
-this file is to trgger a build

--- a/internal/build-trigger
+++ b/internal/build-trigger
@@ -1,0 +1,1 @@
+this file is to trgger a build


### PR DESCRIPTION
# Purpose

Address warnings on pipeline

Fixes MLPAB-2205

## Approach

- update buildx version to 0.15.1

## Learning

- https://github.com/docker/setup-buildx-action?tab=readme-ov-file
- https://github.com/docker/buildx