### PR TITLE
MLPAB-2643 - refactor opensearch into account level regional resource

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -5,20 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.84.0"
   constraints = ">= 5.5.0, ~> 5.84.0"
   hashes = [
-    "h1:897cPKLnktFTBHxlPDyv52hQoR7rUy52Tzr9F/bvXW0=",
-    "h1:EJLTu1eqP93P4+DexFZHnuMCwEapkmHhEUirUT+tjZw=",
-    "h1:MVppdPvKcROdwwj1i7OMoZ/ODFZlqrYr7GVHI1Fevb8=",
-    "h1:MsFKMU05GLbXfXQZHqy+eC5FC5hDxyRB1irY3lvAaf8=",
-    "h1:N0mARumaxRCk1FmbDiEW89izbpV/3jkWowrm/78HucQ=",
     "h1:OJ53RNte7HLHSMxSkzu1S6H8sC0T8qnCAOcNLjjtMpc=",
-    "h1:TpsSFMkiuLC1V29n4Ov99g4L6jlsBmBMWxqDX3GZNww=",
-    "h1:X50oGSrQb2Hzf6i1BWnYOqIneJSy7TiWNtKK+VY+aGA=",
-    "h1:dwpeFUdcxgXVAc0JSqO57xf0/r2qOBLPloombCQWFz8=",
-    "h1:eeLhwhBhj96w3YFnTcOMPV0ybGER5fbv/ihcTMeoTk4=",
-    "h1:iBnPrv1hIjnS26jHVGXuxTDF27OaVOx2XJ0Sbp45qHs=",
-    "h1:lL0Ftd7QOGinm/1w/1qwfoj6urdJsmRSVxV+xfBD8R4=",
-    "h1:mwHAD66PY6wi858oGl5NcWGfA9X7mdxPrZrAGfJGS3A=",
-    "h1:p7kabmCUZYyP5A6VqtIvuy/+CTiGn03jVdcIFMbQkOI=",
     "zh:078f77438aba6ec8bf9154b7d223e5c71c48d805d6cd3bcf9db0cc1e82668ac3",
     "zh:1f6591ff96be00501e71b792ed3a5a14b21ff03afec9a1c4a3fd9300e6e5b674",
     "zh:2ab694e022e81dd74485351c5836148a842ed71cf640664c9d871cb517b09602",
@@ -41,19 +28,7 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "3.19.4"
   constraints = "3.19.4"
   hashes = [
-    "h1:6uh2ljGz8wh8zOvgBSi1meGSEO3OdD6ZjYT0s16Cj7g=",
-    "h1:BArzD20N7MRjfaNUdBSEsoAmgRgpT+h31n9fesL0A08=",
-    "h1:LHXFrd8NVC1cLd/guTGtkzfAQOi39bCBblWhxN75cRk=",
-    "h1:T5zJKrF0ey4eZwSFbKAywiAEvo131bHRqEuBXyQsX3A=",
-    "h1:f5PRK4FVelfA7KeNYxpMouqTnpbBCYwTZ9MMkzXcRAI=",
-    "h1:geFJfzh5ttynHA1Upv9pbqZiMtobc5UUY7QDaTArnyc=",
-    "h1:jtB0ZQ6FzQ2iXxe0wy/rnJIUWKaT8g/MApztbqF4sDg=",
-    "h1:nWoIrb3KwSFmblHik7Zqj6spycYudn0dx+wFcSjWRlo=",
-    "h1:qGDMGIVi/FqFy81QbTDhDMBiWa4srpPPJ6ELhfS8H54=",
-    "h1:qGXN/20ud2MpBTJ+t41VhJv5jDNuezuIYPoQJMcZbf0=",
-    "h1:t8P6sokG6SL2NZsLjlparpW5L/T52g/FVVMiZ/NWshE=",
     "h1:tw/5/H9WVRowcIjDvvo4Y1iO+d4AQESdWid599txUNI=",
-    "h1:uVnam+RsXViojmrMQM5gnXCToxOhGeowvlz2F8gXuNQ=",
     "zh:086a813e9710c7190f228ef25d0386a4e1e78f5409ee7b963c0bd957de5ba7ad",
     "zh:0c490df8464c8d6bd2e7136e9d5200347a6bd59d45cbe95cb9f26d2012f88784",
     "zh:353b9107565d68bc0f8977594f328d839b83e5c6c3c485e2b5f2f89e42b88024",

--- a/terraform/account/iam_sns_feedback_role.tf
+++ b/terraform/account/iam_sns_feedback_role.tf
@@ -1,9 +1,0 @@
-data "aws_iam_role" "sns_success_feedback" {
-  name     = "SNSSuccessFeedback"
-  provider = aws.global
-}
-
-data "aws_iam_role" "sns_failure_feedback" {
-  provider = aws.global
-  name     = "SNSFailureFeedback"
-}

--- a/terraform/account/refactoring.tf
+++ b/terraform/account/refactoring.tf
@@ -249,3 +249,8 @@ moved {
   from = pagerduty_service_integration.opensearch
   to   = module.eu_west_1[0].pagerduty_service_integration.opensearch
 }
+
+moved {
+  from = aws_opensearchserverless_access_policy.team_breakglass_access[0]
+  to   = module.eu_west_1[0].aws_opensearchserverless_access_policy.team_breakglass_access[0]
+}

--- a/terraform/account/refactoring.tf
+++ b/terraform/account/refactoring.tf
@@ -194,3 +194,58 @@ moved {
   from = module.eu_west_1[0].module.aws_backup_vaults.aws_sns_topic_policy.aws_backup_failure_events
   to   = module.aws_backup_vaults_eu_west_1.aws_sns_topic_policy.aws_backup_failure_events
 }
+
+moved {
+  from = aws_cloudwatch_metric_alarm.opensearch_4xx_errors
+  to   = module.eu_west_1[0].aws_cloudwatch_metric_alarm.opensearch_4xx_errors
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.opensearch_5xx_errors
+  to   = module.eu_west_1[0].aws_cloudwatch_metric_alarm.opensearch_5xx_errors
+}
+
+moved {
+  from = aws_opensearchserverless_access_policy.github_actions_access[0]
+  to   = module.eu_west_1[0].aws_opensearchserverless_access_policy.github_actions_access[0]
+}
+
+moved {
+  from = aws_opensearchserverless_access_policy.team_operator_access[0]
+  to   = module.eu_west_1[0].aws_opensearchserverless_access_policy.team_operator_access[0]
+}
+
+moved {
+  from = aws_opensearchserverless_collection.lpas_collection
+  to   = module.eu_west_1[0].aws_opensearchserverless_collection.lpas_collection
+}
+
+moved {
+  from = aws_opensearchserverless_security_policy.lpas_collection_development_network_policy[0]
+  to   = module.eu_west_1[0].aws_opensearchserverless_security_policy.lpas_collection_development_network_policy[0]
+}
+
+moved {
+  from = aws_opensearchserverless_security_policy.lpas_collection_network_policy
+  to   = module.eu_west_1[0].aws_opensearchserverless_security_policy.lpas_collection_network_policy
+}
+
+moved {
+  from = aws_sns_topic.opensearch
+  to   = module.eu_west_1[0].aws_sns_topic.opensearch
+}
+
+moved {
+  from = aws_opensearchserverless_security_policy.lpas_collection_encryption_policy
+  to   = module.eu_west_1[0].aws_opensearchserverless_security_policy.lpas_collection_encryption_policy
+}
+
+moved {
+  from = aws_sns_topic_subscription.opensearch
+  to   = module.eu_west_1[0].aws_sns_topic_subscription.opensearch
+}
+
+moved {
+  from = pagerduty_service_integration.opensearch
+  to   = module.eu_west_1[0].pagerduty_service_integration.opensearch
+}

--- a/terraform/account/region/outputs.tf
+++ b/terraform/account/region/outputs.tf
@@ -2,6 +2,6 @@ output "ecs_autoscaling_alarm_sns_topic" {
   value = aws_sns_topic.ecs_autoscaling_alarms
 }
 
-output "opensearch_lpas_collection_vpc_endpoint" {
-  value = aws_opensearchserverless_vpc_endpoint.lpas_collection_vpc_endpoint
-}
+# output "opensearch_lpas_collection_vpc_endpoint" {
+#   value = aws_opensearchserverless_vpc_endpoint.lpas_collection_vpc_endpoint
+# }

--- a/terraform/account/region/outputs.tf
+++ b/terraform/account/region/outputs.tf
@@ -1,7 +1,3 @@
 output "ecs_autoscaling_alarm_sns_topic" {
   value = aws_sns_topic.ecs_autoscaling_alarms
 }
-
-# output "opensearch_lpas_collection_vpc_endpoint" {
-#   value = aws_opensearchserverless_vpc_endpoint.lpas_collection_vpc_endpoint
-# }

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -195,7 +195,7 @@ module "s3_event_notifications" {
     "s3:ObjectRemoved:*",
     "s3:ObjectAcl:Put",
   ]
-  sns_kms_key_alias             = var.sns_kms_key_alias
+  sns_kms_key_alias             = var.sns_kms_key.kms_key_alias_name
   s3_bucket_id                  = aws_s3_bucket.access_log.id
   sns_failure_feedback_role_arn = data.aws_iam_role.sns_failure_feedback.arn
   sns_success_feedback_role_arn = data.aws_iam_role.sns_success_feedback.arn

--- a/terraform/account/region/sns_topics.tf
+++ b/terraform/account/region/sns_topics.tf
@@ -1,5 +1,5 @@
 data "aws_kms_alias" "sns_kms_key_alias" {
-  name     = var.sns_kms_key_alias
+  name     = var.sns_kms_key.kms_key_alias_name
   provider = aws.region
 }
 

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -9,9 +9,9 @@ variable "cloudwatch_log_group_kms_key_alias" {
   description = "The alias of the KMS Key to use when encrypting Cloudwatch log data."
 }
 
-variable "sns_kms_key_alias" {
-  description = "The alias of the KMS key used to encrypt the SNS topic"
-  type        = string
+variable "sns_kms_key" {
+  type        = any
+  description = "The KMS key used to encrypt the SNS topic"
 }
 
 variable "secrets_manager_kms_key_alias" {
@@ -32,4 +32,13 @@ variable "dynamodb_exports_s3_bucket_server_side_encryption_key_id" {
 variable "network_firewall_rules_file" {
   type        = string
   description = "The path to the file containing the network firewall rules."
+}
+
+variable "opensearch_kms_target_key_arn" {
+  type        = string
+  description = "kms target key ARN for opensearch serverless encryption"
+}
+
+variable "pagerduty_service_name" {
+  type = string
 }

--- a/terraform/account/region/versions.tf
+++ b/terraform/account/region/versions.tf
@@ -11,5 +11,9 @@ terraform {
         aws.global,
       ]
     }
+    pagerduty = {
+      source  = "PagerDuty/pagerduty"
+      version = "3.19.4"
+    }
   }
 }

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -4,10 +4,12 @@ module "eu_west_1" {
   network_cidr_block                                       = "10.162.0.0/16"
   network_firewall_rules_file                              = "./network_firewall_rules.rules"
   cloudwatch_log_group_kms_key_alias                       = module.cloudwatch_kms.kms_key_alias_name
-  sns_kms_key_alias                                        = module.sns_kms.kms_key_alias_name
+  sns_kms_key                                              = module.sns_kms
   secrets_manager_kms_key_alias                            = module.secrets_manager_kms.kms_key_alias_name
   reduced_fees_uploads_s3_encryption_kms_key_alias         = module.reduced_fees_uploads_s3_kms.kms_key_alias_name
   dynamodb_exports_s3_bucket_server_side_encryption_key_id = module.dynamodb_exports_s3_bucket_kms.eu_west_1_target_key_id
+  opensearch_kms_target_key_arn                            = module.opensearch_kms.eu_west_1_target_key_arn
+  pagerduty_service_name                                   = local.account.pagerduty_service_name
   providers = {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
@@ -21,10 +23,12 @@ module "eu_west_2" {
   network_cidr_block                                       = "10.162.0.0/16"
   network_firewall_rules_file                              = "./network_firewall_rules.rules"
   cloudwatch_log_group_kms_key_alias                       = module.cloudwatch_kms.kms_key_alias_name
-  sns_kms_key_alias                                        = module.sns_kms.kms_key_alias_name
+  sns_kms_key                                              = module.sns_kms
   secrets_manager_kms_key_alias                            = module.secrets_manager_kms.kms_key_alias_name
   reduced_fees_uploads_s3_encryption_kms_key_alias         = module.reduced_fees_uploads_s3_kms.kms_key_alias_name
   dynamodb_exports_s3_bucket_server_side_encryption_key_id = module.dynamodb_exports_s3_bucket_kms.eu_west_2_target_key_id
+  opensearch_kms_target_key_arn                            = module.opensearch_kms.eu_west_2_target_key_arn
+  pagerduty_service_name                                   = local.account.pagerduty_service_name
   providers = {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2


### PR DESCRIPTION
# Purpose

Make Opensearch serverless resources regional for failover

Fixes MLPAB-2643

## Approach

- Move opensearch file into region module
- create variables to pass resources and attributes in from root
- use moved blocks to relocate resources to their new address

## Learning

- https://developer.hashicorp.com/terraform/language/moved
