### PR TITLE
MLPAB-2818 - update lambda runtime interface emulator

### DIFF
--- a/docs/runbooks/update_lambda_runtime_interface_emulator_for_local_dev.md
+++ b/docs/runbooks/update_lambda_runtime_interface_emulator_for_local_dev.md
@@ -1,0 +1,20 @@
+# Setting up the AWS Distro for OpenTelemetry Collector (ADOT Collector) for Go Lambda Function Images
+
+## Introduction
+
+The Lambda Runtime Interface Emulator (RIE) can be used to locally test a lambda image.
+
+We keep a copy of the RIE in the repository. It can be updated using the following command
+
+```sh
+curl -Lo docker/aws-lambda-rie/aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie && \
+    chmod +x docker/aws-lambda-rie/aws-lambda-rie
+```
+
+## Using the ADOT Collector in a docker container
+
+The following Dockerfile instructions can be used to add the Lambda RIE
+
+```Dockerfile
+COPY --link docker/aws-lambda-rie ./aws-lambda-rie
+```

--- a/docs/runbooks/update_lambda_runtime_interface_emulator_for_local_dev.md
+++ b/docs/runbooks/update_lambda_runtime_interface_emulator_for_local_dev.md
@@ -1,4 +1,4 @@
-# Setting up the AWS Distro for OpenTelemetry Collector (ADOT Collector) for Go Lambda Function Images
+# Updating the Lambda Runtime Interface
 
 ## Introduction
 


### PR DESCRIPTION
# Purpose

Keep the RIE up to date for local development

Fixes MLPAB-2818

## Approach

- Add instructions for updating the rie
- add binary

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
