### PR TITLE
MLPAB-2166 - use new pagerduty service for production alerts

### DIFF
--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -25,7 +25,7 @@
       "regions": [
         "eu-west-1"
       ],
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production"
+      "pagerduty_service_name": "OPG Modernising LPA Production"
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -484,7 +484,7 @@
         "deletion_protection_enabled": true
       },
       "cloudwatch_application_insights_enabled": true,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+      "pagerduty_service_name": "OPG Modernising LPA Production",
       "event_bus": {
         "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
         "receive_account_ids": []


### PR DESCRIPTION
# Purpose

Isolate alerts for productions resources to their own pagerduty service

Fixes MLPAB-2166

## Approach

- Use the production pagerduty service for producton account and environment
