### PR TITLE
MLPAB-2971: Add placeholder text when no restrictions

### DIFF
--- a/lang/cy.json
+++ b/lang/cy.json
@@ -57,7 +57,8 @@
     "errorReferenceNumber": "Rhaid i’r {{lowerFirst .Label}} ddechrau â’r rhif 7 neu’r llythyren M",
     "errorNoLinks": "Does dim modd cynnwys dolenni i wefannau yn {{lowerFirst .Label}} gan y byddan nhw’n gwneud eich LPA yn annilys",
     "donorMatchesActorWarning": "<p class=\"govuk-body\">Welsh {{lowerFirst .Type}} {{lowerFirst .ArticleAndType}}</p><p class=\"govuk-body\">Welsh {{lowerFirst .Type}} </p>",
-    "replacementAttorneyMatchesActorWarning": "Mae yna atwrnai wrth gefn hefyd o’r enw {{.FirstNames}} {{.LastName}}. Ni all atwrnai wrth gefn fod yn {{.ArticleAndType}}.", "replacementAttorneyMatchesReplacementAttorneyWarning": "Mae yna atwrnai wrth gefn yn barod o’r enw {{.FirstNames}} {{.LastName}}.",
+    "replacementAttorneyMatchesActorWarning": "Mae yna atwrnai wrth gefn hefyd o’r enw {{.FirstNames}} {{.LastName}}. Ni all atwrnai wrth gefn fod yn {{.ArticleAndType}}.",
+    "replacementAttorneyMatchesReplacementAttorneyWarning": "Mae yna atwrnai wrth gefn yn barod o’r enw {{.FirstNames}} {{.LastName}}.",
     "certificateProviderMatchesActorWarning": "{{.FirstNames}} {{.LastName}} yw enw’r darparwr tystysgrif hefyd. Ni all y darparwr tystysgrif fod yn {{.ArticleAndType}}.",
     "personToNotifyMatchesActorWarning": "Mae person i’w hysbysu hefyd o’r enw {{.FirstNames}} {{.LastName}}. Ni all person i’w hysbysu fod yn {{.ArticleAndType}}.",
     "personToNotifyMatchesPersonToNotifyWarning": "Mae yna berson i’w hysbysu yn barod o’r enw {{.FirstNames}} {{.LastName}}.",
@@ -1901,5 +1902,7 @@
     "checkYourAttorneysDetails": "Welsh",
     "dateOfBirthIsUnder18Attorney": "<p class=\"govuk-body\">Welsh</p>",
     "actorMatchesDifferentActorTypeWarning": "<p class=\"govuk-body\">Welsh {{.FirstNames}} {{.LastName}} {{lowerFirst .MatchArticleAndType}} </p><p class=\"govuk-body\">Welsh</p>",
-    "actorMatchesSameActorTypeWarning": "<p class=\"govuk-body\">Welsh {{.FirstNames}} {{.LastName}} {{lowerFirst .MatchArticleAndType}}</p><p class=\"govuk-body\">Welsh {{.TypePlural}}</p>"
+    "actorMatchesSameActorTypeWarning": "<p class=\"govuk-body\">Welsh {{.FirstNames}} {{.LastName}} {{lowerFirst .MatchArticleAndType}}</p><p class=\"govuk-body\">Welsh {{.TypePlural}}</p>",
+    "noRestrictionsOrConditionsAddedToLPA": "Welsh",
+    "add": "Welsh"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1802,5 +1802,7 @@
     "useTheTextBoxToAddRestrictionForAttorneys": "Use the text box to add a restriction to your LPA stating which decisions your attorneys must make jointly.",
     "seeExamplesOfRestrictionsInstructingAttorneys": "See examples of restrictions instructing attorneys to act jointly (opens in new tab)",
     "aRestrictionStatingWhichDecisionsYourAttorneysMustMakeJointly": "a restriction stating which decisions your attorneys must make jointly",
-    "checkYourAttorneysDetails": "Check your attorney’s details"
+    "checkYourAttorneysDetails": "Check your attorney’s details",
+    "noRestrictionsOrConditionsAddedToLPA": "No restrictions or conditions have been added to this LPA.",
+    "add": "Add"
 }

--- a/web/template/layout/changeable-contextual-lpa.gohtml
+++ b/web/template/layout/changeable-contextual-lpa.gohtml
@@ -450,7 +450,11 @@
 
     {{ template "contextual-lpa-warning" $app }}
 
-    <h3 class="govuk-heading-m">{{ tr $app "restrictions" }}</h3>
+    {{ $hasOtherRestrictions := or .Donor.AttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers .Donor.HowShouldReplacementAttorneysStepInDetails .Donor.ReplacementAttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers }}
+
+    {{ if $hasOtherRestrictions}}
+        <h3 class="govuk-heading-m">{{ tr $app "restrictions" }}</h3>
+    {{ end }}
 
     <dl class="govuk-summary-list app-stacked-summary-list">
         {{ if .Donor.AttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers }}
@@ -492,10 +496,36 @@
                 $donorFullName $canChange $isDonor) }}
         {{ end }}
 
-        {{ template "summary-row" (summaryRow $app "restrictions"
-            .Donor.Restrictions
-            (fromLink $app global.Paths.Restrictions "")
-            $donorFullName $canChange $isDonor) }}
+        {{/* Not using summary-row here due to complexities with heading logic */}}
+        <div class="govuk-summary-list__row{{ if or (eq "" .Donor.Restrictions) (not $canChange) }} govuk-summary-list__row--no-actions{{ end }}">
+            <dt class="govuk-summary-list__key">
+                {{ if $hasOtherRestrictions }}
+                    {{ tr $app "restrictions" }}
+                {{ else }}
+                    <h3 class="govuk-heading-m govuk-!-margin-bottom-1">{{ (tr $app "restrictions") }}</h3>
+                {{end}}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ if .Donor.Restrictions }}
+                    {{ .Donor.Restrictions }}
+                {{ else }}
+                    <p class="govuk-body">{{ tr $app "noRestrictionsOrConditionsAddedToLPA" }}</p>
+
+                    {{ if $canChange}}
+                        <a href="{{ (fromLink $app global.Paths.Restrictions "") }}" class="govuk-link">
+                            {{ tr $app "add" }} {{ lowerFirst (tr $app "restrictions") }} {{ if not $isDonor }} <span class="govuk-visually-hidden"> {{ trFormat $app "forFullName" "FullName" $donorFullName }}</span>{{ end }}
+                        </a>
+                    {{ end }}
+                {{ end }}
+            </dd>
+            {{ if and .Donor.Restrictions $canChange }}
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ (fromLink $app global.Paths.Restrictions "") }}">{{ tr $app "change" }}<span class="govuk-visually-hidden">
+                    {{ lowerFirst (tr $app "restrictions") }}{{ if not $isDonor }} {{ trFormat $app "forFullName" "FullName" $donorFullName }}{{ end }}
+                </span></a>
+                </dd>
+            {{ end }}
+        </div>
     </dl>
 
     {{ template "contextual-lpa-warning" $app }}

--- a/web/template/layout/contextual-lpa.gohtml
+++ b/web/template/layout/contextual-lpa.gohtml
@@ -256,7 +256,11 @@
 
     {{ template "contextual-lpa-warning" .App }}
 
-    <h3 class="govuk-heading-m">{{ tr .App "restrictions" }}</h3>
+    {{ $hasOtherRestrictions := or .Lpa.AttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers .Lpa.HowShouldReplacementAttorneysStepInDetails .Lpa.ReplacementAttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers }}
+
+    {{ if $hasOtherRestrictions}}
+        <h3 class="govuk-heading-m">{{ tr .App "restrictions" }}</h3>
+    {{ end }}
 
     <dl class="govuk-summary-list app-stacked-summary-list">
         {{ if .Lpa.AttorneyDecisions.How.IsJointlyForSomeSeverallyForOthers }}
@@ -274,8 +278,24 @@
                 .Lpa.ReplacementAttorneyDecisions.Details) }}
         {{ end }}
 
-        {{ template "text-summary-row" (staticSummaryRow .App "restrictions"
-            .Lpa.Restrictions) }}
+        {{/* Not using text-summary-row here due to complexities with heading logic */}}
+        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">
+                {{ if $hasOtherRestrictions }}
+                    {{ tr .App "restrictions" }}
+                {{ else }}
+                    <h3 class="govuk-heading-m govuk-!-margin-bottom-1">{{ (tr .App "restrictions") }}</h3>
+                {{end}}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ if .Lpa.Restrictions }}
+                    {{ .Lpa.Restrictions }}
+                {{ else }}
+                    <p class="govuk-body">{{ tr .App "noRestrictionsOrConditionsAddedToLPA" }}</p>
+                {{ end }}
+            </dd>
+        </div>
+
     </dl>
 
     {{ template "contextual-lpa-warning" .App }}

--- a/web/template/layout/text-summary-row.gohtml
+++ b/web/template/layout/text-summary-row.gohtml
@@ -1,7 +1,7 @@
 {{ define "text-summary-row" }}
     <div class="govuk-summary-list__row{{ if and (not .Static) (or (eq "" .Value) (not .CanChange)) }} govuk-summary-list__row--no-actions{{ end }}">
         <dt class="govuk-summary-list__key">{{ tr .App .Label }}</dt>
-        <dd class="govuk-summary-list__value app-wrap-text">
+        <dd class="govuk-summary-list__value {{ if .Value }}app-wrap-text{{ end }}">
             {{- if .Value -}}
                 {{- .Value -}}
             {{- else if .CanChange -}}


### PR DESCRIPTION
# Purpose

I've used HTML rather than one of the `summary-row` partials here as the combo of needing to suppress a heading (while remaining semantically correct) + add placeholder text was making the templates too complex.

Fixes MLPAB-2971
