### PR TITLE
MLPAB-2343 - create a self service SBOM generation workflow in GitHub actions

### DIFF
--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -56,6 +56,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: $${ matrix.service }}-sbom-${{ matrix.image_tag }}
+          name: ${ matrix.service }}-sbom-${{ matrix.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -51,11 +51,11 @@ jobs:
         working-directory: scripts/sbom_exporter
         id: export_and_download_sbom
         run: |
-          ./export_ecr_image_sbom.sh ${ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
+          ./export_ecr_image_sbom.sh ${{ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
       - name: Upload SBOMs as a Github artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${ matrix.service }}-sbom-${{ matrix.image_tag }}
+          name: ${{ matrix.service }}-sbom-${{ matrix.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -59,3 +59,7 @@ jobs:
           name: ${{ matrix.service }}-sbom-${{ matrix.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default
+      - name: Put download URL in summary
+        if: always()
+        run: |
+          echo "Download ${{ matrix.service }} ${{ matrix.image_tag }} SBOMs from: ${{ steps.export_and_download_sbom.outputs.download_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -44,11 +44,11 @@ jobs:
         id: export_and_download_modernising_lpa_sbom
         run: |
           ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
-      - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
-        working-directory: scripts/sbom_exporter
-        id: export_and_download_mock_onelogin_sbom
-        run: |
-          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
+      # - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
+      #   working-directory: scripts/sbom_exporter
+      #   id: export_and_download_mock_onelogin_sbom
+      #   run: |
+      #     ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -28,14 +28,7 @@ defaults:
 jobs:
 
   export_sbom:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - service: modernising-lpa
-            image_tag: ${{ inputs.image_tag }}
-            filter_criteria: modernising_lpa_filter_criteria.json
-    name: Export Software Bill of Materials (SBOM) for ${{ matrix.image_tag }}
+    name: Export Software Bill of Materials (SBOM) for modernising-lpa ${{ inputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,19 +40,15 @@ jobs:
           role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-github-actions-sbom-export
           role-duration-seconds: 900
           role-session-name: GithubActionsExportSBOM
-      - name: Request and Download SBOM Export for ${{ matrix.service }} ${{ matrix.image_tag }}
+      - name: Request and Download SBOM Export for modernising-lpa ${{ inputs.image_tag }}
         working-directory: scripts/sbom_exporter
         id: export_and_download_sbom
         run: |
-          ./export_ecr_image_sbom.sh ${{ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
+          ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.service }}-sbom-${{ matrix.image_tag }}
+          name: modernising-lpa-sbom-${{ inputs.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default
-      - name: Put download URL in summary
-        if: always()
-        run: |
-          echo "Download ${{ matrix.service }} ${{ matrix.image_tag }} SBOMs from: ${{ steps.export_and_download_sbom.outputs.download_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: modernising-lpa-sbom-${{ inputs.image_tag }}

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -44,6 +44,7 @@ jobs:
         id: export_and_download_modernising_lpa_sbom
         run: |
           ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
+          pwd
       # - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
       #   working-directory: scripts/sbom_exporter
       #   id: export_and_download_mock_onelogin_sbom
@@ -53,5 +54,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: modernising-lpa-sbom-${{ inputs.image_tag }}
-          path: '${{ github.workspace }}/exports/**/*.json'
+          path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -45,11 +45,11 @@ jobs:
         run: |
           ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
           pwd
-      # - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
-      #   working-directory: scripts/sbom_exporter
-      #   id: export_and_download_mock_onelogin_sbom
-      #   run: |
-      #     ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
+      - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
+        working-directory: scripts/sbom_exporter
+        id: export_and_download_mock_onelogin_sbom
+        run: |
+          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -30,6 +30,8 @@ jobs:
     name: Export Software Bill of Materials (SBOM) for ${{ inputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: unfor19/install-aws-cli-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -53,5 +53,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: modernising-lpa-sbom-${{ inputs.image_tag }}
-          path: '${{ github.workspace }}/exports/*/*.json'
+          path: '${{ github.workspace }}/exports/**/*.json'
           retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: scripts/sbom_exporter
         id: export_and_download_sbom
         run: |
-          ./export_ecr_image_sbom.sh $${ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
+          ./export_ecr_image_sbom.sh ${ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
       - name: Upload SBOMs as a Github artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: scripts/sbom_exporter
         id: export_and_download_mock_onelogin_sbom
         run: |
-          ./export_ecr_image_sbom.sh modernising-lpa latest mock_onelogin_filter_criteria.json
+          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -39,8 +39,19 @@ jobs:
           role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-github-actions-sbom-export
           role-duration-seconds: 900
           role-session-name: GithubActionsExportSBOM
-      - name: Request and Download SBO Export for ${{ inputs.image_tag }}
+      - name: Request and Download SBO Export for modernising-lpa ${{ inputs.image_tag }}
         working-directory: scripts/sbom_exporter
-        id: export_and_download_sbom
+        id: export_and_download_modernising_lpa_sbom
         run: |
           ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
+      - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
+        working-directory: scripts/sbom_exporter
+        id: export_and_download_mock_onelogin_sbom
+        run: |
+          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
+      - name: Upload SBOMs as a Github artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: modernising-lpa-sbom-${{ inputs.image_tag }}
+          path: '${{ github.workspace }}/exports/*/*.json'
+          retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           name: modernising-lpa-sbom-${{ inputs.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
-          retention-days: 20 # 90 is the default
+          retention-days: 20

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -26,8 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+
   export_sbom:
-    name: Export Software Bill of Materials (SBOM) for ${{ inputs.image_tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: modernising-lpa
+            image_tag: ${{ inputs.image_tag }}
+            filter_criteria: modernising_lpa_filter_criteria.json
+    name: Export Software Bill of Materials (SBOM) for ${{ matrix.image_tag }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,21 +47,15 @@ jobs:
           role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-github-actions-sbom-export
           role-duration-seconds: 900
           role-session-name: GithubActionsExportSBOM
-      - name: Request and Download SBO Export for modernising-lpa ${{ inputs.image_tag }}
+      - name: Request and Download SBOM Export for ${{ matrix.service }} ${{ matrix.image_tag }}
         working-directory: scripts/sbom_exporter
-        id: export_and_download_modernising_lpa_sbom
+        id: export_and_download_sbom
         run: |
-          ./export_ecr_image_sbom.sh modernising-lpa ${{ inputs.image_tag }} modernising_lpa_filter_criteria.json
-          pwd
-      - name: Request and Download SBO Export for mock-onelogin ${{ inputs.image_tag }}
-        working-directory: scripts/sbom_exporter
-        id: export_and_download_mock_onelogin_sbom
-        run: |
-          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
+          ./export_ecr_image_sbom.sh $${ matrix.service }} ${{ matrix.image_tag }} ${{ matrix.filter_criteria }}
       - name: Upload SBOMs as a Github artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: modernising-lpa-sbom-${{ inputs.image_tag }}
+          name: $${ matrix.service }}-sbom-${{ matrix.image_tag }}
           path: '${{ github.workspace }}/scripts/sbom_exporter/exports/**/*.json'
           retention-days: 20 # 90 is the default

--- a/.github/workflows/dispatch_export_sbom.yml
+++ b/.github/workflows/dispatch_export_sbom.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: scripts/sbom_exporter
         id: export_and_download_mock_onelogin_sbom
         run: |
-          ./export_ecr_image_sbom.sh mock-onelogin latest mock_onelogin_filter_criteria.json
+          ./export_ecr_image_sbom.sh modernising-lpa latest mock_onelogin_filter_criteria.json
       - name: Upload SBOMs as a Github artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ multi-reporter-config.json
 /coverage/*
 
 scripts/sbom_exporter/exports/*
+scripts/sbom_exporter/tmp.*.json

--- a/scripts/sbom_exporter/export_ecr_image_sbom.sh
+++ b/scripts/sbom_exporter/export_ecr_image_sbom.sh
@@ -38,7 +38,6 @@ while true; do
 
     if [ "$STATUS" != "IN_PROGRESS" ]; then
         echo "Final status: $STATUS"
-        # echo $RESPONSE | jq -C
         mkdir -p exports/$SERVICE_NAME/$IMAGE_TAG
         echo "downloading SBOMs from S3..."
         aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$SERVICE_NAME/$IMAGE_TAG --recursive

--- a/scripts/sbom_exporter/export_ecr_image_sbom.sh
+++ b/scripts/sbom_exporter/export_ecr_image_sbom.sh
@@ -43,7 +43,7 @@ while true; do
         echo "downloading SBOMs from S3..."
         aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$SERVICE_NAME/$IMAGE_TAG --recursive
         echo "replacing : with - ..."
-        for f in exports/$SERVICE_NAME/$IMAGE_TAG/*.json; do mv -v -- "$f" "$(echo "$f" | tr ':' '-')"; done
+        for f in exports/$SERVICE_NAME/$IMAGE_TAG/*.json; do mv -- "$f" "$(echo "$f" | tr ':' '-')"; done
         break
     fi
     echo "Status is $STATUS. Retrying in 10 seconds..."

--- a/scripts/sbom_exporter/export_ecr_image_sbom.sh
+++ b/scripts/sbom_exporter/export_ecr_image_sbom.sh
@@ -37,8 +37,8 @@ while true; do
     STATUS=$(echo $RESPONSE | jq -r '.status')
 
     if [ "$STATUS" != "IN_PROGRESS" ]; then
-        echo "Final response:"
-        echo $RESPONSE | jq -C
+        echo "Final status: $STATUS"
+        # echo $RESPONSE | jq -C
         mkdir -p exports/$SERVICE_NAME/$IMAGE_TAG
         echo "downloading SBOMs from S3..."
         aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$SERVICE_NAME/$IMAGE_TAG --recursive

--- a/scripts/sbom_exporter/export_ecr_image_sbom.sh
+++ b/scripts/sbom_exporter/export_ecr_image_sbom.sh
@@ -42,9 +42,10 @@ while true; do
         mkdir -p exports/$SERVICE_NAME/$IMAGE_TAG
         echo "downloading SBOMs from S3..."
         aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$SERVICE_NAME/$IMAGE_TAG --recursive
+        echo "replacing : with - ..."
+        for f in exports/$SERVICE_NAME/$IMAGE_TAG/*.json; do mv -v -- "$f" "$(echo "$f" | tr ':' '-')"; done
         break
     fi
-
     echo "Status is $STATUS. Retrying in 10 seconds..."
     sleep 10
 done

--- a/scripts/sbom_exporter/export_ecr_image_sbom.sh
+++ b/scripts/sbom_exporter/export_ecr_image_sbom.sh
@@ -39,9 +39,9 @@ while true; do
     if [ "$STATUS" != "IN_PROGRESS" ]; then
         echo "Final response:"
         echo $RESPONSE | jq -C
-        mkdir -p exports/$IMAGE_TAG
+        mkdir -p exports/$SERVICE_NAME/$IMAGE_TAG
         echo "downloading SBOMs from S3..."
-        aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$IMAGE_TAG --recursive
+        aws s3 cp s3://opg-aws-inspector-sbom/$SERVICE_NAME/$IMAGE_TAG/SPDX_2_3_outputs_$REPORT_ID/account=$ACCOUNT_ID/resource=AWS_ECR_CONTAINER_IMAGE/ ./exports/$SERVICE_NAME/$IMAGE_TAG --recursive
         break
     fi
 


### PR DESCRIPTION
# Purpose

Finish self service sbom workflow for docker images

Fixes MLPAB-2343

## Approach

- checkout code and install aws cli
- upload artifacts for user download
- ~TODO: get sbom for mock onelogin image~

(the mock-onelogin image is producing empty exports, so will address that over on that repository)

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
