### PR TITLE
MLPAB-2640 - remove region from log group name in destroy job

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -148,7 +148,7 @@ jobs:
           role-session-name: OPGModernisingLPALogGroupDeleteGithubAction
       - name: Remove container insights log group
         run: |
-          aws logs delete-log-group --log-group-name /aws/ecs/containerinsights/${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}-eu-west-1/performance
+          aws logs delete-log-group --log-group-name /aws/ecs/containerinsights/${{ needs.generate_environment_workspace_name.outputs.environment_workspace_name }}/performance
       - name: Configure AWS Credentials For opensearch
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:


### PR DESCRIPTION
# Purpose

Fix destroy job step that removes log group

Fixes MLPAB-2640

## Approach

- remove region from log group name
