### PR TITLE
MLPAB-1659 - create cloudtrail from dynamodb data plane events

### DIFF
--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -47,6 +47,7 @@ resource "aws_cloudtrail" "dynamodb" {
 }
 
 resource "aws_cloudwatch_query_definition" "dynamodb_cloudtrail_table" {
+  count           = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name            = "${local.default_tags.environment-name}/dynamodb cloudtrail table"
   log_group_names = [aws_cloudwatch_log_group.cloudtrail_dynamodb[0].name]
 
@@ -59,6 +60,7 @@ EOF
 }
 
 resource "aws_cloudwatch_query_definition" "dynamodb_cloudtrail_stream" {
+  count           = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name            = "${local.default_tags.environment-name}/dynamodb cloudtrail stream"
   log_group_names = [aws_cloudwatch_log_group.cloudtrail_dynamodb[0].name]
 

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -39,12 +39,8 @@ resource "aws_cloudtrail" "dynamodb" {
       type = "AWS::DynamoDB::Table"
       values = [
         aws_dynamodb_table.lpas_table.arn,
-        aws_dynamodb_table_replica.lpas_table[0].arn
+        local.environment.dynamodb.region_replica_enabled ? aws_dynamodb_table_replica.lpas_table[0].arn : ""
       ]
-    }
-    data_resource {
-      type   = "AWS::DynamoDB::Stream"
-      values = ["${aws_dynamodb_table.lpas_table.arn}/stream/*"]
     }
   }
   provider = aws.eu_west_1

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -22,7 +22,7 @@ data "aws_iam_role" "cloudtrail" {
 
 resource "aws_cloudtrail" "dynamodb" {
   count                         = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
-  name                          = "dynamodb"
+  name                          = "${local.default_tags.environment-name}-dynamodb"
   s3_bucket_name                = data.aws_s3_bucket.cloudtrail.id
   kms_key_id                    = data.aws_kms_alias.cloudtrail.arn
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail_dynamodb[0].arn}:*"

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -3,11 +3,12 @@ data "aws_s3_bucket" "cloudtrail" {
   provider = aws.eu_west_1
 }
 
-data "aws_kms_key_alias" "cloudtrail" {
+data "aws_kms_alias" "cloudtrail" {
   name = "cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {
+  count             = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name              = "/aws/cloudtrail/dynamodb"
   retention_in_days = 365
 }
@@ -20,9 +21,9 @@ resource "aws_cloudtrail" "dynamodb" {
   count                         = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name                          = "dynamodb"
   s3_bucket_name                = data.aws_s3_bucket.cloudtrail.id
-  kms_key_id                    = data.aws_kms_key_alias.cloudtrail.arn
-  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail_dynamodb.arn}:*"
-  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
+  kms_key_id                    = data.aws_kms_alias.cloudtrail.arn
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail_dynamodb[0].arn}:*"
+  cloud_watch_logs_role_arn     = data.aws_iam_role.cloudtrail.arn
   s3_key_prefix                 = "dynamodb"
   enable_log_file_validation    = true
   include_global_service_events = true

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -4,17 +4,20 @@ data "aws_s3_bucket" "cloudtrail" {
 }
 
 data "aws_kms_alias" "cloudtrail" {
-  name = "alias/cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
+  name     = "alias/cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
+  provider = aws.eu_west_1
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {
   count             = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name              = "/aws/cloudtrail/dynamodb"
   retention_in_days = 365
+  provider          = aws.eu_west_1
 }
 
 data "aws_iam_role" "cloudtrail" {
-  name = "modernising-lpa-${local.environment.account_name}"
+  name     = "modernising-lpa-${local.environment.account_name}"
+  provider = aws.eu_west_1
 }
 
 resource "aws_cloudtrail" "dynamodb" {
@@ -44,4 +47,5 @@ resource "aws_cloudtrail" "dynamodb" {
       values = ["${aws_dynamodb_table.lpas_table.arn}/stream/*"]
     }
   }
+  provider = aws.eu_west_1
 }

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -3,11 +3,28 @@ data "aws_s3_bucket" "cloudtrail" {
   provider = aws.eu_west_1
 }
 
+data "aws_kms_key_alias" "cloudtrail" {
+  name = "cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
+}
+
+resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {
+  name              = "/aws/cloudtrail/dynamodb"
+  retention_in_days = 365
+}
+
+data "aws_iam_role" "cloudtrail" {
+  name = "modernising-lpa-${local.environment.account_name}"
+}
+
 resource "aws_cloudtrail" "dynamodb" {
   count                         = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name                          = "dynamodb"
   s3_bucket_name                = data.aws_s3_bucket.cloudtrail.id
+  kms_key_id                    = data.aws_kms_key_alias.cloudtrail.arn
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail_dynamodb.arn}:*"
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
   s3_key_prefix                 = "dynamodb"
+  enable_log_file_validation    = true
   include_global_service_events = true
   is_multi_region_trail         = true
   event_selector {

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -1,0 +1,22 @@
+data "aws_s3_bucket" "cloudtrail" {
+  bucket   = "cloudtrail.${local.environment.account_name}.modernise.opg.service.justice.gov.uk"
+  provider = aws.eu_west_1
+}
+
+resource "aws_cloudtrail" "dynamodb" {
+  count                         = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
+  name                          = "dynamodb"
+  s3_bucket_name                = data.aws_s3_bucket.cloudtrail.id
+  s3_key_prefix                 = "dynamodb"
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  event_selector {
+    read_write_type = "All"
+    # include_management_events = true
+
+    data_resource {
+      type   = "AWS::DynamoDB::Table"
+      values = ["arn:aws:lambda"]
+    }
+  }
+}

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -15,8 +15,15 @@ resource "aws_cloudtrail" "dynamodb" {
     # include_management_events = true
 
     data_resource {
-      type   = "AWS::DynamoDB::Table"
-      values = ["arn:aws:lambda"]
+      type = "AWS::DynamoDB::Table"
+      values = [
+        aws_dynamodb_table.lpas_table.arn,
+        aws_dynamodb_table_replica.lpas_table[0].arn
+      ]
+    }
+    data_resource {
+      type   = "AWS::DynamoDB::Stream"
+      values = ["${aws_dynamodb_table.lpas_table.arn}/stream/*"]
     }
   }
 }

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -4,7 +4,7 @@ data "aws_s3_bucket" "cloudtrail" {
 }
 
 data "aws_kms_alias" "cloudtrail" {
-  name = "cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
+  name = "alias/cloudtrail_s3_modernising_lpa_${local.environment.account_name}"
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {

--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -10,7 +10,7 @@ data "aws_kms_alias" "cloudtrail" {
 
 resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {
   count             = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
-  name              = "/aws/cloudtrail/dynamodb"
+  name              = "/aws/cloudtrail/dynamodb-${local.default_tags.environment-name}"
   retention_in_days = 365
   provider          = aws.eu_west_1
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": true
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -483,7 +483,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": false
+        "cloudtrail_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -568,7 +568,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": false
+        "cloudtrail_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": false

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -57,7 +57,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -141,7 +142,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas-20240717",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -225,7 +227,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -309,7 +312,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -393,7 +397,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": false
@@ -477,7 +482,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true
@@ -561,7 +567,8 @@
       },
       "dynamodb": {
         "table_name": "Lpas",
-        "region_replica_enabled": false
+        "region_replica_enabled": false,
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": false

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": false
+        "cloudtrail_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -67,6 +67,7 @@ variable "environments" {
       dynamodb = object({
         table_name             = string
         region_replica_enabled = bool
+        cloudtrail_enabled     = bool
       })
       ecs = object({
         fargate_spot_capacity_provider_enabled = bool


### PR DESCRIPTION
# Purpose

Log data plane events for Dynamodb

Fixes MLPAB-1659

## Approach

- create Cloudtrail using existing trial bucket
- only create trails for specific environments
- only log Dynamodb data plane events
- ~encrypt trail~ will be done as part of ticket 2436 as requires account level resources to exist first.
- Only enable for preproduction and production

## Learning

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/logging-using-cloudtrail.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail
