### PR TITLE
MLPAB-2944 - create insights query for emitted events

### DIFF
--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -209,8 +209,9 @@ resource "aws_cloudwatch_event_bus_policy" "cross_account_receive" {
 }
 
 resource "aws_cloudwatch_query_definition" "events_emitted" {
+  count           = var.log_emitted_events ? 1 : 0
   name            = "${data.aws_default_tags.current.tags.environment-name}/emitted-events"
-  log_group_names = [aws_cloudwatch_log_group.events_emitted.name]
+  log_group_names = [aws_cloudwatch_log_group.events_emitted[0].name]
 
   query_string = <<EOF
 fields @timestamp, @message, @logStream, @log

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -207,3 +207,15 @@ resource "aws_cloudwatch_event_bus_policy" "cross_account_receive" {
   policy         = data.aws_iam_policy_document.cross_account_receive.json
   provider       = aws.region
 }
+
+resource "aws_cloudwatch_query_definition" "events_emitted" {
+  name            = "${data.aws_default_tags.current.tags.environment-name}/emitted-events"
+  log_group_names = [aws_cloudwatch_log_group.events_emitted.name]
+
+  query_string = <<EOF
+fields @timestamp, @message, @logStream, @log
+| sort @timestamp desc
+| limit 10000
+EOF
+  provider     = aws.region
+}


### PR DESCRIPTION
# Purpose

Make it easy for the team to find relevant logs, by creating an insight query in the environment's folder

Fixes MLPAB-2944

## Approach

- create insight query for emitted events

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_query_definition
