### PR TITLE
MLPAB-2620 - fix issue with access to manifests bucket

### DIFF
--- a/terraform/environment/region/modules/uploads_s3_bucket/s3_object_replication.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/s3_object_replication.tf
@@ -70,7 +70,8 @@ data "aws_iam_policy_document" "replication" {
   statement {
     actions = [
       "s3:GetObject",
-      "s3:GetObjectVersion"
+      "s3:GetObjectVersion",
+      "s3:PutObject"
     ]
 
     effect = "Allow"
@@ -83,11 +84,11 @@ data "aws_iam_policy_document" "replication" {
     effect = "Allow"
 
     actions = [
-      "s3:PutObject"
+      "s3:ListBucket"
     ]
 
     resources = [
-      "arn:aws:s3:::batch-manifests-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}/*"
+      "arn:aws:s3:::batch-manifests-${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-${data.aws_region.current.name}"
     ]
   }
   provider = aws.region

--- a/terraform/environment/region/modules/uploads_s3_bucket/s3_object_replication.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/s3_object_replication.tf
@@ -36,7 +36,6 @@ data "aws_iam_policy_document" "replication" {
       "s3:GetReplicationConfiguration",
       "s3:ListBucket",
       "s3:PutInventoryConfiguration",
-      "s3:HeadBucket"
     ]
 
     resources = [aws_s3_bucket.bucket.arn]


### PR DESCRIPTION
# Purpose

Resolve unauthorised api call errors for list bucket actions when using the batch manifests role

Fixes MLPAB-2620

## Approach

- Add list bucket action for batch manifests

## Learning

- https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
