### PR TITLE
MLPAB-2273 - use image digest from tag for mock onelogin task def

### DIFF
--- a/terraform/environment/region/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/ecs.tf
@@ -137,7 +137,7 @@ locals {
     {
       cpu                    = 1,
       essential              = true,
-      image                  = "${var.repository_url}:${var.container_version}",
+      image                  = "${var.repository_url}@${var.container_version}",
       mountPoints            = [],
       readonlyRootFilesystem = true
       name                   = "mock_onelogin",

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -13,6 +13,12 @@ data "aws_ecr_repository" "mock_pay" {
   provider = aws.management_eu_west_1
 }
 
+data "aws_ecr_image" "mock_onelogin" {
+  repository_name = data.aws_ecr_repository.mock_onelogin.name
+  image_tag       = "latest"
+  provider        = aws.management_eu_west_1
+}
+
 module "allow_list" {
   source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.0.1"
 }
@@ -35,7 +41,7 @@ module "eu_west_1" {
   app_service_repository_url              = data.aws_ecr_repository.app.repository_url
   app_service_container_version           = var.container_version
   mock_onelogin_service_repository_url    = data.aws_ecr_repository.mock_onelogin.repository_url
-  mock_onelogin_service_container_version = local.mock_onelogin_version
+  mock_onelogin_service_container_version = data.aws_ecr_image.mock_onelogin.id
   mock_pay_service_repository_url         = data.aws_ecr_repository.mock_pay.repository_url
   mock_pay_service_container_version      = var.container_version
   ingress_allow_list_cidr                 = module.allow_list.moj_sites


### PR DESCRIPTION
# Purpose

persistent environments were not deploying new images for mock onelogin tagged latest

Fixes MLPAB-2273

## Approach

- get image digest for latest image