### PR TITLE
MLPAB-2531 - set a deregistration delay to address load balancer 4xx errors

### DIFF
--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "app" {
   protocol             = "HTTP"
   target_type          = "ip"
   vpc_id               = var.network.vpc_id
-  deregistration_delay = 0
+  deregistration_delay = 300
   depends_on           = [aws_lb.app]
 
   health_check {

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -366,7 +366,8 @@ locals {
           protocol      = "tcp"
         }
       ],
-      volumesFrom = [],
+      volumesFrom    = [],
+      systemControls = []
       logConfiguration = {
         logDriver = "awslogs",
         options = {
@@ -520,7 +521,8 @@ locals {
           max-buffer-size       = "25m"
         }
       },
-      environment = []
+      environment    = [],
+      systemControls = []
   })
 
   amazon_ssm_agent = jsonencode(

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -367,7 +367,7 @@ locals {
         }
       ],
       volumesFrom    = [],
-      systemControls = []
+      systemControls = [],
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/region/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/region/modules/mock_onelogin/alb.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "mock_onelogin" {
   protocol             = "HTTP"
   target_type          = "ip"
   vpc_id               = var.network.vpc_id
-  deregistration_delay = 0
+  deregistration_delay = 300
   depends_on           = [aws_lb.mock_onelogin]
 
   health_check {

--- a/terraform/environment/region/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/ecs.tf
@@ -148,7 +148,8 @@ locals {
           protocol      = "tcp"
         }
       ],
-      volumesFrom = [],
+      volumesFrom    = [],
+      systemControls = [],
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/region/modules/mock_pay/alb.tf
+++ b/terraform/environment/region/modules/mock_pay/alb.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "mock_pay" {
   protocol             = "HTTP"
   target_type          = "ip"
   vpc_id               = var.network.vpc_id
-  deregistration_delay = 0
+  deregistration_delay = 300
   depends_on           = [aws_lb.mock_pay]
 
   health_check {

--- a/terraform/environment/region/modules/mock_pay/ecs.tf
+++ b/terraform/environment/region/modules/mock_pay/ecs.tf
@@ -142,7 +142,8 @@ locals {
           protocol      = "tcp"
         }
       ],
-      volumesFrom = [],
+      volumesFrom    = [],
+      systemControls = [],
       logConfiguration = {
         logDriver = "awslogs",
         options = {


### PR DESCRIPTION
# Purpose

Allow time to drain requests what new targets are deployed

Fixes MLPAB-2531

## Approach

- use the default value 300 seconds for deregistration

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-register-targets.html
