### PR TITLE
MLPAB-2602 - Create an alarm for invocation failures from the event bus

### DIFF
--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -24,3 +24,8 @@ data "aws_caller_identity" "current" {
 data "aws_default_tags" "current" {
   provider = aws.region
 }
+
+data "aws_sns_topic" "custom_cloudwatch_alarms" {
+  name     = "custom_cloudwatch_alarms"
+  provider = aws.region
+}

--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -5,5 +5,6 @@ module "event_bus" {
   receive_account_ids  = var.receive_account_ids
   providers = {
     aws.region = aws.region
+    aws.global = aws.global
   }
 }

--- a/terraform/environment/region/modules/event_bus/data_sources.tf
+++ b/terraform/environment/region/modules/event_bus/data_sources.tf
@@ -1,8 +1,3 @@
-data "aws_sns_topic" "custom_cloudwatch_alarms" {
-  name     = "custom_cloudwatch_alarms"
-  provider = aws.region
-}
-
 data "aws_region" "current" {
   provider = aws.region
 }

--- a/terraform/environment/region/modules/event_bus/data_sources.tf
+++ b/terraform/environment/region/modules/event_bus/data_sources.tf
@@ -14,3 +14,18 @@ data "aws_default_tags" "current" {
 data "aws_caller_identity" "current" {
   provider = aws.region
 }
+
+data "aws_iam_role" "sns_success_feedback" {
+  name     = "SNSSuccessFeedback"
+  provider = aws.global
+}
+
+data "aws_iam_role" "sns_failure_feedback" {
+  name     = "SNSFailureFeedback"
+  provider = aws.global
+}
+
+data "aws_kms_alias" "sns_kms_key_alias" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_sns_secret_encryption_key"
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -53,6 +53,28 @@ data "aws_iam_policy_document" "event_bus_dead_letter_queue" {
   provider = aws.region
 }
 
+resource "aws_sns_topic" "event_bus_dead_letter_queue" {
+  name                                     = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue-alarms"
+  kms_master_key_id                        = data.aws_kms_alias.sns_kms_key_alias.target_key_id
+  application_failure_feedback_role_arn    = data.aws_iam_role.sns_failure_feedback.arn
+  application_success_feedback_role_arn    = data.aws_iam_role.sns_success_feedback.arn
+  application_success_feedback_sample_rate = 100
+  firehose_failure_feedback_role_arn       = data.aws_iam_role.sns_failure_feedback.arn
+  firehose_success_feedback_role_arn       = data.aws_iam_role.sns_success_feedback.arn
+  firehose_success_feedback_sample_rate    = 100
+  http_failure_feedback_role_arn           = data.aws_iam_role.sns_failure_feedback.arn
+  http_success_feedback_role_arn           = data.aws_iam_role.sns_success_feedback.arn
+  http_success_feedback_sample_rate        = 100
+  lambda_failure_feedback_role_arn         = data.aws_iam_role.sns_failure_feedback.arn
+  lambda_success_feedback_role_arn         = data.aws_iam_role.sns_success_feedback.arn
+  lambda_success_feedback_sample_rate      = 100
+  sqs_failure_feedback_role_arn            = data.aws_iam_role.sns_failure_feedback.arn
+  sqs_success_feedback_role_arn            = data.aws_iam_role.sns_success_feedback.arn
+  sqs_success_feedback_sample_rate         = 100
+  provider                                 = aws.region
+}
+
+
 resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -63,7 +85,7 @@ resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "${data.aws_default_tags.current.tags.environment-name} event bus dead letter queue has messages"
-  alarm_actions       = [data.aws_sns_topic.custom_cloudwatch_alarms.arn]
+  alarm_actions       = [aws_sns_topic.event_bus_dead_letter_queue.arn]
   provider            = aws.region
 }
 

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -77,16 +77,19 @@ resource "aws_sns_topic" "event_bus_dead_letter_queue" {
 
 resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Sum"
-  threshold           = 0
+  threshold           = 1
   alarm_description   = "${data.aws_default_tags.current.tags.environment-name} event bus dead letter queue has messages"
   alarm_actions       = [aws_sns_topic.event_bus_dead_letter_queue.arn]
-  provider            = aws.region
+  dimensions = {
+    QueueName = aws_sqs_queue.event_bus_dead_letter_queue.name
+  }
+  provider = aws.region
 }
 
 # Send event to remote account event bus

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Sum"
-  threshold           = 1
+  threshold           = 0
   alarm_description   = "${data.aws_default_tags.current.tags.environment-name} event bus dead letter queue has messages"
   alarm_actions       = [aws_sns_topic.event_bus_dead_letter_queue.arn]
   provider            = aws.region

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -77,7 +77,7 @@ resource "aws_sns_topic" "event_bus_dead_letter_queue" {
 
 resource "aws_cloudwatch_metric_alarm" "event_bus_dead_letter_queue" {
   alarm_name          = "${data.aws_default_tags.current.tags.environment-name}-event-bus-dead-letter-queue"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"

--- a/terraform/environment/region/modules/event_bus/outputs.tf
+++ b/terraform/environment/region/modules/event_bus/outputs.tf
@@ -5,3 +5,7 @@ output "event_bus" {
 output "event_bus_dead_letter_queue" {
   value = aws_sqs_queue.event_bus_dead_letter_queue
 }
+
+output "event_bus_dead_letter_queue_aws_sns_topic_arn" {
+  value = aws_sns_topic.event_bus_dead_letter_queue.arn
+}

--- a/terraform/environment/region/modules/event_bus/versions.tf
+++ b/terraform/environment/region/modules/event_bus/versions.tf
@@ -7,6 +7,7 @@ terraform {
       version = "~> 5.86.0"
       configuration_aliases = [
         aws.region,
+        aws.global
       ]
     }
   }

--- a/terraform/environment/region/pagerduty.tf
+++ b/terraform/environment/region/pagerduty.tf
@@ -75,3 +75,17 @@ resource "aws_sns_topic_subscription" "event_alarms" {
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.event_alarms.integration_key}/enqueue"
   provider               = aws.region
 }
+
+resource "pagerduty_service_integration" "environment_event_bus_dlq_alarms" {
+  name    = "Modernising LPA ${data.aws_default_tags.current.tags.environment-name} ${data.aws_region.current.name} Eventbus DLQ Alarms"
+  service = data.pagerduty_service.main.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
+resource "aws_sns_topic_subscription" "environment_event_bus_dlq_alarms" {
+  topic_arn              = module.event_bus.event_bus_dead_letter_queue_aws_sns_topic_arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.environment_event_bus_dlq_alarms.integration_key}/enqueue"
+  provider               = aws.region
+}

--- a/terraform/environment/region/s3_antivirus.tf
+++ b/terraform/environment/region/s3_antivirus.tf
@@ -21,8 +21,3 @@ module "s3_antivirus" {
     aws.region = aws.region
   }
 }
-
-data "aws_sns_topic" "custom_cloudwatch_alarms" {
-  name     = "custom_cloudwatch_alarms"
-  provider = aws.region
-}


### PR DESCRIPTION
# Purpose

Raise an alarm to team if items arrive in the DLQ for Environment event bus. This would be an indication of an invocation failure for the event-received and schedule runner lambda functions

Fixes MLPAB-2602

## Approach

- add SNS topic for DLQ alarm 
- subscribe Pagerduty to SNS topic

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
