### PR TITLE
MLAB-2499 - abort incomplete MPUs after 7 days

### DIFF
--- a/terraform/account/region/modules/antivirus_definitions/s3.tf
+++ b/terraform/account/region/modules/antivirus_definitions/s3.tf
@@ -47,6 +47,20 @@ resource "aws_s3_bucket_logging" "bucket" {
   provider      = aws.region
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    id = "abort-incomplete-multipart-upload"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    status = "Enabled"
+  }
+}
+
 data "aws_iam_policy_document" "bucket" {
   policy_id = "PutObjPolicy"
 

--- a/terraform/account/region/modules/s3_batch_manifests/s3.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/s3.tf
@@ -47,6 +47,20 @@ resource "aws_s3_bucket_logging" "bucket" {
   provider      = aws.region
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    id = "abort-incomplete-multipart-upload"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    status = "Enabled"
+  }
+}
+
 data "aws_iam_policy_document" "bucket" {
   policy_id = "PutObjPolicy"
 

--- a/terraform/environment/region/modules/uploads_s3_bucket/s3_bucket_lifecycles.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/s3_bucket_lifecycles.tf
@@ -35,5 +35,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "main" {
     status = "Enabled"
   }
 
+  rule {
+    id = "abort-incomplete-multipart-upload"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    status = "Enabled"
+  }
+
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-2499

## Approach

- add lifecycle policy to abort incomplete multipart uploads after 7 days

## Learning

- https://aws.amazon.com/blogs/aws-cloud-financial-management/discovering-and-deleting-incomplete-multipart-uploads-to-lower-amazon-s3-costs/
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration
