### PR TITLE
MLPAB-2857 - Use merge queues

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: none


### PR DESCRIPTION
# Purpose

Automate the merging of PRs when they need to be kept up to date with the main branch.

Fixes MLPAB-2857

## Approach

- (manually) require merge queues in branch protection rules
- Add merge group trigger to PR workflow

## Learning

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
