### PR TITLE
MLPAB-2959 - create eventbridge api destination for opg-metrics

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -2,38 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.94.0"
+  version     = "5.94.1"
   constraints = ">= 5.5.0, ~> 5.94.0"
   hashes = [
-    "h1:1KQLLRCndM1TJJigZwI3xwIvzacYG9P5a+7nCWMWFwM=",
-    "h1:4UWtIcvhDsZJtgzOHrTcgbu4LIYEEQ4G0CWHU9Cw/zk=",
-    "h1:5Oh97L+AjE/boQZXP+rfrgSC1lUzbavlXOMCeofkuBE=",
-    "h1:CvO3FloIuUCBhomGgmG0AwLvok1vui2TpchnPqVV25A=",
-    "h1:FGJRm891XeiwhoJ+82EZ9cKcIRU/IxXYvJjTAwXO6f8=",
-    "h1:Fpos4bBGop5fkupgTG74A2rZ9hFdN6r5Md/2e3je5NU=",
-    "h1:H6ZcjtKcgks0v0DorEc4WnMJQVUIr82ZCKCXQHLEk8w=",
-    "h1:XU8tSLmjTaJtMFXXty7f1/WQizxkTBClq8AQlcSrGGA=",
-    "h1:Z1vyV7Mk7dQLXya4gXOFVgWOrnbs9nWzj0z0BT2+Aas=",
-    "h1:frW+HwwKonEVEUCQVGaDYrP8Vp+FUm+Y52n72QpDipA=",
-    "h1:jmKJAlUbCE8rPVjsaBGOXN/CjwOK/tuktzjRnoVUukM=",
-    "h1:m/Qjq+JgWh5wSJaB3wib24r5oDQnbl9oAtXUNlxuhvc=",
-    "h1:vnBmHfkDQmLW3f3Xug40PJdqWQerNt8yfIguCcfM6sk=",
-    "h1:xca6tTJrUG5QHKkKWFJZXWLRlE0RW9ttNq99Ph2T7vM=",
-    "zh:1486b66ae5ed92260bc24a4ec98f8fbf60a2bf880f036c0cb992f9567eccbb66",
-    "zh:302d702609d0d91bcc37ecd4bd777e40f6f1c267a28b6eb28ccba99714f03762",
-    "zh:55836eef9c0cc5e724a642ac23741e9dd1345cd03e98af489d5041dcf2642a3d",
-    "zh:5ce59ca182ff9a0a3535b8c25339bfcf6224baddab3482e7338e41128302c7c8",
-    "zh:62bac1d207280a9ac3a1d21007d496fe7d12a790f159fbedcff3ce345d0a7ba5",
-    "zh:6d31dc94fb50f2f0dcffdd4f27c460e22d7636cc1705238c606398fb818f69de",
-    "zh:70aed22b328e763ba885a5888c227403dac95bcaab718c6bf4013679ad2e7281",
-    "zh:741ce2ca7d963ecb995438ee19840f845a7f135d2db4fe33f2b84a8eebb3a39e",
+    "h1:dYdnGlaCJONFyGk/t3Y4iJzQ8EiJr2DaDdZ/2JV5PZU=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b1c2e831724364a9df5ed05ac0198577ce57474b135c151d033dd27b6ed2d352",
-    "zh:d8fbe80f84ee83eba13f984eb4595ef0828c40960c3ed75e324c71e5dff33467",
-    "zh:edc5f1b46408b3cb430638a88fe69056a2ee37a623ef51f15b7468441e0c3274",
-    "zh:f3c4c16fbadda3df079e2fad0827a8bab57eb6b9cfba2b366eee3367ab6fbe0f",
-    "zh:f80d323b7828b86a7bfe6dfd7dcce7435198c9af1a9642c5ac827da61ccc3596",
-    "zh:fd93d791b708fe0a650246400b2e9bd76d25cefce01bf4bd7d5c1089f7fec930",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
   ]
 }
 

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -1,0 +1,45 @@
+data "aws_default_tags" "current" {
+  provider = aws.eu_west_1
+}
+
+data "aws_secretsmanager_secret" "opg_metrics_api_key" {
+  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.account-name}"
+  provider = aws.shared_eu_west_1
+}
+
+data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
+  secret_id     = data.aws_secretsmanager_secret.opg_metrics_api_key.id
+  version_stage = "AWSCURRENT"
+  provider      = aws.shared_eu_west_1
+}
+
+resource "aws_cloudwatch_event_connection" "opg_metrics" {
+  name               = "opg-metrics"
+  description        = "Account level - connection and auth for opg-metrics"
+  authorization_type = "API_KEY"
+
+  auth_parameters {
+    api_key {
+      key   = "x-api-key"
+      value = data.aws_secretsmanager_secret_version.opg_metrics_api_key.secret_string
+    }
+  }
+  provider = aws.eu_west_1
+}
+
+resource "aws_cloudwatch_event_api_destination" "opg_metrics" {
+  name                             = "opg-metrics"
+  description                      = "Account level - an endpoint to push metrics to"
+  invocation_endpoint              = "https://development.api.metrics.opg.service.justice.gov.uk"
+  http_method                      = "PUT"
+  invocation_rate_limit_per_second = 300
+  connection_arn                   = aws_cloudwatch_event_connection.opg_metrics.arn
+  provider                         = aws.eu_west_1
+}
+
+resource "aws_ssm_parameter" "opg_metrics_arn" {
+  name     = "opg-metrics-api-destination-arn"
+  type     = "String"
+  value    = aws_cloudwatch_event_api_destination.opg_metrics.arn
+  provider = aws.eu_west_1
+}

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -27,10 +27,11 @@ resource "aws_cloudwatch_event_connection" "opg_metrics" {
   provider = aws.eu_west_1
 }
 
-resource "aws_cloudwatch_event_api_destination" "opg_metrics" {
-  name                             = "opg-metrics"
-  description                      = "Account level - an endpoint to push metrics to"
-  invocation_endpoint              = "https://development.api.metrics.opg.service.justice.gov.uk"
+resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {
+  name        = "opg-metrics metrics PUT"
+  description = "Account level - an endpoint to push metrics to"
+  # only the development metrics service exists at this time
+  invocation_endpoint              = "${local.account.opg_metrics_endpoint}/metrics"
   http_method                      = "PUT"
   invocation_rate_limit_per_second = 300
   connection_arn                   = aws_cloudwatch_event_connection.opg_metrics.arn
@@ -40,6 +41,6 @@ resource "aws_cloudwatch_event_api_destination" "opg_metrics" {
 resource "aws_ssm_parameter" "opg_metrics_arn" {
   name     = "opg-metrics-api-destination-arn"
   type     = "String"
-  value    = aws_cloudwatch_event_api_destination.opg_metrics.arn
+  value    = aws_cloudwatch_event_api_destination.opg_metrics_put.arn
   provider = aws.eu_west_1
 }

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -28,9 +28,8 @@ resource "aws_cloudwatch_event_connection" "opg_metrics" {
 }
 
 resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {
-  name        = "opg-metrics metrics PUT"
-  description = "Account level - an endpoint to push metrics to"
-  # only the development metrics service exists at this time
+  name                             = "opg-metrics metrics PUT"
+  description                      = "Account level - an endpoint to push metrics to"
   invocation_endpoint              = "${local.account.opg_metrics_endpoint}/metrics"
   http_method                      = "PUT"
   invocation_rate_limit_per_second = 300

--- a/terraform/account/region/versions.tf
+++ b/terraform/account/region/versions.tf
@@ -9,6 +9,7 @@ terraform {
         aws.region,
         aws.management,
         aws.global,
+        aws.shared,
       ]
     }
     pagerduty = {

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -14,6 +14,7 @@ module "eu_west_1" {
     aws.region     = aws.eu_west_1
     aws.management = aws.management_eu_west_1
     aws.global     = aws.global
+    aws.shared     = aws.shared_eu_west_1
   }
 }
 
@@ -33,6 +34,7 @@ module "eu_west_2" {
     aws.region     = aws.eu_west_2
     aws.management = aws.management_eu_west_2
     aws.global     = aws.global
+    aws.shared     = aws.shared_eu_west_2
   }
 }
 

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -88,6 +88,31 @@ provider "aws" {
   }
 }
 
+# make these roles in org infra
+provider "aws" {
+  alias  = "shared_eu_west_1"
+  region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
+    session_name = "opg-modernising-lpa-terraform-session"
+  }
+}
+
+provider "aws" {
+  alias  = "shared_eu_west_2"
+  region = "eu-west-2"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
+    session_name = "opg-modernising-lpa-terraform-session"
+  }
+}
+
 data "aws_region" "eu_west_1" {
   provider = aws.eu_west_1
 }

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -88,7 +88,6 @@ provider "aws" {
   }
 }
 
-# make these roles in org infra
 provider "aws" {
   alias  = "shared_eu_west_1"
   region = "eu-west-1"

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -8,7 +8,8 @@
                 "eu-west-1"
             ],
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-            "athena_enabled": false
+            "athena_enabled": false,
+            "shared_account_id": "679638075911"
         },
         "preproduction": {
             "account_id": "792093328875",
@@ -18,7 +19,8 @@
                 "eu-west-1"
             ],
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
-            "athena_enabled": false
+            "athena_enabled": false,
+            "shared_account_id": "679638075911"
         },
         "production": {
             "account_id": "313879017102",
@@ -28,7 +30,8 @@
                 "eu-west-1"
             ],
             "pagerduty_service_name": "OPG Modernising LPA Production",
-            "athena_enabled": false
+            "athena_enabled": false,
+            "shared_account_id": "679638075911"
         }
     }
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -9,7 +9,8 @@
             ],
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "athena_enabled": false,
-            "shared_account_id": "679638075911"
+            "shared_account_id": "679638075911",
+            "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
         },
         "preproduction": {
             "account_id": "792093328875",
@@ -20,7 +21,8 @@
             ],
             "pagerduty_service_name": "OPG Modernising LPA Non-Production",
             "athena_enabled": false,
-            "shared_account_id": "679638075911"
+            "shared_account_id": "679638075911",
+            "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
         },
         "production": {
             "account_id": "313879017102",
@@ -31,7 +33,8 @@
             ],
             "pagerduty_service_name": "OPG Modernising LPA Production",
             "athena_enabled": false,
-            "shared_account_id": "679638075911"
+            "shared_account_id": "679638075911",
+            "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
         }
     }
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -16,6 +16,7 @@ variable "accounts" {
       regions                = list(string)
       pagerduty_service_name = string
       athena_enabled         = bool
+      shared_account_id      = string
     })
   )
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -17,6 +17,7 @@ variable "accounts" {
       pagerduty_service_name = string
       athena_enabled         = bool
       shared_account_id      = string
+      opg_metrics_endpoint   = string
     })
   )
 }

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,38 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.94.0"
+  version     = "5.94.1"
   constraints = "~> 5.94.0"
   hashes = [
-    "h1:1KQLLRCndM1TJJigZwI3xwIvzacYG9P5a+7nCWMWFwM=",
-    "h1:4UWtIcvhDsZJtgzOHrTcgbu4LIYEEQ4G0CWHU9Cw/zk=",
-    "h1:5Oh97L+AjE/boQZXP+rfrgSC1lUzbavlXOMCeofkuBE=",
-    "h1:CvO3FloIuUCBhomGgmG0AwLvok1vui2TpchnPqVV25A=",
-    "h1:FGJRm891XeiwhoJ+82EZ9cKcIRU/IxXYvJjTAwXO6f8=",
-    "h1:Fpos4bBGop5fkupgTG74A2rZ9hFdN6r5Md/2e3je5NU=",
-    "h1:H6ZcjtKcgks0v0DorEc4WnMJQVUIr82ZCKCXQHLEk8w=",
-    "h1:XU8tSLmjTaJtMFXXty7f1/WQizxkTBClq8AQlcSrGGA=",
-    "h1:Z1vyV7Mk7dQLXya4gXOFVgWOrnbs9nWzj0z0BT2+Aas=",
-    "h1:frW+HwwKonEVEUCQVGaDYrP8Vp+FUm+Y52n72QpDipA=",
-    "h1:jmKJAlUbCE8rPVjsaBGOXN/CjwOK/tuktzjRnoVUukM=",
-    "h1:m/Qjq+JgWh5wSJaB3wib24r5oDQnbl9oAtXUNlxuhvc=",
-    "h1:vnBmHfkDQmLW3f3Xug40PJdqWQerNt8yfIguCcfM6sk=",
-    "h1:xca6tTJrUG5QHKkKWFJZXWLRlE0RW9ttNq99Ph2T7vM=",
-    "zh:1486b66ae5ed92260bc24a4ec98f8fbf60a2bf880f036c0cb992f9567eccbb66",
-    "zh:302d702609d0d91bcc37ecd4bd777e40f6f1c267a28b6eb28ccba99714f03762",
-    "zh:55836eef9c0cc5e724a642ac23741e9dd1345cd03e98af489d5041dcf2642a3d",
-    "zh:5ce59ca182ff9a0a3535b8c25339bfcf6224baddab3482e7338e41128302c7c8",
-    "zh:62bac1d207280a9ac3a1d21007d496fe7d12a790f159fbedcff3ce345d0a7ba5",
-    "zh:6d31dc94fb50f2f0dcffdd4f27c460e22d7636cc1705238c606398fb818f69de",
-    "zh:70aed22b328e763ba885a5888c227403dac95bcaab718c6bf4013679ad2e7281",
-    "zh:741ce2ca7d963ecb995438ee19840f845a7f135d2db4fe33f2b84a8eebb3a39e",
+    "h1:dYdnGlaCJONFyGk/t3Y4iJzQ8EiJr2DaDdZ/2JV5PZU=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b1c2e831724364a9df5ed05ac0198577ce57474b135c151d033dd27b6ed2d352",
-    "zh:d8fbe80f84ee83eba13f984eb4595ef0828c40960c3ed75e324c71e5dff33467",
-    "zh:edc5f1b46408b3cb430638a88fe69056a2ee37a623ef51f15b7468441e0c3274",
-    "zh:f3c4c16fbadda3df079e2fad0827a8bab57eb6b9cfba2b366eee3367ab6fbe0f",
-    "zh:f80d323b7828b86a7bfe6dfd7dcce7435198c9af1a9642c5ac827da61ccc3596",
-    "zh:fd93d791b708fe0a650246400b2e9bd76d25cefce01bf4bd7d5c1089f7fec930",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
   ]
 }
 


### PR DESCRIPTION
# Purpose

Create a shared api destination for opg-metrics put requests

Fixes MLPAB-2959

## Approach

- create api destination
- create connection with auth using api key
- put api destination arn in a parameter

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_connection
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_api_destination
