### PR TITLE
Remove URN prefix from actorUID in events

### DIFF
--- a/internal/certificateprovider/certificateproviderpage/identity_with_one_login_callback.go
+++ b/internal/certificateprovider/certificateproviderpage/identity_with_one_login_callback.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor/actoruid"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/appcontext"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/certificateprovider"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/certificateprovider/certificateproviderdata"
@@ -66,7 +65,7 @@ func IdentityWithOneLoginCallback(oneLoginClient OneLoginClient, sessionStore Se
 		if certificateProvider.IdentityUserData.Status.IsConfirmed() || certificateProvider.IdentityUserData.Status.IsFailed() {
 			if err := eventClient.SendIdentityCheckMismatched(r.Context(), event.IdentityCheckMismatched{
 				LpaUID:   lpa.LpaUID,
-				ActorUID: actoruid.Prefixed(certificateProvider.UID),
+				ActorUID: certificateProvider.UID,
 				Provided: event.IdentityCheckMismatchedDetails{
 					FirstNames:  lpa.CertificateProvider.FirstNames,
 					LastName:    lpa.CertificateProvider.LastName,

--- a/internal/certificateprovider/certificateproviderpage/identity_with_one_login_callback_test.go
+++ b/internal/certificateprovider/certificateproviderpage/identity_with_one_login_callback_test.go
@@ -118,7 +118,7 @@ func TestGetIdentityWithOneLoginCallbackWhenIdentityMismatched(t *testing.T) {
 	eventClient.EXPECT().
 		SendIdentityCheckMismatched(r.Context(), event.IdentityCheckMismatched{
 			LpaUID:   "lpa-uid",
-			ActorUID: actoruid.Prefixed(actorUID),
+			ActorUID: actorUID,
 			Provided: event.IdentityCheckMismatchedDetails{
 				FirstNames: "John",
 				LastName:   "Doe",

--- a/internal/donor/donorpage/identity_with_one_login_callback.go
+++ b/internal/donor/donorpage/identity_with_one_login_callback.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ministryofjustice/opg-modernising-lpa/internal/actor/actoruid"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/appcontext"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/donor"
 	"github.com/ministryofjustice/opg-modernising-lpa/internal/donor/donordata"
@@ -57,7 +56,7 @@ func IdentityWithOneLoginCallback(oneLoginClient OneLoginClient, sessionStore Se
 		if (!provided.WitnessedByCertificateProviderAt.IsZero() && !provided.DonorIdentityConfirmed()) || provided.IdentityUserData.Status.IsFailed() {
 			if err := eventClient.SendIdentityCheckMismatched(r.Context(), event.IdentityCheckMismatched{
 				LpaUID:   provided.LpaUID,
-				ActorUID: actoruid.Prefixed(provided.Donor.UID),
+				ActorUID: provided.Donor.UID,
 				Provided: event.IdentityCheckMismatchedDetails{
 					FirstNames:  provided.Donor.FirstNames,
 					LastName:    provided.Donor.LastName,

--- a/internal/donor/donorpage/identity_with_one_login_callback_test.go
+++ b/internal/donor/donorpage/identity_with_one_login_callback_test.go
@@ -135,7 +135,7 @@ func TestGetIdentityWithOneLoginCallbackWhenIdentityMismatched(t *testing.T) {
 	eventClient.EXPECT().
 		SendIdentityCheckMismatched(r.Context(), event.IdentityCheckMismatched{
 			LpaUID:   "lpa-uid",
-			ActorUID: actoruid.Prefixed(actorUID),
+			ActorUID: actorUID,
 			Provided: event.IdentityCheckMismatchedDetails{
 				FirstNames: "John",
 				LastName:   "Doe",
@@ -464,7 +464,7 @@ func TestGetIdentityWithOneLoginCallbackWhenAnyOtherReturnCodeClaimPresent(t *te
 	eventClient.EXPECT().
 		SendIdentityCheckMismatched(r.Context(), event.IdentityCheckMismatched{
 			LpaUID:   "lpa-uid",
-			ActorUID: actoruid.Prefixed(actorUID),
+			ActorUID: actorUID,
 			Provided: event.IdentityCheckMismatchedDetails{
 				FirstNames: "John",
 				LastName:   "Doe",

--- a/internal/event/client_test.go
+++ b/internal/event/client_test.go
@@ -49,7 +49,7 @@ func TestClientSendEvents(t *testing.T) {
 			return func(client *Client) error { return client.SendNotificationSent(ctx, event) }, event
 		},
 		"paper-form-requested": func() (func(*Client) error, any) {
-			event := PaperFormRequested{UID: "a", ActorType: "attorney", ActorUID: actoruid.Prefixed(actoruid.New())}
+			event := PaperFormRequested{UID: "a", ActorType: "attorney", ActorUID: actoruid.New()}
 
 			return func(client *Client) error { return client.SendPaperFormRequested(ctx, event) }, event
 		},
@@ -64,12 +64,12 @@ func TestClientSendEvents(t *testing.T) {
 			return func(client *Client) error { return client.SendCertificateProviderStarted(ctx, event) }, event
 		},
 		"attorney-started": func() (func(*Client) error, any) {
-			event := AttorneyStarted{LpaUID: "a", ActorUID: actoruid.Prefixed(uid)}
+			event := AttorneyStarted{LpaUID: "a", ActorUID: uid}
 
 			return func(client *Client) error { return client.SendAttorneyStarted(ctx, event) }, event
 		},
 		"identity-check-mismatched": func() (func(*Client) error, any) {
-			event := IdentityCheckMismatched{LpaUID: "a", ActorUID: actoruid.Prefixed(uid)}
+			event := IdentityCheckMismatched{LpaUID: "a", ActorUID: uid}
 
 			return func(client *Client) error { return client.SendIdentityCheckMismatched(ctx, event) }, event
 		},

--- a/internal/event/events.go
+++ b/internal/event/events.go
@@ -53,10 +53,10 @@ type NotificationSent struct {
 }
 
 type PaperFormRequested struct {
-	UID        string            `json:"uid"`
-	ActorType  string            `json:"actorType"`
-	ActorUID   actoruid.Prefixed `json:"actorUID"`
-	AccessCode string            `json:"accessCode"`
+	UID        string       `json:"uid"`
+	ActorType  string       `json:"actorType"`
+	ActorUID   actoruid.UID `json:"actorUID"`
+	AccessCode string       `json:"accessCode"`
 }
 
 type PaymentReceived struct {
@@ -70,13 +70,13 @@ type CertificateProviderStarted struct {
 }
 
 type AttorneyStarted struct {
-	LpaUID   string            `json:"uid"`
-	ActorUID actoruid.Prefixed `json:"actorUID"`
+	LpaUID   string       `json:"uid"`
+	ActorUID actoruid.UID `json:"actorUID"`
 }
 
 type IdentityCheckMismatched struct {
 	LpaUID   string                         `json:"uid"`
-	ActorUID actoruid.Prefixed              `json:"actorUID"`
+	ActorUID actoruid.UID                   `json:"actorUID"`
 	Provided IdentityCheckMismatchedDetails `json:"provided"`
 	Verified IdentityCheckMismatchedDetails `json:"verified"`
 }

--- a/internal/event/events_test.go
+++ b/internal/event/events_test.go
@@ -62,27 +62,27 @@ var eventTests = map[string]map[string]any{
 	"paper-form-requested": {
 		"certificate provider": PaperFormRequested{
 			UID:       "M-0000-0000-0000",
-			ActorUID:  actoruid.Prefixed(actoruid.New()),
+			ActorUID:  actoruid.New(),
 			ActorType: "certificateProvider",
 		},
 		"attorney": PaperFormRequested{
 			UID:       "M-0000-0000-0000",
-			ActorUID:  actoruid.Prefixed(actoruid.New()),
+			ActorUID:  actoruid.New(),
 			ActorType: "attorney",
 		},
 		"replacement attorney": PaperFormRequested{
 			UID:       "M-0000-0000-0000",
-			ActorUID:  actoruid.Prefixed(actoruid.New()),
+			ActorUID:  actoruid.New(),
 			ActorType: "replacementAttorney",
 		},
 		"trust corporation": PaperFormRequested{
 			UID:       "M-0000-0000-0000",
-			ActorUID:  actoruid.Prefixed(actoruid.New()),
+			ActorUID:  actoruid.New(),
 			ActorType: "trustCorporation",
 		},
 		"replacement trust corporation": PaperFormRequested{
 			UID:       "M-0000-0000-0000",
-			ActorUID:  actoruid.Prefixed(actoruid.New()),
+			ActorUID:  actoruid.New(),
 			ActorType: "replacementTrustCorporation",
 		},
 	},
@@ -94,7 +94,7 @@ var eventTests = map[string]map[string]any{
 	"attorney-started": {
 		"valid": AttorneyStarted{
 			LpaUID:   "M-0000-0000-0000",
-			ActorUID: actoruid.Prefixed(actoruid.New()),
+			ActorUID: actoruid.New(),
 		},
 	},
 	"certificate-provider-started": {
@@ -125,7 +125,7 @@ var eventTests = map[string]map[string]any{
 	"identity-check-mismatched": {
 		"valid": IdentityCheckMismatched{
 			LpaUID:   "M-1111-1111-1111",
-			ActorUID: actoruid.Prefixed(actoruid.New()),
+			ActorUID: actoruid.New(),
 			Provided: IdentityCheckMismatchedDetails{
 				FirstNames:  "a",
 				LastName:    "b",

--- a/internal/event/testdata/attorney-started.json
+++ b/internal/event/testdata/attorney-started.json
@@ -12,7 +12,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the attorney",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     }
   },
   "required": ["uid", "actorUID"]

--- a/internal/event/testdata/identity-check-mismatched.json
+++ b/internal/event/testdata/identity-check-mismatched.json
@@ -12,7 +12,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the actor the identity check relates to",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     },
     "provided": {
       "description": "The data as provided on the LPA",

--- a/internal/event/testdata/paper-form-requested.json
+++ b/internal/event/testdata/paper-form-requested.json
@@ -17,7 +17,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the actor that needs a paper form",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     },
     "accessCode": {
       "type": "string",

--- a/internal/sharecode/sender.go
+++ b/internal/sharecode/sender.go
@@ -340,7 +340,7 @@ func (s *Sender) sendPaperForm(ctx context.Context, lpaUID string, actorType act
 	return s.eventClient.SendPaperFormRequested(ctx, event.PaperFormRequested{
 		UID:        lpaUID,
 		ActorType:  actorType.String(),
-		ActorUID:   actoruid.Prefixed(actorUID),
+		ActorUID:   actorUID,
 		AccessCode: shareCode,
 	})
 }
@@ -348,6 +348,6 @@ func (s *Sender) sendPaperForm(ctx context.Context, lpaUID string, actorType act
 func (s *Sender) sendAttorneyStarted(ctx context.Context, lpaUID string, actorUID actoruid.UID) error {
 	return s.eventClient.SendAttorneyStarted(ctx, event.AttorneyStarted{
 		LpaUID:   lpaUID,
-		ActorUID: actoruid.Prefixed(actorUID),
+		ActorUID: actorUID,
 	})
 }

--- a/internal/sharecode/sender_test.go
+++ b/internal/sharecode/sender_test.go
@@ -381,7 +381,7 @@ func TestShareCodeSenderSendCertificateProviderPromptPaper(t *testing.T) {
 		SendPaperFormRequested(ctx, event.PaperFormRequested{
 			UID:        "lpa-uid",
 			ActorType:  actor.TypeCertificateProvider.String(),
-			ActorUID:   actoruid.Prefixed(actorUID),
+			ActorUID:   actorUID,
 			AccessCode: testRandomString,
 		}).
 		Return(nil)
@@ -755,7 +755,7 @@ func TestShareCodeSenderSendAttorneys(t *testing.T) {
 		SendPaperFormRequested(ctx, event.PaperFormRequested{
 			UID:        "lpa-uid",
 			ActorType:  "attorney",
-			ActorUID:   actoruid.Prefixed(attorney3UID),
+			ActorUID:   attorney3UID,
 			AccessCode: testRandomString,
 		}).
 		Return(nil)
@@ -763,50 +763,50 @@ func TestShareCodeSenderSendAttorneys(t *testing.T) {
 		SendPaperFormRequested(ctx, event.PaperFormRequested{
 			UID:        "lpa-uid",
 			ActorType:  "replacementAttorney",
-			ActorUID:   actoruid.Prefixed(replacement2UID),
+			ActorUID:   replacement2UID,
 			AccessCode: testRandomString,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(attorney1UID),
+			ActorUID: attorney1UID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(attorney2UID),
+			ActorUID: attorney2UID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(attorney3UID),
+			ActorUID: attorney3UID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(trustCorporationUID),
+			ActorUID: trustCorporationUID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(replacementTrustCorporationUID),
+			ActorUID: replacementTrustCorporationUID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(replacement1UID),
+			ActorUID: replacement1UID,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(replacement2UID),
+			ActorUID: replacement2UID,
 		}).
 		Return(nil)
 
@@ -868,7 +868,7 @@ func TestShareCodeSenderSendAttorneysTrustCorporationsNoEmail(t *testing.T) {
 		SendPaperFormRequested(ctx, event.PaperFormRequested{
 			UID:        "lpa-uid",
 			ActorType:  "trustCorporation",
-			ActorUID:   actoruid.Prefixed(uid1),
+			ActorUID:   uid1,
 			AccessCode: testRandomString,
 		}).
 		Return(nil)
@@ -876,20 +876,20 @@ func TestShareCodeSenderSendAttorneysTrustCorporationsNoEmail(t *testing.T) {
 		SendPaperFormRequested(ctx, event.PaperFormRequested{
 			UID:        "lpa-uid",
 			ActorType:  "replacementTrustCorporation",
-			ActorUID:   actoruid.Prefixed(uid2),
+			ActorUID:   uid2,
 			AccessCode: testRandomString,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(uid1),
+			ActorUID: uid1,
 		}).
 		Return(nil)
 	eventClient.EXPECT().
 		SendAttorneyStarted(ctx, event.AttorneyStarted{
 			LpaUID:   donor.LpaUID,
-			ActorUID: actoruid.Prefixed(uid2),
+			ActorUID: uid2,
 		}).
 		Return(nil)
 
@@ -993,13 +993,13 @@ func TestShareCodeSenderSendAttorneysWithTestCode(t *testing.T) {
 			eventClient.EXPECT().
 				SendAttorneyStarted(ctx, event.AttorneyStarted{
 					LpaUID:   donor.LpaUID,
-					ActorUID: actoruid.Prefixed(uid),
+					ActorUID: uid,
 				}).
 				Return(nil)
 			eventClient.EXPECT().
 				SendAttorneyStarted(ctx, event.AttorneyStarted{
 					LpaUID:   donor.LpaUID,
-					ActorUID: actoruid.Prefixed(uid),
+					ActorUID: uid,
 				}).
 				Return(nil)
 


### PR DESCRIPTION
# Purpose

Remove URN prefix so it's just the UUID stored in the LPA Store.

To match [event store changes](https://github.com/ministryofjustice/opg-event-store/pull/101)

For CTC-192 #minor

## Approach

Updated the event structs, then fixed all the now-broken code.

## Learning

Nothing particular, it wasn't a particularly mentally taxing task.
