### PR TITLE
MLPAB-2966 stop using deprecated state lock mechanism for terraform

### DIFF
--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     assume_role = {
       role_arn = "arn:aws:iam::311462405659:role/modernising-lpa-state-access"
     }
-    dynamodb_table = "remote_lock"
+    use_lockfile = true
   }
 }
 #

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     assume_role = {
       role_arn = "arn:aws:iam::311462405659:role/modernising-lpa-state-access"
     }
-    dynamodb_table = "remote_lock"
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
# Purpose

Using dynamodb for state locking is now deprecated.

Fixes MLPAB-2966

## Approach

- set `use_lockfile` to true in S3 backend setup for environment and account level terraform 

## Learning

- https://developer.hashicorp.com/terraform/language/backend/s3#state-locking
