### PR TITLE
MLPAB-2640 - fix workspace name in destroy job

### DIFF
--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate workspace name
         id: name_workspace
         run: |
-          workspace=${{ github.event.pull_request.number }}${{ github.event.pull_request.head.ref }}
+          workspace=${{ github.event.pull_request.number }}
           workspace=${workspace//-}
           workspace=${workspace//_}
           workspace=${workspace//\/}


### PR DESCRIPTION
# Purpose

Destroy job is not using hte correct workspace names

Fixes MLPAB-2640

## Approach

- use only PR number for destroy job
