### PR TITLE
MLPAB-2793 - use pull through cache for otel collector

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -507,7 +507,7 @@ locals {
     {
       cpu                    = 0,
       essential              = true,
-      image                  = "public.ecr.aws/aws-observability/aws-otel-collector:v0.21.0",
+      image                  = "311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.21.0",
       mountPoints            = [],
       readonlyRootFilesystem = true
       name                   = "aws-otel-collector",


### PR DESCRIPTION
# Purpose

Remove use of public ecr images, starting with otel collector (ssm agent is not being used at present).

Fixes MLPAB-2793

## Approach

- use pull through cache host for otel collector image
