### PR TITLE
MLPAB-2857 - create a new merge group workflow

### DIFF
--- a/.github/workflows/workflow_merge_group.yml
+++ b/.github/workflows/workflow_merge_group.yml
@@ -1,9 +1,8 @@
-name: "[Workflow] PR"
+name: "[Workflow] Merge Group"
 
 on:
-  pull_request:
-    branches:
-      - main
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: none
@@ -125,7 +124,7 @@ jobs:
       ]
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
-        workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}
+        workspace_name: staging
         version_tag: ${{ needs.create_tags.outputs.version_tag }}
       secrets:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}


### PR DESCRIPTION
# Purpose

Run a new workflow in merge queues

Fixes MLPAB-2857

## Approach

- create merge group workflow
- deploy to staging environment
- identify when running as a merge group trigger and create a pre-release tag

## Learning

- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group