### PR TITLE
MLPAB-2569 Disable mock pay on demo env

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -196,7 +196,7 @@
         "real_user_monitoring_cw_logs_enabled": true
       },
       "mock_onelogin_enabled": true,
-      "mock_pay_enabled": true,
+      "mock_pay_enabled": false,
       "uid_service": {
         "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
         "api_arns": [


### PR DESCRIPTION
All the environments on development use mock-pay, so I'm thinking it will be fine to just change the existing secret to a new API key for the correct account and only demo will use that. Unless anyone can think of a reason we'd want to use another test account?