### PR TITLE
rename athena db to avoid broken db in production

### DIFF
--- a/terraform/account/region/load_balancer_access_logs_athena.tf
+++ b/terraform/account/region/load_balancer_access_logs_athena.tf
@@ -126,7 +126,7 @@ resource "aws_athena_workgroup" "alb_logs" {
 }
 
 resource "aws_athena_database" "access_logs" {
-  name          = "${data.aws_default_tags.current.tags.account-name}_load_balancer_logs"
+  name          = "load_balancer_logs"
   bucket        = aws_s3_bucket.athena_results.id
   force_destroy = true
 


### PR DESCRIPTION
# Purpose

An error during the production account creation of the athena db has resulted in a db that cannot be updated or deleted. I've opted to create another alongside.

## Approach

- rename db

I've already checked and applied this to production, and checked preproduction is ok.

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
