### PR TITLE
MLPAB-2947 - Fix path to live failure notifications

### DIFF
--- a/.github/workflows/slack_job.yml
+++ b/.github/workflows/slack_job.yml
@@ -25,5 +25,5 @@ jobs:
       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
         method: chat.postMessage
-        token: ${{ secrets.SLACK_BOT_TOKEN }}
+        token: ${{ secrets.slack-bot-token }}
         payload: ${{ inputs.payload }}


### PR DESCRIPTION
# Purpose

Path to live failure notifications had stopped worked with an error saying the slack token was missing. 

Fixes MLPAB-2947

## Approach

- Use correct name for slack secret

## Learning


