### PR TITLE
MLPAB-2011 - only publish lambda when the lambda source changes

### DIFF
--- a/terraform/environment/region/modules/s3_antivirus/lambda_function.tf
+++ b/terraform/environment/region/modules/s3_antivirus/lambda_function.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
   runtime          = "provided.al2023"
   timeout          = 300
   memory_size      = 4096
-  publish          = filebase64sha256("${path.module}/myFunction.zip") != terraform_data.replacement.triggers_replace[0] ? true : false
+  publish          = filebase64sha256("${path.module}/myFunction.zip") != terraform_data.replacement.triggers_replace[0]
 
   layers = [
     aws_lambda_layer_version.lambda_layer.arn


### PR DESCRIPTION
# Purpose

Lambda's would previously always publish a new version even when nothing had changed about them.

Fixes MLPAB-2011

## Approach

- Use a terraform_data resource to hold a replacement trigger
- compare SHA256 to replacement trigger to determine when to publish

## Learning

- https://developer.hashicorp.com/terraform/language/resources/terraform-data
