### PR TITLE
MLPAB-2431 investigate demo healthchecks reporting site down

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,38 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.63.0"
+  version     = "5.63.1"
   constraints = "~> 5.63.0"
   hashes = [
-    "h1:+9QoL4+xBDJg4Arv/oQSCLEby2qfh5qSOyiDETdztNk=",
-    "h1:+BIGqFMm8TiejSq8LS2Ke1sGnWdrl5WVrFQ3TRyaUaQ=",
-    "h1:+S5g7CsGDYbZ9p879sLsxq0jNP4BnvzWkKw95syZzmk=",
-    "h1:2/nHv+co4Of6VCr76KVBW7+5kTCyiJG5Sc1Qe1o5ock=",
-    "h1:MUF90afNgzlGQYnKg/IL0RzU0OlyFGb2WVUxCI0hQ6k=",
-    "h1:NLTqbeBNFzXubf3Huqs5i+sWtM8/WXdiFWGVvLJPwDc=",
-    "h1:V4V0EiUr2hRzMbnUCmR4SYz6lG+Ym4m9xaaekScs+aw=",
-    "h1:WuZDn1l1CugBTqubP/B1xdKaWeWbQd6RXW7lluZutKM=",
-    "h1:jGnSBSPCBaDmu9MCu3eyPJBPCobae2XaFib8OQ2C5OA=",
-    "h1:mhVxzwfSZVxPJNZsr1fvKZe51+48BdM7pzWChVQ4v68=",
-    "h1:tbsSy9b7WH98xKUIEXWCX6iiGY+XiEouq5rghPB4j8k=",
-    "h1:u3jH1MSkNJxEZAtBypzsO4cjra56kd00KK0yj2jLHDk=",
-    "h1:w00gGD1cLqr2ocn1fIbEquhghMdnmb/noriXKNKr3bA=",
-    "h1:xE3Hg7BaxLCQuD+x4jP8Mo1M4nRpo7HSr8+6uNJrTZ4=",
-    "zh:21f3a6870dd80b8312b6aac28784b29a7c2cf072175f0de943f09bddbf14cad6",
-    "zh:28feb0621baeaa9b6992a6209fd0d7ad1c665b1dd895123f2fd36d91d69d116f",
-    "zh:301d51b398c3e3488ea2b63defeb254436854c83046d9fc5ca129b13faaa4319",
-    "zh:343e89645a2b23363226e2e0571639637ac1ddf7fa8c562bf883b17c8ad30d7d",
-    "zh:56c89148fc105a1bf32ffcd574ec1e679144377ea26c9ae4211dd491a3def358",
-    "zh:5e3b88e3eb28b23819126d43b191a2bda28a09d7690aee7e577b3b6235c4824a",
-    "zh:64c21f3b38a8f0f0ef8b938df71cde76d77e010236bb6a0b46f66daa6cab6f99",
-    "zh:6869e5fafe6535954ac75ece63e9765d6b12d1752b54cf9639a01585f1a5583e",
-    "zh:90a6894868c585a5abf00e784723d74ea80aff3d0403b36028c4b08c5c4894d6",
-    "zh:92e9e4b7c183e518c1decd0fbc780e9f1941d05710c9c20329c78556a7f0adac",
+    "h1:Wu2MrBj79v8k4hMb8GKMu5p9KpVtCjNBsZ/R5wOTgZs=",
+    "zh:093adc21714d264005f66002464f4e9f48d6759adaaa88ca32db0c1134c2ca2b",
+    "zh:15505e01889d8da3e569ae3a8300cf12e8853822a5909a54eb07cf57f17daa74",
+    "zh:1c64ea9ab2c4a46a2e6eeafa4069106c1d9208aa2823264e58e826049b9417f7",
+    "zh:1ca7e98446f519f08ad684928b8bc22d480e419b6210955af8a31730d8dbc5ad",
+    "zh:3bd8fe53647e17fadcfe13536160009e4bb77e1c2fe224e991c82fb228ab4ece",
+    "zh:68d4bd6ffba3c6484c228a1756b1c7c16802ebd58a20b8d6bfb547d96a2eaa69",
+    "zh:68fbabfc04bde3655ded9919f5954ab8884a35d265d41aec53f95804e741ca7c",
+    "zh:69c2ea737c1cfb7252f22ca7a50d8cc7a4729ea288fc3833933c2380023ca605",
+    "zh:796caec3b4e8d177e5e4787d7b61a8a541993edc33db2c3ffffdfdbbad3967b5",
+    "zh:877a02805e1b4503b4e174a34084055873619af9d9e57e7098c27d0e0be0b592",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:bbc053d060d4f6e95ef60549a0e92487fbbd88807f8161507cc389edc7dde0f7",
-    "zh:cfd8e88029a2fdafdfa77688f966705ade9211d173cbb6aa1552839c9993c19a",
-    "zh:d291875c26a6a05b60e02f1481c296269080232fa0ae86cce5caa04a6df82ed6",
-    "zh:f42f0b81587de0c51859e37cd671c442d8eaf42558d83c6421b1e46549576f89",
+    "zh:d37f14e0807d73eff3a8384d694b4e770d41ae3286b5195927d9d809076a2d68",
+    "zh:e45279ca14b28647ac26dc8ca87f67da994f961e92ad316c9bc71be922c0a3fb",
+    "zh:e63eb4cc5b78319a26120bdce985f44ac4b1e71e43abac0eca4eaceb0af570f5",
+    "zh:f5c12695fcd777825434aa7aa560b6e1d851f823d75fda7c9df5c177071720a5",
   ]
 }
 

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -150,7 +150,7 @@ resource "aws_security_group" "app_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "ap-southeast-1"]
+  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "us-west-2"]
   provider = aws.region
 }
 

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -154,6 +154,14 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
+resource "terraform_data" "route53_healthchecks_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+}
+
+resource "terraform_data" "route53_healthchecks_ipv6_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
+}
+
 resource "terraform_data" "ingress_allow_list_cidr" {
   input = var.ingress_allow_list_cidr
 }
@@ -201,7 +209,13 @@ resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
   ipv6_cidr_blocks  = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
   security_group_id = aws_security_group.app_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.route53_healthchecks_cidr_blocks,
+      terraform_data.route53_healthchecks_ipv6_cidr_blocks
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "app_loadbalancer_public_access_ingress" {

--- a/terraform/environment/region/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/region/modules/mock_onelogin/alb.tf
@@ -86,7 +86,7 @@ resource "aws_security_group" "mock_onelogin_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "ap-southeast-1"]
+  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "us-west-2"]
   provider = aws.region
 }
 

--- a/terraform/environment/region/modules/mock_pay/alb.tf
+++ b/terraform/environment/region/modules/mock_pay/alb.tf
@@ -90,6 +90,14 @@ data "aws_ip_ranges" "route53_healthchecks" {
   provider = aws.region
 }
 
+resource "terraform_data" "route53_healthchecks_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+}
+
+resource "terraform_data" "route53_healthchecks_ipv6_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
+}
+
 resource "terraform_data" "ingress_allow_list_cidr" {
   input = var.ingress_allow_list_cidr
 }
@@ -135,7 +143,13 @@ resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
   ipv6_cidr_blocks  = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
   security_group_id = aws_security_group.mock_pay_loadbalancer.id
-  provider          = aws.region
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.route53_healthchecks_cidr_blocks,
+      terraform_data.route53_healthchecks_ipv6_cidr_blocks
+    ]
+  }
+  provider = aws.region
 }
 
 resource "aws_security_group_rule" "mock_pay_loadbalancer_public_access_ingress" {

--- a/terraform/environment/region/modules/mock_pay/alb.tf
+++ b/terraform/environment/region/modules/mock_pay/alb.tf
@@ -86,7 +86,7 @@ resource "aws_security_group" "mock_pay_loadbalancer" {
 
 data "aws_ip_ranges" "route53_healthchecks" {
   services = ["route53_healthchecks"]
-  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "ap-southeast-1"]
+  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "us-west-2"]
   provider = aws.region
 }
 


### PR DESCRIPTION
# Purpose

Fix demo environment health-checks failing

Fixes MLPAB-2431

## Approach

- use Oregon region for health-check ingress
- replace public and private rules when toggling public access (also enables recovery from duplicate entries error)
- replace health-check ingress rules when AWS checkers cidr or ipv6 cidr ranges change rather than update in place

## Learning

- https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by
