### PR TITLE
MLPAB-2013 - replace underscores with hyphens in kms key names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: go-imports # Runs gofmt
       - id: go-mod-tidy # Tidies up and removes unused requires in go.mod using go mod tidy
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.261.4
+    rev: 40.10.4
     hooks:
       - id: renovate-config-validator
   - repo: local

--- a/terraform/account/kms_key_cloudwatch.tf
+++ b/terraform/account/kms_key_cloudwatch.tf
@@ -1,7 +1,7 @@
 module "cloudwatch_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "Cloudwatch application logs"
-  kms_key_alias_name      = "${local.default_tags.application}_cloudwatch_application_logs_encryption"
+  kms_key_alias_name      = "${local.default_tags.application}-cloudwatch-application-logs-encryption"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_dynamodb.tf
+++ b/terraform/account/kms_key_dynamodb.tf
@@ -1,7 +1,7 @@
 module "dynamodb_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "dynamodb"
-  kms_key_alias_name      = "${local.default_tags.application}_dynamodb_encryption"
+  kms_key_alias_name      = "${local.default_tags.application}-dynamodb-encryption"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_dynamodb_cloudtrail_log_group.tf
+++ b/terraform/account/kms_key_dynamodb_cloudtrail_log_group.tf
@@ -2,7 +2,7 @@
 module "dynamodb_cloudtrail_log_group" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "dynamodb cloudtrail log group"
-  kms_key_alias_name      = "${local.default_tags.application}_dynamodb_cloudtrail_log_group_encryption"
+  kms_key_alias_name      = "${local.default_tags.application}-dynamodb-cloudtrail-log-group-encryption"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_event_received_sqs.tf
+++ b/terraform/account/kms_key_event_received_sqs.tf
@@ -1,7 +1,7 @@
 module "event_received_sqs_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "SQS"
-  kms_key_alias_name      = "${local.default_tags.application}_event_received_sqs_secret_encryption_key"
+  kms_key_alias_name      = "${local.default_tags.application}-event-received-sqs-secret-encryption-key"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_reduced_fees_uploads_s3.tf
+++ b/terraform/account/kms_key_reduced_fees_uploads_s3.tf
@@ -1,7 +1,7 @@
 module "reduced_fees_uploads_s3_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "reduced_fees_uploads_s3_bucket"
-  kms_key_alias_name      = "${local.default_tags.application}_reduced_fees_uploads_s3_encryption"
+  kms_key_alias_name      = "${local.default_tags.application}-reduced-fees-uploads-s3-encryption"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_secrets_manager.tf
+++ b/terraform/account/kms_key_secrets_manager.tf
@@ -1,7 +1,7 @@
 module "secrets_manager_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "Secrets Manager secret"
-  kms_key_alias_name      = "${local.default_tags.application}_secrets_manager_secret_encryption_key"
+  kms_key_alias_name      = "${local.default_tags.application}-secrets-manager-secret-encryption-key"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/kms_key_sns.tf
+++ b/terraform/account/kms_key_sns.tf
@@ -1,7 +1,7 @@
 module "sns_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "SNS"
-  kms_key_alias_name      = "${local.default_tags.application}_sns_secret_encryption_key"
+  kms_key_alias_name      = "${local.default_tags.application}-sns-secret-encryption-key"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10
@@ -21,7 +21,7 @@ resource "aws_kms_replica_key" "sns_replica_global" {
 }
 
 resource "aws_kms_alias" "sns_alias_global" {
-  name          = "alias/${local.default_tags.application}_sns_secret_encryption_key"
+  name          = "alias/${local.default_tags.application}-sns-secret-encryption-key"
   target_key_id = aws_kms_replica_key.sns_replica_global.key_id
   provider      = aws.global
 }

--- a/terraform/account/kms_key_sqs.tf
+++ b/terraform/account/kms_key_sqs.tf
@@ -1,7 +1,7 @@
 module "sqs_kms" {
   source                  = "./modules/kms_key"
   encrypted_resource      = "SQS"
-  kms_key_alias_name      = "${local.default_tags.application}_sqs_secret_encryption_key"
+  kms_key_alias_name      = "${local.default_tags.application}-sqs-secret-encryption-key"
   enable_key_rotation     = true
   enable_multi_region     = true
   deletion_window_in_days = 10

--- a/terraform/account/modules/aws_backup_vault/data_sources.tf
+++ b/terraform/account/modules/aws_backup_vault/data_sources.tf
@@ -7,7 +7,7 @@ data "aws_default_tags" "current" {
 }
 
 data "aws_kms_alias" "sns_encryption_key" {
-  name     = "alias/${data.aws_default_tags.current.tags.application}_sns_secret_encryption_key"
+  name     = "alias/${data.aws_default_tags.current.tags.application}-sns-secret-encryption-key"
   provider = aws.region
 }
 


### PR DESCRIPTION
# Purpose

Meet standard for naming resources in terraform, using hyphens not underscores

Fixes MLPAB-2013

## Approach

- replace underscores with hyphens in KMS key aliases for account
- replace underscores with hyphens in KMS key aliases for environment
- upgrade precommit

This PR requires the account level resources to be applied before merging (because the environment relies on the aliases
