### PR TITLE
MLPAB-2941 - remove s3 av zip lambda setup as deprecated

### DIFF
--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: read
+  pull-requests: write
   actions: none
   checks: none
   deployments: none

--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: none
+  pull-requests: read
   actions: none
   checks: none
   deployments: none

--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -16,7 +16,7 @@ permissions:
   actions: none
   checks: none
   deployments: none
-  issues: none
+  issues: write
   packages: none
   repository-projects: none
   statuses: none

--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -26,28 +26,6 @@ defaults:
     shell: bash
 
 jobs:
-  fetch_s3_av_version:
-    name: Fetch the S3 AV Zip version tag
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-github-actions-ssm-get-parameter
-          role-duration-seconds: 900
-          role-session-name: GithubActionsSSMGetParameter
-      - name: Pull S3 AV Zip tag
-        id: pull_s3_av_tag
-        run: |
-          key="/opg-s3-antivirus/zip-version-main"
-          value=$(aws ssm get-parameter --name "$key" --query 'Parameter.Value' --output text 2>/dev/null || true)
-          echo "Using $key: $value"
-          echo "tag=${value}" >> $GITHUB_OUTPUT
-    outputs:
-      s3_av_scanner_zip_tag: ${{ steps.pull_s3_av_tag.outputs.tag }}
-
-
   docker_build_scan_push:
     name: Docker Build, Scan and Push
     uses: ./.github/workflows/docker_job.yml
@@ -79,7 +57,6 @@ jobs:
         workspace_name: ur
         version_tag: ur-${{ inputs.tag_to_deploy}}
         checkout_tag: ${{ inputs.tag_to_deploy}}
-        s3_av_scanner_zip_tag: ${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}
       secrets:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -12,11 +12,11 @@ permissions:
   id-token: write
   contents: write
   security-events: write
-  pull-requests: write
+  pull-requests: none
   actions: none
   checks: none
   deployments: none
-  issues: write
+  issues: none
   packages: none
   repository-projects: none
   statuses: none

--- a/.github/workflows/dispatch_deploy_to_ur_environment.yml
+++ b/.github/workflows/dispatch_deploy_to_ur_environment.yml
@@ -51,7 +51,7 @@ jobs:
 
   deploy:
       name: ur Environment Deploy
-      needs: [ui_tests_image, fetch_s3_av_version]
+      needs: [ui_tests_image]
       uses: ./.github/workflows/terraform_environment_job.yml
       with:
         workspace_name: ur


### PR DESCRIPTION
# Purpose

The deploy UR job fails because it supplies inputs that are no longer required

Fixes MLPAB-2941

## Approach

- remove S3 AV lambda zip steps as no longer required
- remove `s3_av_scanner_zip_tag` input from environment deploy job

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
