### PR TITLE
MLPAB-2269 - add toggle for waf alb association and protect mocks

### DIFF
--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -34,6 +34,7 @@ module "app" {
   app_allowed_api_arns            = concat(var.uid_service.api_arns, var.lpa_store_service.api_arns)
   ingress_allow_list_cidr         = concat(var.ingress_allow_list_cidr, split(",", data.aws_ssm_parameter.additional_allowed_ingress_cidrs.value))
   alb_deletion_protection_enabled = var.alb_deletion_protection_enabled
+  waf_alb_association_enabled     = var.waf_alb_association_enabled
   lpas_table                      = var.lpas_table
   container_port                  = 8080
   public_access_enabled           = var.public_access_enabled
@@ -60,6 +61,7 @@ module "app" {
   search_endpoint                                      = var.search_endpoint
   search_index_name                                    = var.search_index_name
   search_collection_arn                                = var.search_collection_arn
+
   providers = {
     aws.region     = aws.region
     aws.management = aws.management
@@ -79,6 +81,7 @@ module "mock_onelogin" {
   repository_url                  = var.mock_onelogin_service_repository_url
   container_version               = var.mock_onelogin_service_container_version
   alb_deletion_protection_enabled = var.alb_deletion_protection_enabled
+  waf_alb_association_enabled     = var.waf_alb_association_enabled
   container_port                  = 8080
   public_access_enabled           = var.public_access_enabled
   redirect_base_url               = var.app_env_vars.auth_redirect_base_url
@@ -110,6 +113,7 @@ module "mock_pay" {
   repository_url                  = var.mock_pay_service_repository_url
   container_version               = var.mock_pay_service_container_version
   alb_deletion_protection_enabled = var.alb_deletion_protection_enabled
+  waf_alb_association_enabled     = var.waf_alb_association_enabled
   container_port                  = 8080
   public_access_enabled           = var.public_access_enabled
   network = {

--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -158,3 +158,9 @@ variable "search_collection_arn" {
   description = "ARN of the OpenSearch collection to use"
   nullable    = true
 }
+
+variable "waf_alb_association_enabled" {
+  type        = bool
+  description = "Enable WAF association with the ALB"
+  default     = true
+}

--- a/terraform/environment/region/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/region/modules/mock_onelogin/variables.tf
@@ -92,3 +92,9 @@ variable "app_ecs_service_security_group_id" {
   type        = string
   description = "ID of the security group for the app ECS service"
 }
+
+variable "waf_alb_association_enabled" {
+  type        = bool
+  description = "Enable WAF association with the ALB"
+  default     = true
+}

--- a/terraform/environment/region/modules/mock_onelogin/waf.tf
+++ b/terraform/environment/region/modules/mock_onelogin/waf.tf
@@ -7,6 +7,6 @@ data "aws_wafv2_web_acl" "main" {
 resource "aws_wafv2_web_acl_association" "app" {
   count        = var.waf_alb_association_enabled ? 1 : 0
   provider     = aws.region
-  resource_arn = aws_lb.app.arn
+  resource_arn = aws_lb.mock_onelogin.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }

--- a/terraform/environment/region/modules/mock_pay/variables.tf
+++ b/terraform/environment/region/modules/mock_pay/variables.tf
@@ -87,3 +87,9 @@ variable "app_ecs_service_security_group_id" {
   type        = string
   description = "ID of the security group for the app ECS service"
 }
+
+variable "waf_alb_association_enabled" {
+  type        = bool
+  description = "Enable WAF association with the ALB"
+  default     = true
+}

--- a/terraform/environment/region/modules/mock_pay/waf.tf
+++ b/terraform/environment/region/modules/mock_pay/waf.tf
@@ -7,6 +7,6 @@ data "aws_wafv2_web_acl" "main" {
 resource "aws_wafv2_web_acl_association" "app" {
   count        = var.waf_alb_association_enabled ? 1 : 0
   provider     = aws.region
-  resource_arn = aws_lb.app.arn
+  resource_arn = aws_lb.mock_pay.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -190,3 +190,9 @@ variable "real_user_monitoring_cw_logs_enabled" {
   type        = bool
   description = "Enable CloudWatch logging for Real User Monitoring"
 }
+
+variable "waf_alb_association_enabled" {
+  type        = bool
+  description = "Enable WAF association with the ALBs"
+  default     = true
+}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -40,6 +40,7 @@ module "eu_west_1" {
   mock_pay_service_container_version      = var.container_version
   ingress_allow_list_cidr                 = module.allow_list.moj_sites
   alb_deletion_protection_enabled         = local.environment.application_load_balancer.deletion_protection_enabled
+  waf_alb_association_enabled             = local.environment.application_load_balancer.waf_alb_association_enabled
   lpas_table = {
     arn  = aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name
@@ -107,6 +108,7 @@ module "eu_west_2" {
   mock_pay_service_container_version      = var.container_version
   ingress_allow_list_cidr                 = module.allow_list.moj_sites
   alb_deletion_protection_enabled         = local.environment.application_load_balancer.deletion_protection_enabled
+  waf_alb_association_enabled             = local.environment.application_load_balancer.waf_alb_association_enabled
   lpas_table = {
     arn  = local.environment.dynamodb.region_replica_enabled ? aws_dynamodb_table_replica.lpas_table[0].arn : aws_dynamodb_table.lpas_table.arn,
     name = aws_dynamodb_table.lpas_table.name

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -66,7 +66,8 @@
         "application_log_retention_days": 7
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": false
+        "deletion_protection_enabled": false,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
@@ -149,7 +150,8 @@
         "application_log_retention_days": 7
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": false
+        "deletion_protection_enabled": false,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
@@ -232,7 +234,8 @@
         "application_log_retention_days": 7
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": false
+        "deletion_protection_enabled": false,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": false,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
@@ -315,7 +318,8 @@
         "application_log_retention_days": 400
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": false
+        "deletion_protection_enabled": false,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
@@ -398,7 +402,8 @@
         "application_log_retention_days": 7
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": false
+        "deletion_protection_enabled": false,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Non-Production",
@@ -481,7 +486,8 @@
         "application_log_retention_days": 400
       },
       "application_load_balancer": {
-        "deletion_protection_enabled": true
+        "deletion_protection_enabled": true,
+        "waf_alb_association_enabled": true
       },
       "cloudwatch_application_insights_enabled": true,
       "pagerduty_service_name": "OPG Modernising LPA Production",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -76,6 +76,7 @@ variable "environments" {
       })
       application_load_balancer = object({
         deletion_protection_enabled = bool
+        waf_alb_association_enabled = bool
       })
       cloudwatch_application_insights_enabled = bool
       pagerduty_service_name                  = string


### PR DESCRIPTION
# Purpose

Support turning of WAF association for ITHC

Fixes MLPAB-2269

## Approach

- Add variable to toggle WAF ALB association per environment
- protect mock pay and mock onelogin ALBs with WAF
