### PR TITLE
MLPAB-2534 Return dashboard data early when no Lpas with a UID to get

### DIFF
--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -146,6 +146,10 @@ func (s *Store) GetAll(ctx context.Context) (results dashboarddata.Results, err 
 		}
 	}
 
+	if len(donorsDetails) == 0 {
+		return results, nil
+	}
+
 	resolvedLpas, err := s.lpaStoreResolvingService.ResolveList(ctx, donorsDetails)
 	if err != nil {
 		return results, err

--- a/internal/dashboard/store_test.go
+++ b/internal/dashboard/store_test.go
@@ -354,6 +354,29 @@ func TestDashboardStoreGetAllWhenNone(t *testing.T) {
 	assert.Equal(t, dashboarddata.Results{}, results)
 }
 
+func TestDashboardStoreGetAllWhenNoneWithUID(t *testing.T) {
+	ctx := appcontext.ContextWithSession(context.Background(), &appcontext.Session{SessionID: "an-id"})
+
+	dynamoClient := newMockDynamoClient(t)
+	dynamoClient.ExpectAllBySK(ctx, dynamo.SubKey("an-id"),
+		[]dashboarddata.LpaLink{
+			{PK: dynamo.LpaKey("a"), SK: dynamo.SubKey("an-id"), DonorKey: dynamo.LpaOwnerKey(dynamo.DonorKey("b")), ActorType: actor.TypeDonor},
+		}, nil)
+	dynamoClient.ExpectAllByKeys(ctx, []dynamo.Keys{{PK: dynamo.LpaKey("a"), SK: dynamo.LpaOwnerKey(dynamo.DonorKey("b"))}},
+		[]map[string]types.AttributeValue{
+			makeAttributeValueMap(&donordata.Provided{
+				PK: dynamo.LpaKey("a"),
+				SK: dynamo.LpaOwnerKey(dynamo.DonorKey("b")),
+			}),
+		}, nil)
+
+	dashboardStore := &Store{dynamoClient: dynamoClient}
+
+	results, err := dashboardStore.GetAll(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, dashboarddata.Results{}, results)
+}
+
 func TestDashboardStoreGetAllWhenAllForActorErrors(t *testing.T) {
 	ctx := appcontext.ContextWithSession(context.Background(), &appcontext.Session{SessionID: "an-id"})
 


### PR DESCRIPTION
We already filter out the UID-less LPAs, the error we got was actually trying to get LPAs with the empty list `[]`.