### PR TITLE
MLPAB-2177 - fix permission denied on decrypt in event-received

### DIFF
--- a/terraform/environment/region/modules/event_received/lambda.tf
+++ b/terraform/environment/region/modules/event_received/lambda.tf
@@ -151,6 +151,11 @@ data "aws_kms_alias" "secrets_manager_secret_encryption_key" {
   provider = aws.region
 }
 
+data "aws_kms_alias" "aws_lambda" {
+  name     = "alias/aws/lambda"
+  provider = aws.region
+}
+
 locals {
   policy_region_prefix = lower(replace(data.aws_region.current.name, "-", ""))
 }
@@ -208,6 +213,7 @@ data "aws_iam_policy_document" "event_received" {
 
     resources = [
       data.aws_kms_alias.secrets_manager_secret_encryption_key.target_key_arn,
+      data.aws_kms_alias.aws_lambda.target_key_arn,
     ]
 
     actions = [


### PR DESCRIPTION
# Purpose

Fix access denied on kms:decrypt with aws/lambda key

Fixes MLPAB-2177 

## Approach

- let event received role decrypt using the aws/lambda key