### PR TITLE
MLPAB-2974 - don't sent metric events cross-account

### DIFF
--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -119,7 +119,8 @@ resource "aws_cloudwatch_event_rule" "cross_account_put" {
   event_bus_name = aws_cloudwatch_event_bus.main.name
 
   event_pattern = jsonencode({
-    source = ["opg.poas.makeregister"]
+    source      = ["opg.poas.makeregister"]
+    detail-type = [{ "anything-but" : { "prefix" : "metric" } }]
   })
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Metric events are being sent to Sirius, but they don't need to be

Fixes MLPAB-##

## Approach

- Add an `anything-but` operator to the event handling rule

## Learning

- https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-pattern-operators.html
