### PR TITLE
MLPAB-2550 test using arm architecture now that fargate spot supports graviton

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -36,19 +36,19 @@ jobs:
           - ecr_repository: modernising-lpa/app
             name: app
             path: ./docker/mlpa/Dockerfile
-            platforms: linux/amd64
+            platforms: linux/arm64
           - ecr_repository: modernising-lpa/create-s3-batch-replication-job
             name: create-s3-batch-replication-job
             path: ./lambda/create_s3_replication_job/Dockerfile
-            platforms: linux/amd64
+            platforms: linux/arm64
           - ecr_repository: modernising-lpa/event-received
             name: event-received
             path: ./docker/event-received/Dockerfile
-            platforms: linux/amd64
+            platforms: linux/arm64
           - ecr_repository: modernising-lpa/mock-pay
             name: mock-pay
             path: ./docker/mock-pay/Dockerfile
-            platforms: linux/amd64
+            platforms: linux/arm64
 
     runs-on: ubuntu-latest
     name: ${{ matrix.ecr_repository }}

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -36,11 +36,11 @@ jobs:
           - ecr_repository: modernising-lpa/app
             name: app
             path: ./docker/mlpa/Dockerfile
-            platforms: linux/arm64
+            platforms: linux/arm64 # options are linux/amd64, linux/arm64
           - ecr_repository: modernising-lpa/create-s3-batch-replication-job
             name: create-s3-batch-replication-job
             path: ./lambda/create_s3_replication_job/Dockerfile
-            platforms: linux/arm64
+            platforms: linux/amd64
           - ecr_repository: modernising-lpa/event-received
             name: event-received
             path: ./docker/event-received/Dockerfile
@@ -48,7 +48,7 @@ jobs:
           - ecr_repository: modernising-lpa/mock-pay
             name: mock-pay
             path: ./docker/mock-pay/Dockerfile
-            platforms: linux/arm64
+            platforms: linux/amd64
 
     runs-on: ubuntu-latest
     name: ${{ matrix.ecr_repository }}

--- a/cmd/mlpa/buildtrigger
+++ b/cmd/mlpa/buildtrigger
@@ -1,0 +1,1 @@
+trigger a build

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -93,7 +93,7 @@ resource "aws_ecs_task_definition" "app" {
   memory                   = 1024
   runtime_platform {
     operating_system_family = "LINUX"
-    cpu_architecture        = "X86_64"
+    cpu_architecture        = "ARM64" # options are ARM64 or X86_64
   }
   container_definitions = var.fault_injection_experiments_enabled ? "[${local.app}, ${local.aws_otel_collector}, ${local.amazon_ssm_agent}]" : "[${local.app}, ${local.aws_otel_collector}]"
   task_role_arn         = var.ecs_task_role.arn

--- a/terraform/environment/region/modules/event_received/lambda.tf
+++ b/terraform/environment/region/modules/event_received/lambda.tf
@@ -23,6 +23,7 @@ module "event_received" {
   iam_policy_documents = [data.aws_iam_policy_document.api_access_policy.json]
   timeout              = 300
   memory               = 1024
+  architectures        = "arm64"
   vpc_config = {
     subnet_ids         = var.vpc_config.subnet_ids
     security_group_ids = var.vpc_config.security_group_ids

--- a/terraform/environment/region/modules/lambda/main.tf
+++ b/terraform/environment/region/modules/lambda/main.tf
@@ -19,6 +19,7 @@ resource "aws_lambda_function" "lambda_function" {
   function_name = "${var.lambda_name}-${var.environment}"
   description   = var.description
   image_uri     = var.image_uri
+  architectures = var.architectures
   package_type  = var.package_type
   role          = var.aws_iam_role.arn
   timeout       = var.timeout

--- a/terraform/environment/region/modules/lambda/variables.tf
+++ b/terraform/environment/region/modules/lambda/variables.tf
@@ -71,3 +71,13 @@ variable "vpc_config" {
     security_group_ids = []
   }
 }
+
+variable "architectures" {
+  description = "The architectures supported by the Lambda Function."
+  type        = list(string)
+  default     = ["x86_64"]
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.architectures)
+    error_message = "Invalid value for architectures, must be one of x86_64 or arm64"
+  }
+}

--- a/terraform/environment/region/modules/mock_pay/ecs.tf
+++ b/terraform/environment/region/modules/mock_pay/ecs.tf
@@ -120,10 +120,14 @@ resource "aws_ecs_task_definition" "mock_pay" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.mock_pay}]"
-  task_role_arn            = var.ecs_task_role.arn
-  execution_role_arn       = var.ecs_execution_role.arn
-  provider                 = aws.region
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64" # options are ARM64 or X86_64
+  }
+  container_definitions = "[${local.mock_pay}]"
+  task_role_arn         = var.ecs_task_role.arn
+  execution_role_arn    = var.ecs_execution_role.arn
+  provider              = aws.region
 }
 
 locals {


### PR DESCRIPTION
# Purpose

Reduce ECS and lambda costs by using arm64 architecure

Fixes MLPAB-2550

## Approach

- build arm64 images for app and event received
- specify architecture for ECS task definition (make this a variable)
- specify architecture for lambda function

## Learning

- https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-ecs-graviton-based-spot-compute-fargate/
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html