### PR TITLE
MLPAB-2611 - Only use region in resource names when the resource must be globally unique

### DIFF
--- a/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
+++ b/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
@@ -70,3 +70,9 @@ It isn't necessary to include resource type in the name because the resource typ
 
 - Resources will be easier to identify and grant access to
 - some resources will need renaming
+
+resources that must include region name;
+
+- s3 buckets
+- IAM policy names
+- cloudwatch metric alarms

--- a/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
+++ b/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
@@ -60,7 +60,7 @@ It isn't necessary to include resource type in the name because the resource typ
 
 `account-name` should be used for resources shared at account level.
 
-`region-name` only use region if the resource must be globally unique, for example, S3 bucket names.
+`region-name` only use region if the resource must be globally unique, for example, S3 bucket names and IAM policy names.
 
 `environment-name` should be used for resources that are environment-specific.
 

--- a/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
+++ b/docs/architecture/decisions/0005-namespacing-resources-in-aws.md
@@ -60,7 +60,7 @@ It isn't necessary to include resource type in the name because the resource typ
 
 `account-name` should be used for resources shared at account level.
 
-`region-name` can be omitted if the resource is not region-specific.
+`region-name` only use region if the resource must be globally unique, for example, S3 bucket names.
 
 `environment-name` should be used for resources that are environment-specific.
 

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "main" {
-  name = local.name_prefix
+  name = data.aws_default_tags.current.tags.environment-name
   setting {
     name  = "containerInsights"
     value = "enabled"

--- a/terraform/environment/region/ecs_autoscaling.tf
+++ b/terraform/environment/region/ecs_autoscaling.tf
@@ -11,7 +11,7 @@ data "aws_sns_topic" "ecs_autoscaling_alarms" {
 module "app_ecs_autoscaling" {
   source                           = "./modules/ecs_autoscaling"
   environment_name                 = data.aws_default_tags.current.tags.environment-name
-  name_prefix                      = local.name_prefix
+  region_name                      = data.aws_region.current.name
   aws_ecs_cluster_name             = aws_ecs_cluster.main.name
   aws_ecs_service_name             = module.app.ecs_service.name
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn

--- a/terraform/environment/region/ecs_autoscaling.tf
+++ b/terraform/environment/region/ecs_autoscaling.tf
@@ -10,7 +10,8 @@ data "aws_sns_topic" "ecs_autoscaling_alarms" {
 
 module "app_ecs_autoscaling" {
   source                           = "./modules/ecs_autoscaling"
-  environment                      = local.name_prefix
+  environment_name                 = data.aws_default_tags.current.tags.environment-name
+  name_prefix                      = local.name_prefix
   aws_ecs_cluster_name             = aws_ecs_cluster.main.name
   aws_ecs_service_name             = module.app.ecs_service.name
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -48,7 +48,7 @@ resource "aws_ecs_service" "app" {
 }
 
 resource "aws_security_group" "app_ecs_service" {
-  name_prefix = "${local.name_prefix}-ecs-service"
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-ecs-service"
   description = "app service security group"
   vpc_id      = var.network.vpc_id
   lifecycle {
@@ -86,7 +86,7 @@ resource "aws_security_group_rule" "app_ecs_service_egress" {
 }
 
 resource "aws_ecs_task_definition" "app" {
-  family                   = "${local.name_prefix}-app"
+  family                   = "${data.aws_default_tags.current.tags.environment-name}-app"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 512

--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -1,8 +1,4 @@
 locals {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-}
-
-locals {
   policy_region_prefix = lower(replace(data.aws_region.current.name, "-", ""))
 }
 

--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -11,7 +11,7 @@ resource "aws_appautoscaling_target" "ecs_service" {
 # Automatically scale capacity up by one
 resource "aws_appautoscaling_policy" "up" {
   provider           = aws.region
-  name               = "${var.environment}-${var.aws_ecs_service_name}-scale-up"
+  name               = "${var.environment_name}-${var.aws_ecs_service_name}-scale-up"
   service_namespace  = "ecs"
   resource_id        = aws_appautoscaling_target.ecs_service.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_service.scalable_dimension
@@ -33,7 +33,7 @@ resource "aws_appautoscaling_policy" "up" {
 # Automatically scale capacity down by one
 resource "aws_appautoscaling_policy" "down" {
   provider           = aws.region
-  name               = "${var.environment}-${var.aws_ecs_service_name}-scale-down"
+  name               = "${var.environment_name}-${var.aws_ecs_service_name}-scale-down"
   service_namespace  = "ecs"
   resource_id        = aws_appautoscaling_target.ecs_service.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_service.scalable_dimension
@@ -54,7 +54,7 @@ resource "aws_appautoscaling_policy" "down" {
 
 resource "aws_cloudwatch_metric_alarm" "scale_up" {
   provider                  = aws.region
-  alarm_name                = "${var.environment}-${var.aws_ecs_service_name}-scale-up"
+  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-scale-up"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   threshold                 = "1"
@@ -121,7 +121,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
 
 resource "aws_cloudwatch_metric_alarm" "scale_down" {
   provider                  = aws.region
-  alarm_name                = "${var.environment}-${var.aws_ecs_service_name}-scale-down"
+  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-scale-down"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   threshold                 = "1"
@@ -188,7 +188,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down" {
 
 resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   provider                  = aws.region
-  alarm_name                = "${var.environment}-${var.aws_ecs_service_name}-max-scaling-reached"
+  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-max-scaling-reached"
   alarm_actions             = var.max_scaling_alarm_actions
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -197,7 +197,7 @@ resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   period                    = "30"
   statistic                 = "Average"
   threshold                 = var.ecs_task_autoscaling_maximum
-  alarm_description         = "This metric monitors ecs running task count for the ${var.environment} ${var.aws_ecs_service_name} service"
+  alarm_description         = "This metric monitors ecs running task count for the ${var.name_prefix} ${var.aws_ecs_service_name} service"
   insufficient_data_actions = []
   dimensions = {
     ServiceName = var.aws_ecs_service_name

--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -54,7 +54,7 @@ resource "aws_appautoscaling_policy" "down" {
 
 resource "aws_cloudwatch_metric_alarm" "scale_up" {
   provider                  = aws.region
-  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-scale-up"
+  alarm_name                = "${var.environment_name}-${var.region_name}-${var.aws_ecs_service_name}-scale-up"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   threshold                 = "1"
@@ -121,7 +121,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
 
 resource "aws_cloudwatch_metric_alarm" "scale_down" {
   provider                  = aws.region
-  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-scale-down"
+  alarm_name                = "${var.environment_name}-${var.region_name}-${var.aws_ecs_service_name}-scale-down"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   threshold                 = "1"
@@ -188,7 +188,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down" {
 
 resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   provider                  = aws.region
-  alarm_name                = "${var.name_prefix}-${var.aws_ecs_service_name}-max-scaling-reached"
+  alarm_name                = "${var.environment_name}-${var.region_name}-${var.aws_ecs_service_name}-max-scaling-reached"
   alarm_actions             = var.max_scaling_alarm_actions
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -197,7 +197,7 @@ resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   period                    = "30"
   statistic                 = "Average"
   threshold                 = var.ecs_task_autoscaling_maximum
-  alarm_description         = "This metric monitors ecs running task count for the ${var.name_prefix} ${var.aws_ecs_service_name} service"
+  alarm_description         = "This metric monitors ecs running task count for the ${var.environment_name}-${var.region_name} ${var.aws_ecs_service_name} service"
   insufficient_data_actions = []
   dimensions = {
     ServiceName = var.aws_ecs_service_name

--- a/terraform/environment/region/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/variables.tf
@@ -18,8 +18,13 @@ variable "ecs_autoscaling_service_role_arn" {
   type        = string
 }
 
-variable "environment" {
+variable "environment_name" {
   description = "Name of the environment."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "a name prefix for the resources that includes the environment name, and region name"
   type        = string
 }
 

--- a/terraform/environment/region/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/variables.tf
@@ -23,8 +23,8 @@ variable "environment_name" {
   type        = string
 }
 
-variable "name_prefix" {
-  description = "a name prefix for the resources that includes the environment name, and region name"
+variable "region_name" {
+  description = "region name"
   type        = string
 }
 

--- a/terraform/environment/region/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/region/modules/mock_onelogin/ecs.tf
@@ -65,7 +65,7 @@ locals {
 }
 
 resource "aws_security_group" "mock_onelogin_ecs_service" {
-  name_prefix = "${local.name_prefix}-ecs-service"
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-ecs-service"
   description = "mock-onelogin service security group"
   vpc_id      = var.network.vpc_id
   lifecycle {
@@ -119,7 +119,7 @@ resource "aws_security_group_rule" "mock_onelogin_ecs_service_egress" {
 }
 
 resource "aws_ecs_task_definition" "mock_onelogin" {
-  family                   = "${local.name_prefix}-mock-onelogin"
+  family                   = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256

--- a/terraform/environment/region/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/region/modules/mock_onelogin/variables.tf
@@ -1,7 +1,3 @@
-locals {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-}
-
 variable "ecs_execution_role" {
   type = object({
     id  = string

--- a/terraform/environment/region/modules/mock_pay/ecs.tf
+++ b/terraform/environment/region/modules/mock_pay/ecs.tf
@@ -61,7 +61,7 @@ resource "aws_service_discovery_service" "mock_pay" {
 }
 
 resource "aws_security_group" "mock_pay_ecs_service" {
-  name_prefix = "${local.name_prefix}-ecs-service"
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-ecs-service"
   description = "mock-pay service security group"
   vpc_id      = var.network.vpc_id
   lifecycle {
@@ -115,7 +115,7 @@ resource "aws_security_group_rule" "mock_pay_ecs_service_egress" {
 }
 
 resource "aws_ecs_task_definition" "mock_pay" {
-  family                   = "${local.name_prefix}-mock-pay"
+  family                   = "${data.aws_default_tags.current.tags.environment-name}-mock-pay"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256

--- a/terraform/environment/region/modules/mock_pay/variables.tf
+++ b/terraform/environment/region/modules/mock_pay/variables.tf
@@ -1,7 +1,3 @@
-locals {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-}
-
 variable "ecs_execution_role" {
   type = object({
     id  = string

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -1,7 +1,7 @@
 module "s3_create_batch_replication_jobs" {
   source      = "../lambda"
-  lambda_name = "create-s3-batch-replication-jobs-${data.aws_region.current.name}"
-  description = "Function to create and run batch replication jobs"
+  lambda_name = "create-s3-batch-replication-jobs"
+  description = "Function to create and run batch replication jobs in ${data.aws_region.current.name}"
   environment_variables = {
     ENVIRONMENT = data.aws_default_tags.current.tags.environment-name
   }
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "s3_create_batch_replication_jobs" {
 }
 
 resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
-  name = "invoke-lambda-every-2-minutes-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
+  name = "invoke-lambda-every-2-minutes-${data.aws_default_tags.current.tags.environment-name}"
 
   flexible_time_window {
     mode = "OFF"
@@ -76,6 +76,7 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
   provider = aws.region
 }
 
+# TODO: move this resource to global and pass it in using the roles variable
 resource "aws_iam_role" "scheduler_role" {
   name               = "scheduler-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
   assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role.json

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -1,7 +1,3 @@
-locals {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
-}
-
 variable "iam_roles" {
   type = object({
     ecs_execution_role                      = any


### PR DESCRIPTION
# Purpose

Remove region from the naming of resources in the environment so that they can be seen as the same across regions for resilience assessment.

Fixes MLPAB-2611

## Approach

- update ADR on naming resources
- rename ECS and autoscaling resources to remove region when not needed
