### PR TITLE
MLPAB-2383 - replace sgrule when allow list changes

### DIFF
--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -154,6 +154,10 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
+resource "terraform_data" "ingress_allow_list_cidr" {
+  input = var.ingress_allow_list_cidr
+}
+
 resource "aws_security_group_rule" "app_loadbalancer_port_80_redirect_ingress" {
   count             = var.public_access_enabled ? 0 : 1
   description       = "Port 80 ingress for redirection to port 443"
@@ -163,7 +167,12 @@ resource "aws_security_group_rule" "app_loadbalancer_port_80_redirect_ingress" {
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.app_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "app_loadbalancer_ingress" {
@@ -175,7 +184,12 @@ resource "aws_security_group_rule" "app_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.app_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {

--- a/terraform/environment/region/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/region/modules/mock_onelogin/alb.tf
@@ -90,6 +90,10 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
+resource "terraform_data" "ingress_allow_list_cidr" {
+  input = var.ingress_allow_list_cidr
+}
+
 resource "aws_security_group_rule" "mock_onelogin_loadbalancer_port_80_redirect_ingress" {
   description       = "Port 80 ingress for redirection to port 443"
   type              = "ingress"
@@ -98,7 +102,12 @@ resource "aws_security_group_rule" "mock_onelogin_loadbalancer_port_80_redirect_
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "mock_onelogin_loadbalancer_ingress" {
@@ -109,7 +118,12 @@ resource "aws_security_group_rule" "mock_onelogin_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {

--- a/terraform/environment/region/modules/mock_pay/alb.tf
+++ b/terraform/environment/region/modules/mock_pay/alb.tf
@@ -90,6 +90,10 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
+resource "terraform_data" "ingress_allow_list_cidr" {
+  input = var.ingress_allow_list_cidr
+}
+
 resource "aws_security_group_rule" "mock_pay_loadbalancer_port_80_redirect_ingress" {
   description       = "Port 80 ingress for redirection to port 443"
   type              = "ingress"
@@ -98,7 +102,12 @@ resource "aws_security_group_rule" "mock_pay_loadbalancer_port_80_redirect_ingre
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.mock_pay_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "mock_pay_loadbalancer_ingress" {
@@ -109,7 +118,12 @@ resource "aws_security_group_rule" "mock_pay_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = aws_security_group.mock_pay_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {


### PR DESCRIPTION
# Purpose

Replace rules to avoid duplicate rule errors

Fixes MLPAB-2383

## Approach

- Use lifecycle to replace the sgrule resource when allowlist changes

## Learning

- https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by
