### PR TITLE
MLPAB-2856 - Allow MRLPA to put events to UALPA

### DIFF
--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -1,8 +1,8 @@
 module "event_bus" {
-  source               = "./modules/event_bus"
-  target_event_bus_arn = var.target_event_bus_arn
-  iam_role             = var.iam_roles.cross_account_put
-  receive_account_ids  = var.receive_account_ids
+  source                = "./modules/event_bus"
+  target_event_bus_arns = var.target_event_bus_arns
+  iam_role              = var.iam_roles.cross_account_put
+  receive_account_ids   = var.receive_account_ids
   providers = {
     aws.region = aws.region
     aws.global = aws.global

--- a/terraform/environment/region/modules/event_bus/variables.tf
+++ b/terraform/environment/region/modules/event_bus/variables.tf
@@ -1,6 +1,6 @@
-variable "target_event_bus_arn" {
-  type        = string
-  description = "ARN of the event bus to forward events to"
+variable "target_event_bus_arns" {
+  type        = map(string)
+  description = "A map that contains the name and arn of event buses to forward events to"
 }
 
 variable "iam_role" {

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -103,9 +103,9 @@ variable "reduced_fees" {
   })
 }
 
-variable "target_event_bus_arn" {
-  type        = string
-  description = "ARN of the event bus to forward events to"
+variable "target_event_bus_arns" {
+  type        = map(string)
+  description = "A map that contains the name and arn of event buses to forward events to"
 }
 
 variable "receive_account_ids" {

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -69,7 +69,7 @@ module "eu_west_1" {
     destination_account_id                    = local.environment.reduced_fees.destination_account_id
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
-  target_event_bus_arn                 = local.environment.event_bus.target_event_bus_arn
+  target_event_bus_arns                = local.environment.event_bus.target_event_bus_arns
   receive_account_ids                  = local.environment.event_bus.receive_account_ids
   app_env_vars                         = local.environment.app.env
   public_access_enabled                = var.public_access_enabled
@@ -144,7 +144,7 @@ module "eu_west_2" {
     destination_account_id                    = local.environment.reduced_fees.destination_account_id
     enable_s3_batch_job_replication_scheduler = local.environment.reduced_fees.enable_s3_batch_job_replication_scheduler
   }
-  target_event_bus_arn                 = local.environment.event_bus.target_event_bus_arn
+  target_event_bus_arns                = local.environment.event_bus.target_event_bus_arns
   receive_account_ids                  = local.environment.event_bus.receive_account_ids
   app_env_vars                         = local.environment.app.env
   public_access_enabled                = var.public_access_enabled

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -74,7 +74,10 @@
             "cloudwatch_application_insights_enabled": false,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "288342028542"
                 ]
@@ -162,7 +165,10 @@
             "cloudwatch_application_insights_enabled": false,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "288342028542"
                 ]
@@ -250,7 +256,10 @@
             "cloudwatch_application_insights_enabled": false,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "288342028542",
                     "493907465011"
@@ -339,7 +348,10 @@
             "cloudwatch_application_insights_enabled": false,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "288342028542"
                 ]
@@ -427,95 +439,10 @@
             "cloudwatch_application_insights_enabled": true,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
-                "receive_account_ids": [
-                    "288342028542"
-                ]
-            },
-            "reduced_fees": {
-                "enabled": true,
-                "s3_object_replication_enabled": true,
-                "target_environment": "dev",
-                "destination_account_id": "288342028542",
-                "enable_s3_batch_job_replication_scheduler": false
-            },
-            "s3_antivirus_provisioned_concurrency": 0
-        },
-        "ur2": {
-            "account_id": "653761790766",
-            "account_name": "development",
-            "is_production": false,
-            "regions": [
-                "eu-west-1"
-            ],
-            "app": {
-                "env": {
-                    "app_public_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
-                    "auth_redirect_base_url": "https://ur2.app.modernising.opg.service.justice.gov.uk",
-                    "notify_is_production": "",
-                    "onelogin_url": "https://home.integration.account.gov.uk",
-                    "dev_mode": "1"
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
                 },
-                "autoscaling": {
-                    "minimum": 1,
-                    "maximum": 3
-                },
-                "dependency_health_check_alarm_enabled": false,
-                "service_health_check_alarm_enabled": false,
-                "cloudwatch_application_insights_enabled": true,
-                "fault_injection_experiments_enabled": false,
-                "real_user_monitoring_cw_logs_enabled": true
-            },
-            "mock_onelogin_enabled": false,
-            "mock_pay_enabled": true,
-            "egress_checker_enabled": false,
-            "uid_service": {
-                "base_url": "https://development.lpa-uid.api.opg.service.justice.gov.uk",
-                "api_arns": [
-                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/POST/cases",
-                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/POST/cases",
-                    "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/health",
-                    "arn:aws:execute-api:eu-west-2:288342028542:*/*/GET/health"
-                ]
-            },
-            "lpa_store_service": {
-                "base_url": "https://development.lpa-store.api.opg.service.justice.gov.uk",
-                "api_arns": [
-                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas",
-                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas",
-                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/lpas/*",
-                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/lpas/*",
-                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/PUT/lpas/*",
-                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/PUT/lpas/*",
-                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/POST/lpas/*/updates",
-                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/POST/lpas/*/updates",
-                    "arn:aws:execute-api:eu-west-1:493907465011:*/*/GET/health-check",
-                    "arn:aws:execute-api:eu-west-2:493907465011:*/*/GET/health-check"
-                ]
-            },
-            "backups": {
-                "backup_plan_enabled": true,
-                "copy_action_enabled": false
-            },
-            "dynamodb": {
-                "table_name": "Lpas",
-                "region_replica_enabled": false,
-                "cloudtrail_enabled": false
-            },
-            "ecs": {
-                "fargate_spot_capacity_provider_enabled": false
-            },
-            "cloudwatch_log_groups": {
-                "application_log_retention_days": 400
-            },
-            "application_load_balancer": {
-                "deletion_protection_enabled": false,
-                "waf_alb_association_enabled": true
-            },
-            "cloudwatch_application_insights_enabled": true,
-            "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-            "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
                 "receive_account_ids": [
                     "288342028542"
                 ]
@@ -603,7 +530,10 @@
             "cloudwatch_application_insights_enabled": true,
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "936779158973"
                 ]
@@ -691,7 +621,10 @@
             "cloudwatch_application_insights_enabled": true,
             "pagerduty_service_name": "OPG Modernising LPA Production",
             "event_bus": {
-                "target_event_bus_arn": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                "target_event_bus_arns": {
+                    "sirius": "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas",
+                    "ualpa": "arn:aws:events:eu-west-1:123456789012:event-bus/dev-poas"
+                },
                 "receive_account_ids": [
                     "764856231715"
                 ]

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -89,8 +89,8 @@ variable "environments" {
       cloudwatch_application_insights_enabled = bool
       pagerduty_service_name                  = string
       event_bus = object({
-        target_event_bus_arn = string
-        receive_account_ids  = list(string)
+        target_event_bus_arns = map(string)
+        receive_account_ids   = list(string)
       })
       reduced_fees = object({
         enabled                                   = bool


### PR DESCRIPTION
# Purpose

Add permissions to put cross account events into a remote event bus

Fixes MLPAB-2856

## Approach

- refactor target_bus_arn to support map of strings
- specify correct arns and busses
- remove ur2 environment definition
- TODO: replace target arn region (currently all eu-west-1)

Note: not all environments in UALPA have an event bus yet.

## Learning

- https://developer.hashicorp.com/terraform/language/expressions/types#map
- https://developer.hashicorp.com/terraform/language/meta-arguments/for_each
- https://spacelift.io/blog/terraform-map-variable#using-terraform-map
