### PR TITLE
MLPAB-2593 - Use hadolint to improve dockerfiles

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,8 +66,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'success'
-        # steps.hadolint.outcome == 'failure'
+        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != ''
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} == 'failure'
+        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} != 'success'
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'failure'
+        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} == 'failure'
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -25,8 +25,7 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: write
-  issues: write
+  pull-requests: read
 
 jobs:
   docker_build_scan_push:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'success'
+        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'failure'
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -59,12 +59,13 @@ jobs:
           ref: ${{ inputs.checkout_tag }}
 
       - uses: hadolint/hadolint-action@v3.1.0
+        id: hadolint
         with:
           dockerfile: ${{ matrix.path }}
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.hadolint.outcome != ''
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -25,7 +25,8 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: read
+  pull-requests: write
+  issues: write
 
 jobs:
   docker_build_scan_push:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -61,6 +61,25 @@ jobs:
         with:
           dockerfile: ${{ matrix.path }}
 
+      - name: Update Pull Request
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const output = `
+            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            \`\`\`
+            ${process.env.HADOLINT_RESULTS}
+            \`\`\`
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -65,25 +65,6 @@ jobs:
           no-fail: false
           failure-threshold: warning
 
-      - name: Update Pull Request
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} == 'failure'
-        with:
-          script: |
-            const output = `
-            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
-            \`\`\`
-            ${process.env.HADOLINT_RESULTS}
-            \`\`\`
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != ''
+        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'success'
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && steps.hadolint.outcome != ''
+        if: github.event_name == 'pull_request' && process.env.HADOLINT_RESULTS != '' && ${{ steps.hadolint.outcome }} == 'success'
+        # steps.hadolint.outcome == 'failure'
         with:
           script: |
             const output = `

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -62,7 +62,8 @@ jobs:
         id: hadolint
         with:
           dockerfile: ${{ matrix.path }}
-          no-fail: true
+          no-fail: false
+          failure-threshold: warning
 
       - name: Update Pull Request
         uses: actions/github-script@v6

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -57,6 +57,10 @@ jobs:
         with:
           ref: ${{ inputs.checkout_tag }}
 
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ matrix.path }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -62,6 +62,7 @@ jobs:
         id: hadolint
         with:
           dockerfile: ${{ matrix.path }}
+          no-fail: true
 
       - name: Update Pull Request
         uses: actions/github-script@v6

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} != 'success'
+        if: github.event_name == 'pull_request' && ${{ steps.hadolint.outcome }} == 'failure'
         with:
           script: |
             const output = `

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,15 +45,6 @@ repos:
         entry: yarn run stop-only
         language: node
         args: [--folder, cypress]
-  - repo: https://github.com/hadolint/hadolint/.pre-commit-hooks.yaml
-    rev: v2.12.0
-    hooks:
-      - id: hadolint-docker\
-        name: Lint Dockerfiles
-        description: Runs hadolint Docker image to lint Dockerfiles
-        language: docker_image
-        types: ["dockerfile"]
-        entry: ghcr.io/hadolint/hadolint hadolint
 #  - repo: https://github.com/Yelp/detect-secrets
 #    rev: v1.4.0
 #    hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,12 @@ repos:
         entry: yarn run stop-only
         language: node
         args: [--folder, cypress]
-
+  - id: hadolint-docker
+    name: Lint Dockerfiles
+    description: Runs hadolint Docker image to lint Dockerfiles
+    language: docker_image
+    types: ["dockerfile"]
+    entry: ghcr.io/hadolint/hadolint hadolint
 #  - repo: https://github.com/Yelp/detect-secrets
 #    rev: v1.4.0
 #    hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,15 @@ repos:
         entry: yarn run stop-only
         language: node
         args: [--folder, cypress]
-  - id: hadolint-docker
-    name: Lint Dockerfiles
-    description: Runs hadolint Docker image to lint Dockerfiles
-    language: docker_image
-    types: ["dockerfile"]
-    entry: ghcr.io/hadolint/hadolint hadolint
+  - repo: https://github.com/hadolint/hadolint/.pre-commit-hooks.yaml
+    rev: v2.12.0
+    hooks:
+      - id: hadolint-docker\
+        name: Lint Dockerfiles
+        description: Runs hadolint Docker image to lint Dockerfiles
+        language: docker_image
+        types: ["dockerfile"]
+        entry: ghcr.io/hadolint/hadolint hadolint
 #  - repo: https://github.com/Yelp/detect-secrets
 #    rev: v1.4.0
 #    hooks:

--- a/docker/event-logger/Dockerfile
+++ b/docker/event-logger/Dockerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/even
 
 FROM scratch AS production
 
+WORKDIR /app
+
 COPY --from=base /go/bin/event-logger event-logger
 
 ENTRYPOINT ["./event-logger"]

--- a/docker/event-received/Dockerfile
+++ b/docker/event-received/Dockerfile
@@ -27,7 +27,7 @@ COPY --link  docker/event-received/install_lambda_insights.sh /app/
 
 
 RUN chmod +x /app/install_lambda_insights.sh \
-  && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
+  && /app/install_lambda_insights.sh ${TARGETPLATFORM}
 
 COPY --from=build /app/event-received ./event-received
 COPY --link lang ./lang

--- a/docker/event-received/Dockerfile
+++ b/docker/event-received/Dockerfile
@@ -27,7 +27,7 @@ COPY --link  docker/event-received/install_lambda_insights.sh /app/
 
 
 RUN chmod +x /app/install_lambda_insights.sh \
-  && /app/install_lambda_insights.sh ${TARGETPLATFORM}
+  && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
 
 COPY --from=build /app/event-received ./event-received
 COPY --link lang ./lang

--- a/docker/localstack/Dockerfile
+++ b/docker/localstack/Dockerfile
@@ -15,11 +15,11 @@ RUN GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -tag
 
 FROM localstack/localstack:3.8.0 AS localstack
 
-WORKDIR /app
 
 COPY --from=build /app/event-received.zip /etc/event-received.zip
 
 COPY ./docker/localstack/localstack-init.sh /etc/localstack/init/ready.d/localstack-init.sh
-COPY ./docker/localstack/dynamodb-lpa-gsi-schema.json ./dynamodb-lpa-gsi-schema.json
+
+COPY ./docker/localstack/dynamodb-lpa-gsi-schema.json /app/dynamodb-lpa-gsi-schema.json
 
 RUN chmod 544 /etc/localstack/init/ready.d/localstack-init.sh

--- a/docker/localstack/Dockerfile
+++ b/docker/localstack/Dockerfile
@@ -20,6 +20,6 @@ COPY --from=build /app/event-received.zip /etc/event-received.zip
 
 COPY ./docker/localstack/localstack-init.sh /etc/localstack/init/ready.d/localstack-init.sh
 
-COPY ./docker/localstack/dynamodb-lpa-gsi-schema.json /app/dynamodb-lpa-gsi-schema.json
+COPY ./docker/localstack/dynamodb-lpa-gsi-schema.json ./dynamodb-lpa-gsi-schema.json
 
 RUN chmod 544 /etc/localstack/init/ready.d/localstack-init.sh

--- a/docker/localstack/Dockerfile
+++ b/docker/localstack/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23.2-alpine AS build
 
-RUN apk add zip
+RUN apk add --no-cache zip=3.0-r12 unzip=6.0-r14
 
 WORKDIR /app
 
@@ -10,10 +10,12 @@ RUN go mod download
 COPY --link cmd/event-received ./cmd/event-received
 COPY --link internal ./internal
 
-RUN GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -tags lambda.norpc -o event-received ./cmd/event-received
-RUN zip event-received.zip event-received
+RUN GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -tags lambda.norpc -o event-received ./cmd/event-received \
+  && zip event-received.zip event-received
 
 FROM localstack/localstack:3.8.0 AS localstack
+
+WORKDIR /app
 
 COPY --from=build /app/event-received.zip /etc/event-received.zip
 

--- a/docker/localstack/localstack-init.sh
+++ b/docker/localstack/localstack-init.sh
@@ -24,7 +24,7 @@ awslocal dynamodb create-table \
          --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S AttributeName=LpaUID,AttributeType=S AttributeName=UpdatedAt,AttributeType=S \
          --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE \
          --provisioned-throughput ReadCapacityUnits=1000,WriteCapacityUnits=1000 \
-         --global-secondary-indexes file://app/dynamodb-lpa-gsi-schema.json
+         --global-secondary-indexes file://dynamodb-lpa-gsi-schema.json
 
 echo 'creating bucket'
 awslocal s3api create-bucket --bucket evidence --create-bucket-configuration LocationConstraint=eu-west-1

--- a/docker/localstack/localstack-init.sh
+++ b/docker/localstack/localstack-init.sh
@@ -24,7 +24,7 @@ awslocal dynamodb create-table \
          --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S AttributeName=LpaUID,AttributeType=S AttributeName=UpdatedAt,AttributeType=S \
          --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE \
          --provisioned-throughput ReadCapacityUnits=1000,WriteCapacityUnits=1000 \
-         --global-secondary-indexes file://dynamodb-lpa-gsi-schema.json
+         --global-secondary-indexes file://app/dynamodb-lpa-gsi-schema.json
 
 echo 'creating bucket'
 awslocal s3api create-bucket --bucket evidence --create-bucket-configuration LocationConstraint=eu-west-1

--- a/docker/mock-notify/Dockerfile
+++ b/docker/mock-notify/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23.2-alpine AS build-env
 
-RUN apk --no-cache add openssl
+RUN apk --no-cache add openssl=3.3.2-r0
 
 WORKDIR /app
 

--- a/docker/mock-os-api/Dockerfile
+++ b/docker/mock-os-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23.2-alpine AS build-env
 
-RUN apk --no-cache add openssl
+RUN apk --no-cache add openssl=3.3.2-r0
 
 WORKDIR /app
 

--- a/docker/mock-pay/Dockerfile
+++ b/docker/mock-pay/Dockerfile
@@ -1,2 +1,2 @@
-FROM outofcoffee/imposter:latest
+FROM outofcoffee/imposter:4.0.5
 COPY ./docker/mock-pay /opt/imposter/config/

--- a/lambda/create_s3_replication_job/Dockerfile
+++ b/lambda/create_s3_replication_job/Dockerfile
@@ -3,40 +3,37 @@ ARG FUNCTION_DIR="/function"
 
 FROM python:3.12-alpine3.19 AS python-alpine
 RUN apk add --no-cache \
-    libstdc++ \
-    elfutils-dev
+    libstdc++=13.2.1_git20231014-r0 \
+    elfutils-dev=0.190-r1
 
 FROM python-alpine AS build-image
-
 # Install aws-lambda-cpp build dependencies
 RUN apk add --no-cache \
-    build-base \
-    libtool \
-    autoconf \
-    automake \
-    make \
-    cmake \
-    libcurl
+    build-base=0.5-r3 \
+    libtool=2.4.7-r3 \
+    autoconf=2.71-r2 \
+    automake=1.16.5-r2 \
+    make=4.4.1-r2 \
+    cmake=3.27.8-r0 \
+    libcurl=8.9.1-r1
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
-# Create function directory
+# Create function directory and set working directory to function root directory
 RUN mkdir -p ${FUNCTION_DIR}
+WORKDIR ${FUNCTION_DIR}
 
-# Copy function code
-COPY lambda/create_s3_replication_job/src/main.py ${FUNCTION_DIR}
-
-COPY lambda/create_s3_replication_job/src/requirements.txt requirements.txt
+# Copy function code and requirements.txt
+COPY lambda/create_s3_replication_job/src/main.py lambda/create_s3_replication_job/src/requirements.txt ${FUNCTION_DIR}/
 
 # Install the runtime interface client
-RUN python -m pip install --upgrade pip
-RUN python -m pip install \
+RUN python -m pip install --root-user-action=ignore \
+        --no-cache-dir \
         --target ${FUNCTION_DIR} \
         --requirement requirements.txt
 
 # Multi-stage build: grab a fresh copy of the base image
 FROM python-alpine
-
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 # Set working directory to function root directory

--- a/lambda/create_s3_replication_job/Dockerfile
+++ b/lambda/create_s3_replication_job/Dockerfile
@@ -33,7 +33,7 @@ RUN python -m pip install --root-user-action=ignore \
         --requirement requirements.txt
 
 # Multi-stage build: grab a fresh copy of the base image
-FROM python-alpine
+FROM python-alpine AS production
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 # Set working directory to function root directory


### PR DESCRIPTION
# Purpose

Apply where possible Dockerfile best practices using Hadolint

Fixes MLPAB-2593

## Approach

- Address Hadolint findings on `create_s3_replication` Dockerfile
  - pin package versions
  - use no-cache
  - don't upgrade pip for consistent builds
  - consolidate COPY command
  - name final stage as production
  - ~TODO: fix log output, should write batch job id (see https://docs.aws.amazon.com/cli/latest/reference/lambda/invoke.html and invocation type dry-run for deployed function)~ created ticket 2596

- Address Hadolint findings on `event-received` Dockerfile
  - Double quote to prevent globbing and word splitting.
 
- Address Hadolint findings on `localstack` Dockerfile
  - pin package versions
  - use no-cache
  - ~COPY to a relative destination without WORKDIR set.~
  - Consolidate consecutive RUN commands
- ~update localstack-init.sh to use new path~
 
- Address Hadolint findings on `mock-notify` Dockerfile
  - pin package versions

- Address Hadolint findings on `mock-os-api` Dockerfile
  - pin package versions


- Address Hadolint findings on `mock-pay` Dockerfile
  - pin imposter image versions

## Learning

- https://docs.docker.com/build/building/best-practices/
- https://github.com/hadolint/hadolint-action
