### PR TITLE
MLPAB-2436 - enable encryption for the dynamodb cloudtrail log group

### DIFF
--- a/terraform/environment/dynamodb_cloudtrail.tf
+++ b/terraform/environment/dynamodb_cloudtrail.tf
@@ -8,10 +8,16 @@ data "aws_kms_alias" "cloudtrail" {
   provider = aws.eu_west_1
 }
 
+data "aws_kms_alias" "dynamodb_cloudtrail_log_group" {
+  name     = "alias/${local.default_tags.application}_dynamodb_cloudtrail_log_group_encryption"
+  provider = aws.eu_west_1
+}
+
 resource "aws_cloudwatch_log_group" "cloudtrail_dynamodb" {
   count             = local.environment.dynamodb.cloudtrail_enabled ? 1 : 0
   name              = "/aws/cloudtrail/dynamodb-${local.default_tags.environment-name}"
   retention_in_days = 365
+  kms_key_id        = data.aws_kms_alias.dynamodb_cloudtrail_log_group.target_key_arn
   provider          = aws.eu_west_1
 }
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": false
+        "cloudtrail_enabled": true
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -58,7 +58,7 @@
       "dynamodb": {
         "table_name": "Lpas",
         "region_replica_enabled": false,
-        "cloudtrail_enabled": true
+        "cloudtrail_enabled": false
       },
       "ecs": {
         "fargate_spot_capacity_provider_enabled": true


### PR DESCRIPTION
# Purpose

Enable CMK encryption of CloudWatch Log Groups

Fixes MLPAB-2436

## Approach

- use KMS CMK for log group
- Allow CKM to be used by cloudtrail

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
