### PR TITLE
MLPAB-2796 - update the otel collector image used in ECS

### DIFF
--- a/terraform/environment/global/iam_ecs_execution_role.tf
+++ b/terraform/environment/global/iam_ecs_execution_role.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "execution_role" {
     actions = [
       "ecr:GetAuthorizationToken",
       "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchImportUpstreamImage",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
     ]

--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -61,6 +61,7 @@ module "app" {
   search_endpoint                                      = var.search_endpoint
   search_index_name                                    = var.search_index_name
   search_collection_arn                                = var.search_collection_arn
+  ecs_aws_otel_collector_version                       = var.ecs_aws_otel_collector_version
 
   providers = {
     aws.region     = aws.region

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -507,7 +507,7 @@ locals {
     {
       cpu                    = 0,
       essential              = true,
-      image                  = "311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.21.0",
+      image                  = "311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:${var.ecs_aws_otel_collector_version}",
       mountPoints            = [],
       readonlyRootFilesystem = true
       name                   = "aws-otel-collector",

--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -160,3 +160,8 @@ variable "waf_alb_association_enabled" {
   description = "Enable WAF association with the ALB"
   default     = true
 }
+
+variable "ecs_aws_otel_collector_version" {
+  type        = string
+  description = "semver tag for the public ecr tag of the aws-otel-collector image"
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -210,3 +210,8 @@ variable "egress_checker_enabled" {
   type    = bool
   default = false
 }
+
+variable "ecs_aws_otel_collector_version" {
+  type        = string
+  description = "semver tag for the public ecr tag of the aws-otel-collector image"
+}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -94,6 +94,7 @@ module "eu_west_1" {
   search_index_name                       = local.search_index_name
   search_collection_arn                   = data.aws_opensearchserverless_collection.lpas_collection.arn
   real_user_monitoring_cw_logs_enabled    = local.environment.app.real_user_monitoring_cw_logs_enabled
+  ecs_aws_otel_collector_version          = var.ecs_aws_otel_collector_version
   providers = {
     aws.region            = aws.eu_west_1
     aws.global            = aws.global
@@ -168,6 +169,7 @@ module "eu_west_2" {
   search_index_name                       = local.search_index_name
   search_collection_arn                   = null
   real_user_monitoring_cw_logs_enabled    = local.environment.app.real_user_monitoring_cw_logs_enabled
+  ecs_aws_otel_collector_version          = var.ecs_aws_otel_collector_version
   providers = {
     aws.region            = aws.eu_west_2
     aws.global            = aws.global

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -1,692 +1,709 @@
 {
-  "environments": {
-    "default": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "",
-          "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
+    "environments": {
+        "default": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "",
+                    "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": false,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": false
+            },
+            "mock_onelogin_enabled": false,
+            "mock_pay_enabled": true,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": false,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": true
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 7
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": false,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "288342028542"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
+        "test": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "",
+                    "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": false,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": false
+            },
+            "mock_onelogin_enabled": false,
+            "mock_pay_enabled": true,
+            "egress_checker_enabled": true,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": true,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": true
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 7
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": false,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "288342028542"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": false,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": false
-      },
-      "mock_onelogin_enabled": false,
-      "mock_pay_enabled": true,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-          "backup_plan_enabled": false,
-          "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": true
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 7
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": false,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["288342028542"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "test": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "",
-          "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
+        "demo": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": true,
+                "service_health_check_alarm_enabled": true,
+                "cloudwatch_application_insights_enabled": true,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": true
+            },
+            "mock_onelogin_enabled": true,
+            "mock_pay_enabled": false,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://demo.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": false,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": true
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 7
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": false,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
+                "receive_account_ids": [
+                    "288342028542",
+                    "493907465011"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "integration",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": true
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
+        "codesign": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://codesign.app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://codesign.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": false,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": false
+            },
+            "mock_onelogin_enabled": true,
+            "mock_pay_enabled": true,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": false,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": true
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 7
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": false,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
+                "receive_account_ids": [
+                    "288342028542"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "integration",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": true
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": false,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": false
-      },
-      "mock_onelogin_enabled": false,
-      "mock_pay_enabled": true,
-      "egress_checker_enabled": true,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-          "backup_plan_enabled": true,
-          "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas-20240717",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": true
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 7
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": false,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["288342028542"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "demo": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
+        "ur": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": true,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": true
+            },
+            "mock_onelogin_enabled": true,
+            "mock_pay_enabled": true,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": true,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": false
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 400
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": true,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "288342028542"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
+        "ur2": {
+            "account_id": "653761790766",
+            "account_name": "development",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": "1"
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": true,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": true
+            },
+            "mock_onelogin_enabled": false,
+            "mock_pay_enabled": true,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": true,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": false
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": false
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 400
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": true,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "288342028542"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": true,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "dependency_health_check_alarm_enabled": true,
-        "service_health_check_alarm_enabled": true,
-        "cloudwatch_application_insights_enabled": true,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": true
-      },
-      "mock_onelogin_enabled": true,
-      "mock_pay_enabled": false,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://demo.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-          "backup_plan_enabled": false,
-          "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": true
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 7
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": false,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
-        "receive_account_ids": ["288342028542", "493907465011"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "integration",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": true
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "codesign": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://codesign.app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://codesign.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
+        "preproduction": {
+            "account_id": "792093328875",
+            "account_name": "preproduction",
+            "is_production": false,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "1",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": ""
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": false,
+                "service_health_check_alarm_enabled": false,
+                "cloudwatch_application_insights_enabled": true,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": true
+            },
+            "mock_onelogin_enabled": false,
+            "mock_pay_enabled": false,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://preproduction.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://preproduction.lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:936779158973:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:936779158973:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:936779158973:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:936779158973:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:936779158973:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:936779158973:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:936779158973:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:936779158973:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:936779158973:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:936779158973:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": false,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": true
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": true
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 7
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": false,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": true,
+            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "936779158973"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": false,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
         },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
-        },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": false,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": false
-      },
-      "mock_onelogin_enabled": true,
-      "mock_pay_enabled": true,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-          "backup_plan_enabled": false,
-          "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": true
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 7
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": false,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
-        "receive_account_ids": ["288342028542"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "integration",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": true
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "ur": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://ur.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
-        },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
-        },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": true,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": true
-      },
-      "mock_onelogin_enabled": true,
-      "mock_pay_enabled": true,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-        "backup_plan_enabled": true,
-        "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": false
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 400
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": true,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["288342028542"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "ur2": {
-      "account_id": "653761790766",
-      "account_name": "development",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": "1"
-        },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
-        },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": true,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": true
-      },
-      "mock_onelogin_enabled": false,
-      "mock_pay_enabled": true,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-        "backup_plan_enabled": true,
-        "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": false
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": false
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 400
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": true,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["288342028542"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": true,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "preproduction": {
-      "account_id": "792093328875",
-      "account_name": "preproduction",
-      "is_production": false,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://preproduction.app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "1",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": ""
-        },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
-        },
-        "dependency_health_check_alarm_enabled": false,
-        "service_health_check_alarm_enabled": false,
-        "cloudwatch_application_insights_enabled": true,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": true
-      },
-      "mock_onelogin_enabled": false,
-      "mock_pay_enabled": false,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://preproduction.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:492687888235:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:492687888235:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:492687888235:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:492687888235:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://preproduction.lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:936779158973:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:936779158973:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:936779158973:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:936779158973:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:936779158973:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:936779158973:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:936779158973:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:936779158973:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:936779158973:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:936779158973:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-          "backup_plan_enabled": false,
-          "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": true
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": true
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 7
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": false,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": true,
-      "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["936779158973"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": false,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
-    },
-    "production": {
-      "account_id": "313879017102",
-      "account_name": "production",
-      "is_production": true,
-      "regions": [
-        "eu-west-1"
-      ],
-      "app": {
-        "env": {
-          "app_public_url": "https://app.modernising.opg.service.justice.gov.uk",
-          "auth_redirect_base_url": "https://app.modernising.opg.service.justice.gov.uk",
-          "notify_is_production": "1",
-          "onelogin_url": "https://home.integration.account.gov.uk",
-          "dev_mode": ""
-        },
-        "autoscaling": {
-          "minimum": 1,
-          "maximum": 3
-        },
-        "dependency_health_check_alarm_enabled": true,
-        "service_health_check_alarm_enabled": true,
-        "cloudwatch_application_insights_enabled": true,
-        "fault_injection_experiments_enabled": false,
-        "real_user_monitoring_cw_logs_enabled": true
-      },
-      "mock_onelogin_enabled": false,
-      "mock_pay_enabled": false,
-      "egress_checker_enabled": false,
-      "uid_service": {
-        "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-          "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-          "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-        ]
-      },
-      "lpa_store_service": {
-        "base_url": "https://lpa-store.api.opg.service.justice.gov.uk",
-        "api_arns": [
-          "arn:aws:execute-api:eu-west-1:764856231715:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-2:764856231715:*/*/POST/lpas",
-          "arn:aws:execute-api:eu-west-1:764856231715:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-2:764856231715:*/*/GET/lpas/*",
-          "arn:aws:execute-api:eu-west-1:764856231715:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-2:764856231715:*/*/PUT/lpas/*",
-          "arn:aws:execute-api:eu-west-1:764856231715:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-2:764856231715:*/*/POST/lpas/*/updates",
-          "arn:aws:execute-api:eu-west-1:764856231715:*/*/GET/health-check",
-          "arn:aws:execute-api:eu-west-2:764856231715:*/*/GET/health-check"
-        ]
-      },
-      "backups": {
-        "backup_plan_enabled": true,
-        "copy_action_enabled": false
-      },
-      "dynamodb": {
-        "table_name": "Lpas",
-        "region_replica_enabled": false,
-        "cloudtrail_enabled": true
-      },
-      "ecs": {
-        "fargate_spot_capacity_provider_enabled": false
-      },
-      "cloudwatch_log_groups": {
-        "application_log_retention_days": 400
-      },
-      "application_load_balancer": {
-        "deletion_protection_enabled": true,
-        "waf_alb_association_enabled": true
-      },
-      "cloudwatch_application_insights_enabled": true,
-      "pagerduty_service_name": "OPG Modernising LPA Production",
-      "event_bus": {
-        "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-        "receive_account_ids": ["764856231715"]
-      },
-      "reduced_fees": {
-        "enabled": true,
-        "s3_object_replication_enabled": false,
-        "target_environment": "dev",
-        "destination_account_id": "288342028542",
-        "enable_s3_batch_job_replication_scheduler": false
-      },
-      "s3_antivirus_provisioned_concurrency": 0
+        "production": {
+            "account_id": "313879017102",
+            "account_name": "production",
+            "is_production": true,
+            "regions": [
+                "eu-west-1"
+            ],
+            "app": {
+                "env": {
+                    "app_public_url": "https://app.modernising.opg.service.justice.gov.uk",
+                    "auth_redirect_base_url": "https://app.modernising.opg.service.justice.gov.uk",
+                    "notify_is_production": "1",
+                    "onelogin_url": "https://home.integration.account.gov.uk",
+                    "dev_mode": ""
+                },
+                "autoscaling": {
+                    "minimum": 1,
+                    "maximum": 3
+                },
+                "dependency_health_check_alarm_enabled": true,
+                "service_health_check_alarm_enabled": true,
+                "cloudwatch_application_insights_enabled": true,
+                "fault_injection_experiments_enabled": false,
+                "real_user_monitoring_cw_logs_enabled": true
+            },
+            "mock_onelogin_enabled": false,
+            "mock_pay_enabled": false,
+            "egress_checker_enabled": false,
+            "uid_service": {
+                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
+                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
+                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
+                ]
+            },
+            "lpa_store_service": {
+                "base_url": "https://lpa-store.api.opg.service.justice.gov.uk",
+                "api_arns": [
+                    "arn:aws:execute-api:eu-west-1:764856231715:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-2:764856231715:*/*/POST/lpas",
+                    "arn:aws:execute-api:eu-west-1:764856231715:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:764856231715:*/*/GET/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:764856231715:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-2:764856231715:*/*/PUT/lpas/*",
+                    "arn:aws:execute-api:eu-west-1:764856231715:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-2:764856231715:*/*/POST/lpas/*/updates",
+                    "arn:aws:execute-api:eu-west-1:764856231715:*/*/GET/health-check",
+                    "arn:aws:execute-api:eu-west-2:764856231715:*/*/GET/health-check"
+                ]
+            },
+            "backups": {
+                "backup_plan_enabled": true,
+                "copy_action_enabled": false
+            },
+            "dynamodb": {
+                "table_name": "Lpas",
+                "region_replica_enabled": false,
+                "cloudtrail_enabled": true
+            },
+            "ecs": {
+                "fargate_spot_capacity_provider_enabled": false
+            },
+            "cloudwatch_log_groups": {
+                "application_log_retention_days": 400
+            },
+            "application_load_balancer": {
+                "deletion_protection_enabled": true,
+                "waf_alb_association_enabled": true
+            },
+            "cloudwatch_application_insights_enabled": true,
+            "pagerduty_service_name": "OPG Modernising LPA Production",
+            "event_bus": {
+                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "receive_account_ids": [
+                    "764856231715"
+                ]
+            },
+            "reduced_fees": {
+                "enabled": true,
+                "s3_object_replication_enabled": false,
+                "target_environment": "dev",
+                "destination_account_id": "288342028542",
+                "enable_s3_batch_job_replication_scheduler": false
+            },
+            "s3_antivirus_provisioned_concurrency": 0
+        }
     }
-  }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -17,6 +17,12 @@ variable "pagerduty_api_key" {
   sensitive = true
 }
 
+variable "ecs_aws_otel_collector_version" {
+  type        = string
+  description = "semver tag for the public ecr tag of the aws-otel-collector image"
+  default     = "v0.42.0"
+}
+
 output "container_version" {
   value = var.container_version
 }


### PR DESCRIPTION
# Purpose

Update the otel collector image used in ECS

Fixes MLPAB-2796

## Approach

- use var for image tag and allow ecs to pull upstream images
- allow ecs execution role to pull upstream images to update the pull through cache

## Learning

- https://gallery.ecr.aws/aws-observability/aws-otel-collector
- https://aws-otel.github.io/docs/setup/ecs
