### PR TITLE
MLPAB-2777 - create role for egress checker

### DIFF
--- a/terraform/environment/global/iam_egress_checker_lambda_role.tf
+++ b/terraform/environment/global/iam_egress_checker_lambda_role.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_role" "egress_checker_lambda" {
+  name               = "egress-checker-${data.aws_default_tags.current.tags.environment-name}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.global
+}

--- a/terraform/environment/global/outputs.tf
+++ b/terraform/environment/global/outputs.tf
@@ -10,6 +10,7 @@ output "iam_roles" {
     cross_account_put                       = aws_iam_role.cross_account_put,
     fault_injection_simulator               = aws_iam_role.fault_injection_simulator,
     create_s3_batch_replication_jobs_lambda = aws_iam_role.create_s3_batch_replication_jobs_lambda
+    egress_checker_lambda                   = aws_iam_role.egress_checker_lambda
     event_received_lambda                   = aws_iam_role.event_received_lambda
     schedule_runner_lambda                  = aws_iam_role.schedule_runner_lambda
     opensearch_pipeline                     = aws_iam_role.opensearch_pipeline

--- a/terraform/environment/region/egress_checker.tf
+++ b/terraform/environment/region/egress_checker.tf
@@ -3,7 +3,7 @@ module "egress_checker" {
   source                        = "./modules/egress_checker"
   lambda_function_image_ecr_url = var.egress_checker_repository_url
   lambda_function_image_tag     = var.egress_checker_container_version
-  event_received_lambda_role    = var.iam_roles.event_received_lambda
+  egress_checker_lambda_role    = var.iam_roles.egress_checker_lambda
   vpc_config = {
     subnet_ids         = data.aws_subnet.application[*].id
     security_group_ids = [data.aws_security_group.lambda_egress.id]

--- a/terraform/environment/region/modules/egress_checker/main.tf
+++ b/terraform/environment/region/modules/egress_checker/main.tf
@@ -12,7 +12,7 @@ module "egress_checker" {
   lambda_name          = "egress-checker"
   description          = "Function to check egress from the VPC via the network firewall"
   image_uri            = "${var.lambda_function_image_ecr_url}:${var.lambda_function_image_tag}"
-  aws_iam_role         = var.event_received_lambda_role
+  aws_iam_role         = var.egress_checker_lambda_role
   environment          = data.aws_default_tags.current.tags.environment-name
   kms_key              = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
   iam_policy_documents = []

--- a/terraform/environment/region/modules/egress_checker/variables.tf
+++ b/terraform/environment/region/modules/egress_checker/variables.tf
@@ -6,7 +6,7 @@ variable "lambda_function_image_tag" {
   type = string
 }
 
-variable "event_received_lambda_role" {
+variable "egress_checker_lambda_role" {
   type = any
 }
 

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -6,6 +6,7 @@ variable "iam_roles" {
     cross_account_put                       = any
     fault_injection_simulator               = any
     create_s3_batch_replication_jobs_lambda = any
+    egress_checker_lambda                   = any
     event_received_lambda                   = any
     schedule_runner_scheduler               = any
     schedule_runner_lambda                  = any

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -38,6 +38,7 @@ module "eu_west_1" {
     cross_account_put                       = module.global.iam_roles.cross_account_put
     fault_injection_simulator               = module.global.iam_roles.fault_injection_simulator
     create_s3_batch_replication_jobs_lambda = module.global.iam_roles.create_s3_batch_replication_jobs_lambda
+    egress_checker_lambda                   = module.global.iam_roles.egress_checker_lambda
     event_received_lambda                   = module.global.iam_roles.event_received_lambda
     schedule_runner_lambda                  = module.global.iam_roles.schedule_runner_lambda
     schedule_runner_scheduler               = module.global.iam_roles.schedule_runner_scheduler
@@ -111,6 +112,7 @@ module "eu_west_2" {
     cross_account_put                       = module.global.iam_roles.cross_account_put
     fault_injection_simulator               = module.global.iam_roles.fault_injection_simulator
     create_s3_batch_replication_jobs_lambda = module.global.iam_roles.create_s3_batch_replication_jobs_lambda
+    egress_checker_lambda                   = module.global.iam_roles.egress_checker_lambda
     event_received_lambda                   = module.global.iam_roles.event_received_lambda
     schedule_runner_lambda                  = module.global.iam_roles.schedule_runner_lambda
     schedule_runner_scheduler               = module.global.iam_roles.schedule_runner_scheduler


### PR DESCRIPTION
# Purpose

Policy documents were being overwritten on each apply toggling api permissions for event received on and off. This was caused by accidental reuse of a role and policy name

Fixes MLPAB-2777

## Approach

- create role for egress checker