### PR TITLE
MLPAB-2991 - schedule targetted apply for api destination credentials

### DIFF
--- a/.github/workflows/analysis-codeql.yml
+++ b/.github/workflows/analysis-codeql.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version: '^1.20'

--- a/.github/workflows/analysis-tfsec-pr-feedback.yml
+++ b/.github/workflows/analysis-tfsec-pr-feedback.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
       - name: tfsec with pr comments

--- a/.github/workflows/analysis-tfsec-to-github-security.yml
+++ b/.github/workflows/analysis-tfsec-to-github-security.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run tfsec
         uses: tfsec/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608 # v0.1.4
         with:

--- a/.github/workflows/detect_changes_to_app_job.yml
+++ b/.github/workflows/detect_changes_to_app_job.yml
@@ -11,7 +11,7 @@ jobs:
   compare_changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.ref }}
           fetch-depth: 0 # Fetch all history for all tags and branches

--- a/.github/workflows/dispatch_change_dns_target_region.yml
+++ b/.github/workflows/dispatch_change_dns_target_region.yml
@@ -37,7 +37,7 @@ jobs:
   change_dns_target_region:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
       - name: Configure AWS credentials for dns target region parameter change
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0

--- a/.github/workflows/dispatch_manage_maintenance_mode.yml
+++ b/.github/workflows/dispatch_manage_maintenance_mode.yml
@@ -41,7 +41,7 @@ jobs:
   manage_maintenance_mode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
       - name: Determine role to use for maintenance mode
         id: determine_role

--- a/.github/workflows/dispatch_manage_public_access_ur_environment.yml
+++ b/.github/workflows/dispatch_manage_public_access_ur_environment.yml
@@ -26,45 +26,10 @@ defaults:
     shell: bash
 
 jobs:
-  fetch_s3_av_version:
-    name: Fetch the S3 AV Zip version tag
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::311462405659:role/modernising-lpa-github-actions-ssm-get-parameter
-          role-duration-seconds: 900
-          role-session-name: GithubActionsSSMGetParameter
-      - name: Pull S3 AV Zip tag
-        id: pull_s3_av_tag
-        run: |
-          key="/opg-s3-antivirus/zip-version-main"
-          value=$(aws ssm get-parameter --name "$key" --query 'Parameter.Value' --output text 2>/dev/null || true)
-          echo "Using $key: $value"
-          echo "tag=${value}" >> $GITHUB_OUTPUT
-    outputs:
-      s3_av_scanner_zip_tag: ${{ steps.pull_s3_av_tag.outputs.tag }}
-
   ur_toggle_public_access:
     runs-on: ubuntu-latest
-    needs: [ fetch_s3_av_version ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: get lambda function zips
-        working-directory: ./terraform/environment/region/modules/s3_antivirus/
-        run: |
-          echo "Pulling AV lambda version: ${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}" >> $GITHUB_STEP_SUMMARY
-          wget https://github.com/ministryofjustice/opg-s3-antivirus/releases/download/${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}/lambda_layer-amd64.zip -O lambda_layer.zip
-          wget https://github.com/ministryofjustice/opg-s3-antivirus/releases/download/${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}/lambda_layer-amd64.zip.sha256sum -O lambda_layer.zip.sha256sum
-          sha256sum -c "lambda_layer.zip.sha256sum"
-          echo "Lambda Layer Zip SHA256 Hash: $(cat lambda_layer.zip.sha256sum)" >> $GITHUB_STEP_SUMMARY
-
-          wget https://github.com/ministryofjustice/opg-s3-antivirus/releases/download/${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}/myFunction-amd64.zip -O myFunction.zip
-          wget https://github.com/ministryofjustice/opg-s3-antivirus/releases/download/${{ needs.fetch_s3_av_version.outputs.s3_av_scanner_zip_tag }}/myFunction-amd64.zip.sha256sum -O myFunction.zip.sha256sum
-          sha256sum -c "myFunction.zip.sha256sum"
-          echo "Lambda Function Zip SHA256 Hash: $(cat myFunction.zip.sha256sum)" >> $GITHUB_STEP_SUMMARY
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
       - name: Parse terraform version
         id: tf_version_setup

--- a/.github/workflows/dispatch_trivy_scan_production.yml
+++ b/.github/workflows/dispatch_trivy_scan_production.yml
@@ -79,7 +79,7 @@ jobs:
       - name: check file exists
         if: ${{ hashFiles('trivy-results.txt') != '' }}
         run: rm -f trivy-results.txt
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Trivy Image Vulnerability Scanner for ${{ matrix.ecr_repository }}
         id: trivy_scan
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.ecr_repository }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.checkout_tag }}
 

--- a/.github/workflows/document_linting_job.yml
+++ b/.github/workflows/document_linting_job.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Lint markdown files
       uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1
       with:

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/remove_ingress_job.yml
+++ b/.github/workflows/remove_ingress_job.yml
@@ -23,7 +23,7 @@ jobs:
   remove_ingress:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
         name: Run Against Image/aws-cli-action
       - name: Manage Ingress/Configure AWS Credentials

--- a/.github/workflows/schedule_update_opg_metrics_credentials.yml
+++ b/.github/workflows/schedule_update_opg_metrics_credentials.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Terraform Init
         run: terraform init -input=false
         working-directory: ./terraform/account
-      - name: Terraform Toggle Public Access for UR
+      - name: Terraform Update API OPG Metrics API destination
         env:
           TF_WORKSPACE: ${{ matrix.environment }}
           TF_VAR_pagerduty_api_key: ${{ secrets.pagerduty_api_key }}

--- a/.github/workflows/schedule_update_opg_metrics_credentials.yml
+++ b/.github/workflows/schedule_update_opg_metrics_credentials.yml
@@ -1,12 +1,7 @@
-name: "[WD] Toggle public access to UR environment"
+name: "[Scheduled] Update OPG Metrics API key"
 
 on:
   workflow_dispatch:
-    inputs:
-      public_access_enabled:
-        description: 'Enable public access to the UR environment?'
-        required: true
-        type: boolean
 
 permissions:
   id-token: write
@@ -63,7 +58,7 @@ jobs:
         working-directory: ./terraform/environment
       - name: Terraform Toggle Public Access for UR
         env:
-          TF_WORKSPACE: ur
+          TF_WORKSPACE: test
           TF_VAR_pagerduty_api_key: ${{ secrets.pagerduty_api_key }}
         run: |
           terraform apply -lock-timeout=300s  -input=false -auto-approve -var public_access_enabled=${{ inputs.public_access_enabled }} \

--- a/.github/workflows/schedule_update_opg_metrics_credentials.yml
+++ b/.github/workflows/schedule_update_opg_metrics_credentials.yml
@@ -2,6 +2,8 @@ name: "[Scheduled] Update OPG Metrics API key"
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *' # Every 3 a.m.
 
 permissions:
   id-token: write
@@ -21,14 +23,24 @@ defaults:
     shell: bash
 
 jobs:
-  ur_toggle_public_access:
+  update_opg_metrics_api_keys:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: development
+            oidc_role: ""
+          - environment: preproduction
+            oidc_role: ""
+          - environment: production
+            oidc_role: ""
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
       - name: Parse terraform version
         id: tf_version_setup
-        working-directory: ./terraform/environment
+        working-directory: ./terraform/account
         run: |
           if [ -f ./versions.tf ]; then
             terraform_version=$(cat ./versions.tf | ../../scripts/terraform-version.sh)
@@ -37,7 +49,7 @@ jobs:
           fi
       - name: "Terraform version [${{ steps.tf_version_setup.outputs.TERRAFORM_VERSION }}]"
         run: echo "terraform version [${{ steps.tf_version_setup.outputs.TERRAFORM_VERSION }}]"
-        working-directory: ./terraform/environment
+        working-directory: ./terraform/account
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.tf_version_setup.outputs.TERRAFORM_VERSION }}
@@ -55,18 +67,13 @@ jobs:
           ssh-private-key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}
       - name: Terraform Init
         run: terraform init -input=false
-        working-directory: ./terraform/environment
+        working-directory: ./terraform/account
       - name: Terraform Toggle Public Access for UR
         env:
-          TF_WORKSPACE: test
+          TF_WORKSPACE: ${{ matrix.environment }}
           TF_VAR_pagerduty_api_key: ${{ secrets.pagerduty_api_key }}
         run: |
-          terraform apply -lock-timeout=300s  -input=false -auto-approve -var public_access_enabled=${{ inputs.public_access_enabled }} \
-            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress[0]' \
-            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_public_access_ingress_port_80[0]' \
-            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_port_80_redirect_ingress[0]' \
-            -target 'module.eu_west_1[0].module.app.aws_security_group_rule.app_loadbalancer_ingress[0]' \
-            -target 'module.eu_west_1[0].module.mock_onelogin[0].aws_security_group_rule.mock_onelogin_loadbalancer_public_access_ingress[0]' \
-            -target 'module.eu_west_1[0].aws_service_discovery_private_dns_namespace.internal' \
-            -target 'module.eu_west_1[0].aws_service_discovery_private_dns_namespace.mock_one_login'
-        working-directory: ./terraform/environment
+          terraform apply -lock-timeout=300s  -input=false -auto-approve \
+            -target 'aws_cloudwatch_event_api_destination.opg_metrics_put' \
+            -target 'aws_cloudwatch_event_connection.opg_metrics_put'
+        working-directory: ./terraform/account

--- a/.github/workflows/schedule_update_opg_metrics_credentials.yml
+++ b/.github/workflows/schedule_update_opg_metrics_credentials.yml
@@ -3,7 +3,7 @@ name: "[Scheduled] Update OPG Metrics API key"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *' # Every 3 a.m.
+    - cron: '10 2 * * *' # Every 3 a.m.
 
 permissions:
   id-token: write

--- a/.github/workflows/schedule_update_opg_metrics_credentials.yml
+++ b/.github/workflows/schedule_update_opg_metrics_credentials.yml
@@ -3,7 +3,7 @@ name: "[Scheduled] Update OPG Metrics API key"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '10 2 * * *' # Every 3 a.m.
+    - cron: '10 2 * * *' # Every 2:10 a.m.
 
 permissions:
   id-token: write

--- a/.github/workflows/tags_job.yml
+++ b/.github/workflows/tags_job.yml
@@ -20,7 +20,7 @@ jobs:
     if : ${{ inputs.changes_detected == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: '0'
       - name: Extract branch name

--- a/.github/workflows/terraform_account_job.yml
+++ b/.github/workflows/terraform_account_job.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       tag: ${{ steps.bump_version.outputs.tag }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: '0'
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1

--- a/.github/workflows/terraform_environment_job.yml
+++ b/.github/workflows/terraform_environment_job.yml
@@ -68,7 +68,7 @@ jobs:
       url: ${{ steps.terraform_outputs.outputs.url }}
       environment_config_json: ${{ steps.terraform_outputs.outputs.environment_config_json }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.checkout_tag }}
           fetch-depth: '0'

--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -66,7 +66,7 @@ jobs:
   run_ui_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.checkout_tag }}
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1

--- a/.github/workflows/workflow_destroy_pr_environment.yml
+++ b/.github/workflows/workflow_destroy_pr_environment.yml
@@ -47,7 +47,7 @@ jobs:
     needs: [ generate_environment_workspace_name ]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:

--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -22,7 +22,7 @@ jobs:
   terraform_environment_cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: '0'
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -25,6 +25,9 @@ resource "aws_cloudwatch_event_connection" "opg_metrics" {
     }
   }
   provider = aws.eu_west_1
+  lifecycle {
+    ignore_changes = [auth_parameters[0].invocation_http_parameters]
+  }
 }
 
 resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {


### PR DESCRIPTION
# Purpose

OPG Metrics rotates credentials on a daily basis. Lambda functions using OPG Metrics directly fetch API keys, but Event Bridge API destinations store a copy of the credentials. 

Fixes MLPAB-2991

## Approach

- Schedule a job after the API key rotation (2am) to update the stored credential
- Pin checkout action to patch version
- Remove AV lambda zip related jobs from UR job
- ignore invocation_http_parameters changes (this was triggering a removal of an empty attribute)

## Learning

- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
