### PR TITLE
MLPAB-2740 - fix firewall logging

### DIFF
--- a/terraform/account/region/network.tf
+++ b/terraform/account/region/network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                         = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v0.2.7"
+  source                         = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v0.2.8"
   cidr                           = var.network_cidr_block
   enable_dns_hostnames           = true
   enable_dns_support             = true


### PR DESCRIPTION
# Purpose

Apply on PTL failed due to an invalid resource policy

Fixes MLPAB-2740

## Approach

- upgrade module to add resource policy and use vended logs path

## Learning

- https://repost.aws/questions/QUyaiOwEY5QxKlMKqGTMRPFw/cannot-enable-logging-policy-document-length-breaking-cloudwatch-logs-constraints-either-1-or-5120
- https://stackoverflow.com/questions/73771271/i-am-getting-issue-in-policy-document-length-breaking-cloudwatch-logs-constraint
