### PR TITLE
MLPAB-2977 - redirect starts to mainstream content

### DIFF
--- a/terraform/environment/region/ecs.tf
+++ b/terraform/environment/region/ecs.tf
@@ -62,6 +62,7 @@ module "app" {
   search_index_name                                    = var.search_index_name
   search_collection_arn                                = var.search_collection_arn
   ecs_aws_otel_collector_version                       = var.ecs_aws_otel_collector_version
+  start_page_redirects                                 = var.start_page_redirects
 
   providers = {
     aws.region     = aws.region

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -73,13 +73,14 @@ resource "aws_lb_listener" "app_loadbalancer" {
 }
 
 resource "aws_lb_listener_rule" "donor_start" {
+  count        = var.start_page_redirects.enabled ? 1 : 0
   listener_arn = aws_lb_listener.app_loadbalancer.arn
   priority     = 10
   action {
     type = "redirect"
 
     redirect {
-      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      host        = var.start_page_redirects.start_page_redirect_url
       path        = "/register-lasting-power-of-attorney/make-lpa"
       query       = ""
       port        = "443"
@@ -96,13 +97,14 @@ resource "aws_lb_listener_rule" "donor_start" {
 }
 
 resource "aws_lb_listener_rule" "attorney_start" {
+  count        = var.start_page_redirects.enabled ? 1 : 0
   listener_arn = aws_lb_listener.app_loadbalancer.arn
   priority     = 11
   action {
     type = "redirect"
 
     redirect {
-      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      host        = var.start_page_redirects.start_page_redirect_url
       path        = "/register-lasting-power-of-attorney/attorney"
       query       = ""
       port        = "443"
@@ -119,13 +121,14 @@ resource "aws_lb_listener_rule" "attorney_start" {
 }
 
 resource "aws_lb_listener_rule" "certificate_provider_start" {
+  count        = var.start_page_redirects.enabled ? 1 : 0
   listener_arn = aws_lb_listener.app_loadbalancer.arn
   priority     = 12
   action {
     type = "redirect"
 
     redirect {
-      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      host        = var.start_page_redirects.start_page_redirect_url
       path        = "/register-lasting-power-of-attorney/certificate-provider"
       query       = ""
       port        = "443"

--- a/terraform/environment/region/modules/app/alb.tf
+++ b/terraform/environment/region/modules/app/alb.tf
@@ -72,6 +72,75 @@ resource "aws_lb_listener" "app_loadbalancer" {
   provider = aws.region
 }
 
+resource "aws_lb_listener_rule" "donor_start" {
+  listener_arn = aws_lb_listener.app_loadbalancer.arn
+  priority     = 10
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      path        = "/register-lasting-power-of-attorney/make-lpa"
+      query       = ""
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/start"]
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_rule" "attorney_start" {
+  listener_arn = aws_lb_listener.app_loadbalancer.arn
+  priority     = 11
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      path        = "/register-lasting-power-of-attorney/attorney"
+      query       = ""
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/attorney-start"]
+    }
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_rule" "certificate_provider_start" {
+  listener_arn = aws_lb_listener.app_loadbalancer.arn
+  priority     = 12
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+      path        = "/register-lasting-power-of-attorney/certificate-provider"
+      query       = ""
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/certificate-provider-start"]
+    }
+  }
+  provider = aws.region
+}
+
 resource "aws_lb_listener_rule" "app_maintenance" {
   listener_arn = aws_lb_listener.app_loadbalancer.arn
   priority     = 101 # Specifically set so that maintenance mode scripts can locate the correct rule to modify

--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -165,3 +165,10 @@ variable "ecs_aws_otel_collector_version" {
   type        = string
   description = "semver tag for the public ecr tag of the aws-otel-collector image"
 }
+
+variable "start_page_redirects" {
+  type = object({
+    enabled                 = bool
+    start_page_redirect_url = string
+  })
+}

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -197,3 +197,10 @@ variable "log_emitted_events" {
   description = "Log events emitted to /aws/events/{env}-emitted"
   default     = false
 }
+
+variable "start_page_redirects" {
+  type = object({
+    enabled                 = bool
+    start_page_redirect_url = string
+  })
+}

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -88,6 +88,7 @@ module "eu_west_1" {
   real_user_monitoring_cw_logs_enabled    = local.environment.app.real_user_monitoring_cw_logs_enabled
   ecs_aws_otel_collector_version          = var.ecs_aws_otel_collector_version
   log_emitted_events                      = local.environment.log_emitted_events
+  start_page_redirects                    = local.environment.start_page_redirects
   providers = {
     aws.region            = aws.eu_west_1
     aws.global            = aws.global
@@ -161,6 +162,7 @@ module "eu_west_2" {
   real_user_monitoring_cw_logs_enabled    = local.environment.app.real_user_monitoring_cw_logs_enabled
   ecs_aws_otel_collector_version          = var.ecs_aws_otel_collector_version
   log_emitted_events                      = local.environment.log_emitted_events
+  start_page_redirects                    = local.environment.start_page_redirects
   providers = {
     aws.region            = aws.eu_west_2
     aws.global            = aws.global

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -190,8 +190,8 @@
             },
             "log_emitted_events": false,
             "start_page_redirects": {
-                "enabled": false,
-                "start_page_redirect_url": ""
+                "enabled": true,
+                "start_page_redirect_url": "mainstreamcontent.modernising.opg.service.justice.gov.uk"
             }
         },
         "demo": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -91,7 +91,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": false
             },
-            "log_emitted_events": true
+            "log_emitted_events": true,
+            "start_page_redirects": {
+                "enabled": false,
+                "start_page_redirect_url": ""
+            }
         },
         "test": {
             "account_id": "653761790766",
@@ -184,7 +188,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": false
             },
-            "log_emitted_events": false
+            "log_emitted_events": false,
+            "start_page_redirects": {
+                "enabled": false,
+                "start_page_redirect_url": ""
+            }
         },
         "demo": {
             "account_id": "653761790766",
@@ -278,7 +286,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": true
             },
-            "log_emitted_events": true
+            "log_emitted_events": true,
+            "start_page_redirects": {
+                "enabled": true,
+                "start_page_redirect_url": "mainstreamcontent.modernising.opg.service.justice.gov.uk"
+            }
         },
         "codesign": {
             "account_id": "653761790766",
@@ -371,7 +383,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": true
             },
-            "log_emitted_events": false
+            "log_emitted_events": false,
+            "start_page_redirects": {
+                "enabled": false,
+                "start_page_redirect_url": ""
+            }
         },
         "ur": {
             "account_id": "653761790766",
@@ -464,7 +480,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": false
             },
-            "log_emitted_events": false
+            "log_emitted_events": false,
+            "start_page_redirects": {
+                "enabled": true,
+                "start_page_redirect_url": "ur.mainstreamcontent.modernising.opg.service.justice.gov.uk"
+            }
         },
         "preproduction": {
             "account_id": "792093328875",
@@ -557,7 +577,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": false
             },
-            "log_emitted_events": false
+            "log_emitted_events": false,
+            "start_page_redirects": {
+                "enabled": false,
+                "start_page_redirect_url": ""
+            }
         },
         "production": {
             "account_id": "313879017102",
@@ -650,7 +674,11 @@
                 "destination_account_id": "288342028542",
                 "enable_s3_batch_job_replication_scheduler": false
             },
-            "log_emitted_events": false
+            "log_emitted_events": false,
+            "start_page_redirects": {
+                "enabled": false,
+                "start_page_redirect_url": ""
+            }
         }
     }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -102,6 +102,11 @@ variable "environments" {
         enable_s3_batch_job_replication_scheduler = bool
       })
       log_emitted_events = bool
+      start_page_redirects = object({
+        enabled                 = bool
+        start_page_redirect_url = string
+      })
+
     })
   )
 }


### PR DESCRIPTION
# Purpose

Start pages in the app should be redirected to the mainstream content start pages

Fixes MLPAB-2977

## Approach

- add listener rule for donor start page
- add listener rule for attorney start page
- add listener rule for certificate provider start page 

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/5.95.0/docs/resources/lb_listener_rule.html
