### PR TITLE
MLPAB-2203 - remove app-task-role from dynamodb exports encryption key

### DIFF
--- a/terraform/account/kms_key_dynamodb_exports_s3.tf
+++ b/terraform/account/kms_key_dynamodb_exports_s3.tf
@@ -57,8 +57,7 @@ data "aws_iam_policy_document" "dynamodb_exports_s3_bucket_kms" {
     principals {
       type = "AWS"
       identifiers = [
-        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/${local.account.account_name}-app-task-role",
-        aws_iam_role.aws_backup_role.arn,
+        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:root" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/opensearch-pipeline-role-${local.account.account_name}",
       ]
     }
     condition {


### PR DESCRIPTION
# Purpose

Limit access to export encryption key

Fixes MLPAB-2203

## Approach

- let opensearch pipeline role use encryption key in prod and preprod