### PR TITLE
MLPAB-2565 - use pull through cache for trivy java db

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -102,6 +102,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         env:
           TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_EPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db-java:1
         with:
           image-ref: ${{ matrix.ecr_repository }}:${{ inputs.tag }}
           severity: 'HIGH,CRITICAL'

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -102,7 +102,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         env:
           TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db:2
-          TRIVY_JAVA_DB_EPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db-java:1
+          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db-java:1
         with:
           image-ref: ${{ matrix.ecr_repository }}:${{ inputs.tag }}
           severity: 'HIGH,CRITICAL'

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -102,7 +102,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         env:
           TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db:2
-          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db-java:1
+          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-java-db:1
         with:
           image-ref: ${{ matrix.ecr_repository }}:${{ inputs.tag }}
           severity: 'HIGH,CRITICAL'

--- a/cmd/mlpa/buildtrigger
+++ b/cmd/mlpa/buildtrigger
@@ -1,1 +1,0 @@
-trigger a build

--- a/cmd/mlpa/buildtrigger
+++ b/cmd/mlpa/buildtrigger
@@ -1,0 +1,1 @@
+trigger a build


### PR DESCRIPTION
# Purpose

Mitigate impact of rate limiting when scanning images with Trivy

Fixes MLPAB-2565

## Approach

- Define java db repo and use pass through cache location

## Learning

- https://aquasecurity.github.io/trivy/v0.55/docs/references/configuration/config-file/#db-options
