### PR TITLE
MLPAB-1767 Filter OneByUID so it only returns donor records

### DIFF
--- a/internal/dynamo/client.go
+++ b/internal/dynamo/client.go
@@ -67,13 +67,20 @@ func (c *Client) One(ctx context.Context, pk PK, sk SK, v interface{}) error {
 
 func (c *Client) OneByUID(ctx context.Context, uid string, v interface{}) error {
 	response, err := c.svc.Query(ctx, &dynamodb.QueryInput{
-		TableName:                aws.String(c.table),
-		IndexName:                aws.String(lpaUIDIndex),
-		ExpressionAttributeNames: map[string]string{"#LpaUID": "LpaUID"},
+		TableName: aws.String(c.table),
+		IndexName: aws.String(lpaUIDIndex),
+		ExpressionAttributeNames: map[string]string{
+			"#LpaUID": "LpaUID",
+			"#PK":     "PK",
+			"#SK":     "SK",
+		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":LpaUID": &types.AttributeValueMemberS{Value: uid},
+			":PK":     &types.AttributeValueMemberS{Value: LpaKey("").PK()},
+			":SK":     &types.AttributeValueMemberS{Value: DonorKey("").SK()},
 		},
 		KeyConditionExpression: aws.String("#LpaUID = :LpaUID"),
+		FilterExpression:       aws.String("begins_with(#PK, :PK) and begins_with(#SK, :SK)"),
 		Limit:                  aws.Int32(1),
 	})
 	if err != nil {

--- a/internal/dynamo/client_test.go
+++ b/internal/dynamo/client_test.go
@@ -94,12 +94,17 @@ func TestOneByUID(t *testing.T) {
 	dynamoDB := newMockDynamoDB(t)
 	dynamoDB.EXPECT().
 		Query(ctx, &dynamodb.QueryInput{
-			TableName:                 aws.String("this"),
-			IndexName:                 aws.String(lpaUIDIndex),
-			ExpressionAttributeNames:  map[string]string{"#LpaUID": "LpaUID"},
-			ExpressionAttributeValues: map[string]types.AttributeValue{":LpaUID": &types.AttributeValueMemberS{Value: "M-1111-2222-3333"}},
-			KeyConditionExpression:    aws.String("#LpaUID = :LpaUID"),
-			Limit:                     aws.Int32(1),
+			TableName:                aws.String("this"),
+			IndexName:                aws.String(lpaUIDIndex),
+			ExpressionAttributeNames: map[string]string{"#LpaUID": "LpaUID", "#PK": "PK", "#SK": "SK"},
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":LpaUID": &types.AttributeValueMemberS{Value: "M-1111-2222-3333"},
+				":PK":     &types.AttributeValueMemberS{Value: LpaKey("").PK()},
+				":SK":     &types.AttributeValueMemberS{Value: DonorKey("").SK()},
+			},
+			KeyConditionExpression: aws.String("#LpaUID = :LpaUID"),
+			FilterExpression:       aws.String("begins_with(#PK, :PK) and begins_with(#SK, :SK)"),
+			Limit:                  aws.Int32(1),
 		}).
 		Return(&dynamodb.QueryOutput{
 			Items: []map[string]types.AttributeValue{{


### PR DESCRIPTION
For `(SCHEDULEDDAY#, SCHEDULED#)` records we decided to add the `LpaUID` so they could be removed easily, this means they can be returned by `OneByUID` causing issues when only `(LPA#, DONOR#)` is expected.
