### PR TITLE
MLPAB-2975: Extracting content for review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ multi-reporter-config.json
 
 scripts/sbom_exporter/exports/*
 scripts/sbom_exporter/tmp.*.json
+
+/playwright-report/*
+/test-results/*
+/playwright/screenshots/*

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,6 @@
-const { defineConfig } = require("cypress");
+import {defineConfig} from 'cypress';
 
-module.exports = defineConfig({
+export default defineConfig({
   projectId: "xxbft5",
   e2e: {
     baseUrl: 'http://localhost:5050',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "opg-modernising-lpa",
     "version": "0.0.1",
+    "type": "module",
     "scripts": {
         "build": "yarn build:js && yarn build:fixtures-js && yarn build:css && yarn build:images && yarn build:fonts",
         "build:js": "node_modules/.bin/esbuild --bundle web/assets/main.js --minify --outdir=web/static/javascript --sourcemap --resolve-extensions=.mjs,.js",
@@ -12,7 +13,8 @@
         "cypress:run": "node_modules/.bin/cypress run -vvv",
         "cypress:parallel": "cypress-parallel -s cypress:run -t 6 --spec cypress/e2e/**/*.cy.js cypress/smoke/*.cy.js",
         "cypress:parallel-with-specs": "cypress-parallel -s cypress:run -t 2",
-        "test": "jest"
+        "test": "jest",
+        "extractContent": "npx playwright test complete-section-1.spec.js"
     },
     "license": "MIT",
     "dependencies": {
@@ -24,6 +26,8 @@
         "totp-generator": "^1.0.0"
     },
     "devDependencies": {
+        "@axe-core/playwright": "^4.10.1",
+        "@playwright/test": "^1.52.0",
         "axe-core": "4.10.3",
         "cypress": "14.3.3",
         "cypress-axe": "1.6.0",
@@ -31,6 +35,7 @@
         "cypress-multi-reporters": "2.0.5",
         "cypress-parallel": "0.15.0",
         "cypress-real-events": "1.14.0",
+        "playwright": "^1.52.0",
         "stop-only": "3.4.2"
     },
     "engines": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,84 @@
+import {defineConfig, devices} from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+    testDir: './playwright',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+    outputDir: 'test-results',
+
+    // Each test is given 60 seconds.
+    timeout: 60000,
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Base URL to use in actions like `await page.goto('/')`. */
+        baseURL: 'http://localhost:5050',
+
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: 'chromium',
+            use: {...devices['Desktop Chrome']},
+        },
+
+        // {
+        //   name: 'firefox',
+        //   use: { ...devices['Desktop Firefox'] },
+        // },
+        //
+        // {
+        //   name: 'webkit',
+        //   use: { ...devices['Desktop Safari'] },
+        // },
+
+        /* Test against mobile viewports. */
+        // {
+        //   name: 'Mobile Chrome',
+        //   use: { ...devices['Pixel 5'] },
+        // },
+        // {
+        //   name: 'Mobile Safari',
+        //   use: { ...devices['iPhone 12'] },
+        // },
+
+        /* Test against branded browsers. */
+        // {
+        //   name: 'Microsoft Edge',
+        //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+        // },
+        // {
+        //   name: 'Google Chrome',
+        //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        // },
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: {
+    //   command: 'npm run start',
+    //   url: 'http://127.0.0.1:3000',
+    //   reuseExistingServer: !process.env.CI,
+    // },
+});

--- a/playwright/complete-donor-flow.spec.js
+++ b/playwright/complete-donor-flow.spec.js
@@ -1,0 +1,497 @@
+import {expect, test} from '@playwright/test';
+import {screenshot} from './e2e'
+import {extractTextFromMainAndSave} from "./textExtractor";
+
+test('donor happy path', async ({page}) => {
+    await page.goto('http://localhost:5050/start');
+    await page.getByRole('button', {name: 'Start'}).click();
+
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await page.getByRole('button', {name: 'Accept analytics cookies'}).click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Start now'}).click();
+
+    await expect(page).toHaveURL(/\/your-name/);
+    await page.getByLabel('First names').fill('Samuel');
+    await page.getByLabel('Last name').fill('Smith');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-date-of-birth/);
+    await page.getByLabel('Day').fill('01');
+    await page.getByLabel('Month').fill('01');
+    await page.getByLabel('Year').fill('2000');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/do-you-live-in-the-uk/);
+    await page.getByRole('group', {name: 'Do you live in the UK, the Channel Islands or the Isle of Man?'}).getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-address/);
+    await page.getByLabel('Postcode').fill('B14 7ED');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByLabel('Postcode').press('Enter');
+
+    await expect(page).toHaveURL(/\/your-address/);
+    await page.getByLabel('Select an address').selectOption('{"line1":"1 RICHMOND PLACE","line2":"","line3":"","town":"BIRMINGHAM","postcode":"B14 7ED","country":"GB"}');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-address/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/receiving-updates-about-your-lpa/);
+    await page.getByText('If you do not want to be contacted about your LPA').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/can-you-sign-your-lpa/);
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-preferred-language/);
+    await page.getByText('How to change the language to Welsh').click();
+    await page.getByRole('group', {name: 'Which language would you prefer us to use when we contact you?'}).getByLabel('English').check();
+    await page.getByRole('group', {name: 'In which language would you'}).getByLabel('English').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-legal-rights-and-responsibilities-if-you-make-an-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/lpa-type/);
+    await page.getByLabel('Property and affairs').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+
+    // Give UID service time to return UID
+    await expect.poll(async () => {
+        await page.reload();
+        const referenceNumber = page.getByText('M-');
+        return await referenceNumber.isVisible() && (await referenceNumber.innerText()) !== "";
+    }, {
+        timeout: 20000,
+        intervals: [500]
+    }).toBe(true);
+
+    await page.getByText('Help with making this LPA').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Choose your attorneys'}).click();
+
+    await expect(page).toHaveURL(/\/choose-attorneys-guidance/);
+    await page.getByText('Trust corporations', { exact: true }).click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-attorneys/);
+    await page.getByText('Guidance on choosing an attorney').click();
+    await page.getByLabel('First names').fill('Test');
+    await page.getByLabel('Last name').fill('Testington');
+    await page.getByLabel('Day').fill('01');
+    await page.getByLabel('Month').fill('0');
+    await page.getByLabel('Month').fill('01');
+    await page.getByLabel('Year').fill('2000');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-attorneys-address/);
+    await page.getByLabel('Use an address you’ve already').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-attorneys-address/);
+    await page.getByText('1 RICHMOND PLACE').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-attorneys-summary/);
+    await page.getByLabel('No').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Choose your replacement attorneys'}).click();
+    await page.getByLabel('Yes, I want replacement attorneys').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-replacement-attorneys/);
+    await page.getByLabel('First names').fill('Testy');
+    await page.getByLabel('Last name').fill('Testingtons');
+    await page.getByLabel('Day').fill('01');
+    await page.getByLabel('Month').fill('0');
+    await page.getByLabel('Month').fill('01');
+    await page.getByLabel('Year').fill('2000');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-replacement-attorneys-address/);
+    await page.getByLabel('Use an address you’ve already').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-replacement-attorneys-address/);
+    await page.getByText('1 RICHMOND PLACE').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-replacement-attorneys-summary/);
+    await page.getByLabel('No').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Choose when your LPA can be used'}).click();
+
+    await expect(page).toHaveURL(/\/when-can-the-lpa-be-used/);
+    await page.getByLabel('Whether or not I have mental capacity to make a particular decision myself').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Add restrictions to the LPA'}).click();
+
+    await expect(page).toHaveURL(/\/restrictions/);
+    await page.getByText('Show me some examples').click();
+    await page.getByLabel('Restrictions and conditions (optional)').fill('Dont sell my house');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Choose your certificate provider'}).click();
+
+    await expect(page).toHaveURL(/\/what-a-certificate-provider-does/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-your-certificate-provider/);
+    await page.getByText('Examples of who could act as a professional certificate provider').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/certificate-provider-details/);
+    await page.getByLabel('First names').fill('Joe');
+    await page.getByLabel('Last name').fill('Bloggs');
+    await page.getByLabel('UK mobile number', {exact: true}).fill('07535949272');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/how-do-you-know-your-certificate-provider/);
+    await page.getByLabel('Personally').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/how-long-have-you-known-certificate-provider/);
+    await page.getByLabel('2 years or more').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/how-would-certificate-provider-prefer-to-carry-out-their-role/);
+    await page.getByLabel('By email').check();
+    await page.getByLabel('Certificate provider’s email').fill('alex.saunders@digital.justice.gov.uk');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/certificate-provider-address/);
+    await page.getByLabel('Use an address you’ve already').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/certificate-provider-address/);
+    await page.getByLabel('1 RICHMOND PLACE').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'People to notify about your LPA'}).click();
+
+    await expect(page).toHaveURL(/\/do-you-want-to-notify-people/);
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-people-to-notify/);
+    await page.getByLabel('First names').fill('Joette');
+    await page.getByLabel('Last name').fill('Blogger');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-people-to-notify-address/);
+    await page.getByLabel('Use an address you’ve already').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-people-to-notify-address/);
+    await page.getByLabel('1 RICHMOND PLACE').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/choose-people-to-notify-summary/);
+    await page.getByLabel('No').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Add a correspondent'}).click();
+
+    await expect(page).toHaveURL(/\/add-correspondent/);
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/enter-correspondent-details/);
+    await page.getByLabel('First names').fill('Joettey');
+    await page.getByLabel('Last name').fill('Bloggers');
+    await page.getByLabel('Email address').fill('a@b.com');
+    await page.getByLabel('Organisation (optional)').fill('Blogger corp');
+    await page.getByLabel('Phone number (optional)').fill('07535949272');
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/enter-correspondent-address/);
+    await page.getByLabel('Use an address you’ve already').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/enter-correspondent-address/);
+    await page.getByLabel('1 RICHMOND PLACE').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Check and send to your certificate provider'}).click();
+
+    await expect(page).toHaveURL(/\/confirm-your-certificate-provider-is-not-related/);
+    await page.getByLabel('I confirm that my certificate provider is not related to me or any of my attorneys').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/check-your-lpa/);
+    await page.getByText('Why can’t I change my LPA type?').click();
+    await page.getByText('What happens if I need to make changes later?').click();
+    await page.getByLabel('I’ve checked this LPA and I’m happy for OPG to share it with my certificate provider').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Confirm'}).click();
+
+    await expect(page).toHaveURL(/\/lpa-details-saved/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Return to task list'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Pay for the LPA'}).click();
+
+    await expect(page).toHaveURL(/\/about-payment/);
+    await page.getByText('Who is eligible for an exemption').click();
+    await page.getByText('Paying a half fee based on your income').click();
+    await page.getByText('Who is eligible for a repeat application discount').click();
+    await page.getByText('What you need to make a hardship application').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/are-you-applying-for-fee-discount-or-exemption/);
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click({timeout: 30000});
+
+    await expect(page).toHaveURL(/\/which-fee-type-are-you-applying-for/);
+    await page.getByLabel('No fee (an exemption)').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click({timeout: 30000});
+
+    await expect(page).toHaveURL(/\/evidence-required/);
+    await page.getByText('Eligible means-tested benefits').click();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/how-would-you-like-to-send-evidence/);
+    await page.getByLabel('Send it by post').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/send-us-your-evidence-by-post/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/pending-payment/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Return to task list'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Confirm your identity'}).click();
+
+    await expect(page).toHaveURL(/\/confirm-your-identity/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    // mock GOL
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/identity-details/);
+    await page.getByLabel('Yes').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/identity-details-updated/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/check-your-lpa/);
+    await page.getByText('Why can’t I change my LPA type?').click();
+    await page.getByLabel('I’ve checked this LPA and I’m happy for OPG to share it with my certificate provider, Joe Bloggs').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Confirm'}).click();
+
+    await expect(page).toHaveURL(/\/lpa-details-saved/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Return to task list'}).click();
+
+    await expect(page).toHaveURL(/\/task-list/);
+    await page.getByRole('link', {name: 'Sign the LPA'}).click();
+
+    await expect(page).toHaveURL(/\/how-to-sign-your-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Start'}).click();
+
+    await expect(page).toHaveURL(/\/your-lpa-language/);
+    await page.getByLabel('Register my LPA in English').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Save and continue'}).click();
+
+    await expect(page).toHaveURL(/\/read-your-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/your-legal-rights-and-responsibilities/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue to signing page'}).click();
+
+    await expect(page).toHaveURL(/\/sign-your-lpa/);
+    await page.getByText('What happens once I’ve signed?').click();
+    await page.getByText('How ticking the boxes acts as your legal signature').click();
+    await page.getByLabel('I want to sign this LPA as a deed').check();
+    await page.getByLabel('I want to apply to register this LPA').check();
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Submit my signature'}).click();
+
+    await expect(page).toHaveURL(/\/witnessing-your-signature/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/witnessing-as-certificate-provider/);
+    await page.getByText('I’m having a problem with the witness code').click();
+    await page.getByLabel('Enter code').fill('1234');
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/you-have-submitted-your-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Continue'}).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Actions'}).click();
+    await page.getByRole('link', {name: 'Check LPA progress'}).click();
+
+    await expect(page).toHaveURL(/\/progress/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Return to dashboard'}).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await page.getByRole('button', {name: 'Actions'}).click();
+    await page.getByRole('link', {name: 'View LPA'}).click();
+
+    await expect(page).toHaveURL(/\/view-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('link', {name: 'Manage your LPAs'}).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await page.getByRole('button', {name: 'Actions'}).click();
+    await page.getByRole('link', {name: 'Revoke LPA'}).click();
+
+    await expect(page).toHaveURL(/\/withdraw-this-lpa/);
+    await screenshot(page)
+    await extractTextFromMainAndSave(page)
+    await page.getByRole('button', {name: 'Revoke this LPA'}).click();
+
+    // error with LPA store
+    // await expect(page).toHaveURL(/\/lpa-withdrawn/);
+});
+

--- a/playwright/e2e.js
+++ b/playwright/e2e.js
@@ -1,0 +1,41 @@
+import {expect} from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright'
+
+export const
+    TestEmail = 'simulate-delivered@notifications.service.gov.uk',
+    TestEmail2 = 'simulate-delivered-2@notifications.service.gov.uk',
+    TestMobile = '07700900000'
+
+export function randomShareCode() {
+    const characters = 'abcdefghijklmnpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789'
+    let result = [];
+
+    for (let i = 0; i < 12; i++) {
+        result.push(characters.charAt(Math.floor(Math.random() * characters.length)));
+    }
+
+    return result.join('');
+}
+
+export async function checkA11y(page) {
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .exclude('.govuk-phase-banner')
+        .analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+}
+
+export async function visitLpa(path, page) {
+    console.log(page.url())
+    await page.goto(page.url().split('/').slice(0, 5).join('/') + path);
+}
+
+export function sanitisedPath(page) {
+    const parts = page.url().split('/')
+    return parts[parts.length - 1].replace(/\//g, ' ')
+}
+
+export async function screenshot(page) {
+    await page.screenshot({ path: `playwright/screenshots/${Date.now()} ${sanitisedPath(page)}.png`, fullPage: true });
+}

--- a/playwright/textExtractor.js
+++ b/playwright/textExtractor.js
@@ -1,0 +1,189 @@
+import {sanitisedPath} from "./e2e";
+import fs from "fs";
+
+// So it's usable in browser context but still testable
+function browserTextExtractorLogic() {
+    function parseChildrenNodes(element) {
+        const isSummaryList = element.classList.contains('govuk-summary-list__row');
+        const isListItem = element.tagName.toLowerCase() === 'li';
+        let prependChar = '';
+
+        if (isSummaryList) {
+            prependChar = '|';
+        } else if (isListItem) {
+            prependChar = '•';
+        }
+
+        let textParts = [];
+
+        function processNode(node) {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.tagName.toLowerCase() === 'a') {
+                    textParts.push(`[LINK: ${node.textContent.trim()}](${node.href})`)
+                } else if (node.tagName.toLowerCase() === 'span') {
+                    textParts.push(`${node.textContent.trim()}`)
+                } else {
+                    Array.from(node.childNodes).forEach(processNode)
+                }
+            } else if (node.nodeType === Node.TEXT_NODE) {
+                const textContent = node.textContent?.replace(/\s+/g, " ").trim()
+                if (textContent) {
+                    textParts.push(prependChar && !textParts.some(part => part.startsWith('•')) ? `${prependChar} ${textContent}` : `${textContent}`)
+                }
+            }
+        }
+
+        Array.from(element.childNodes).forEach(processNode);
+
+        let finalText = textParts.join(' ');
+
+        if (isSummaryList) {
+            const childElements = Array.from(element.children);
+            const parts = [];
+
+            childElements.forEach(childEl => {
+                let childText = '';
+                Array.from(childEl.childNodes).forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        if (node.tagName.toLowerCase() === 'a') {
+                            childText += `[LINK: ${node.textContent.trim()}](${node.href}) `;
+                        } else {
+                            childText += `${node.textContent.trim()} `;
+                        }
+                    } else if (node.nodeType === Node.TEXT_NODE) {
+                        const textContent = node.textContent?.replace(/\s+/g, " ").trim();
+                        if (textContent) {
+                            childText += `${textContent} `;
+                        }
+                    }
+                });
+                parts.push(childText.trim());
+            });
+
+            finalText = '| ' + parts.join(' | ') + ' |';
+        }
+
+        return finalText.trim() + '\n\n';
+    }
+
+    function getElementText(element) {
+        const tagName = element.tagName.toLowerCase();
+        const type = element.getAttribute('type');
+        const classList = element.classList;
+        let text = '';
+
+        if ( ['label', 'option', 'script', 'style'].includes(tagName) ||
+            ['govuk-visually-hidden', 'govuk-hint', 'govuk-!-display-none', 'app-dialog', 'govuk-warning-text__icon'].some(
+                cls => element.classList.contains(cls))
+        ) {
+            return '';
+        }
+
+        if ( ['p', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tagName) ||
+            classList.contains('govuk-summary-list__row')) {
+            return parseChildrenNodes(element);
+        }
+
+        switch (true) {
+            case (classList.contains('govuk-button') ||
+                tagName === 'button' ||
+                (tagName === 'input' && type === 'button') ||
+                (tagName === 'a' && element.getAttribute('role') === 'button')):
+                const textContent = element.textContent.trim()
+                text += `[BUTTON: ${textContent ? textContent : element.value}]\n\n`;
+                break;
+
+            case (tagName === 'input' && (type === 'radio' || type === 'checkbox')):
+                const checked = element.checked ? '(checked)' : '(unchecked)';
+                const label = document.querySelector(`label[for="${element.id}"]`);
+                const labelText = label ? label.textContent.trim() : (element.value || '');
+                text += `[${type.toUpperCase()} ${checked}: ${labelText}]\n\n`;
+                break;
+
+            case (tagName === 'select'):
+                const options = Array.from(element.options)
+                    .map(option => {
+                        return (option.selected ? '> ' : '') + (option.textContent ? option.textContent.trim() : '<NO TEXT>');
+                    })
+                    .join('\n');
+                text += `[SELECT: ${element.name || ''}]\n${options}\n\n`;
+                break;
+
+            case ((tagName === 'input' || tagName === 'textarea') && !['checkbox', 'select', 'radio', 'hidden', 'button'].includes(type)):
+                const inputTextareaLabel = element.id ? document.querySelector(`label[for="${element.id}"]`) : null;
+                const inputTextareaLabelText = inputTextareaLabel ? inputTextareaLabel.textContent.trim() : '';
+                const inputTextareaHint = element.closest('.govuk-form-group')?.querySelector('.govuk-hint') ||
+                    element.parentNode?.querySelector('.govuk-hint');
+
+                text += inputTextareaLabelText ? `${inputTextareaLabelText}\n` : '';
+                if (inputTextareaHint) {
+                    text += `${inputTextareaHint.textContent.trim()}\n`;
+                }
+                const value = element.value || '<NO VALUE>';
+                text += tagName === 'input' ? `[INPUT: ${value}]\n\n` : `[TEXTAREA: ${value}]\n\n`;
+                break;
+
+            case element.classList.contains('govuk-error-message'):
+                text += `[ERROR: ${element.textContent?.replace(/\s+/g, " ").trim()}]\n\n`;
+                break;
+
+            case element.classList.contains('govuk-warning-text'):
+                text += `[WARNING: ${element.textContent?.replace(/\s+/g, " ").trim()}]\n\n`;
+                break;
+
+            case tagName.toLowerCase() === 'a':
+                const linkText = element.textContent ? element.textContent.replace(/\s+/g, " ").trim() : '<NO TEXT>';
+                const href = element.href || '<NO HREF>';
+                if (!element.closest('p, li, .govuk-summary-list__row')) {
+                    text += `[LINK: ${linkText}](${href})\n\n`;
+                }
+                break;
+
+            default:
+                if (element.childNodes.length === 0 ||
+                    (element.childNodes.length === 1 && element.childNodes[0].nodeType === Node.TEXT_NODE)) {
+                    if (element.textContent && !element.parentNode.classList.contains('govuk-warning-text'))  {
+                        text += `${element.textContent.trim()}\n\n`;
+                    }
+                }
+                break;
+        }
+
+        for (const child of element.children) {
+            text += getElementText(child);
+        }
+
+        return text;
+    }
+
+    const main = document.querySelector('main');
+    if (!main) {
+        return 'No main element found';
+    }
+
+    const mainContentText = getElementText(main);
+
+    return `[PAGE TITLE: ${document.title}]\n\n` + mainContentText;
+}
+
+
+export async function extractTextFromMainAndSave(page) {
+    const textContent = await page.evaluate(browserTextExtractorLogic);
+
+    try {
+        const dir = 'playwright/screenshots';
+        if (!fs.existsSync(dir)){
+            fs.mkdirSync(dir, { recursive: true });
+        }
+        const filename = `playwright/screenshots/${Date.now()} ${sanitisedPath(page)}.txt`;
+
+        if (!filename.includes('about:blank')) {
+            fs.writeFileSync(filename, textContent, 'utf8');
+            console.log(`Text content saved to ${filename}`);
+        }
+    } catch (error) {
+        console.error(`Failed to save text content: ${error.message}`);
+    }
+
+    return textContent;
+}

--- a/playwright/textExtractor.test.js
+++ b/playwright/textExtractor.test.js
@@ -1,0 +1,356 @@
+import {expect, test} from '@playwright/test';
+import {extractTextFromMainAndSave} from './TextExtractor';
+
+test.describe('extractTextFromMainAndSave', () => {
+
+    test('should handle missing main element', async ({ page }) => {
+        await page.setContent('<body><h1>Outside Main</h1></body>');
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe('No main element found');
+    });
+
+    test('should handle empty main content', async ({ page }) => {
+        await page.setContent('<main></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\n`);
+    });
+
+    test('should extract text from a paragraph', async ({ page }) => {
+        await page.setContent('<main><p>Some plain text.</p></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\nSome plain text.\n\n`);
+    });
+
+    test('should prepend "|" and separate elements in a complex summary list row (2 dd)', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <div class="govuk-summary-list__row">
+                    <dt>Row title <span>with context</span> and text after</dt>
+                    <dd>
+                        Action text
+                        <a href="https://www.example.com/a-link">link</a>
+                        and more text
+                    </dd>
+                </div>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\n| Row title with context and text after | Action text [LINK: link](https://www.example.com/a-link) and more text |\n\n`);
+    });
+
+    test('should prepend "|" and separate elements in a complex summary list row (3 dd)', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <div class="govuk-summary-list__row">
+                    <dt>Row title <span>with context</span> and text after</dt>
+                    <dd>Row value</dd>
+                    <dd>
+                        Action text
+                        <a href="https://www.example.com/a-link">link</a>
+                        and more text
+                    </dd>
+                </div>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\n| Row title with context and text after | Row value | Action text [LINK: link](https://www.example.com/a-link) and more text |\n\n`);
+    });
+
+    test('should prepend "•" for list items', async ({ page }) => {
+        await page.setContent('<main><ul><li>List item.</li></ul></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\n• List item.\n\n`);
+    });
+
+    test('should not add more than one "•" for list items with nested content', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <ul>
+                    <li>
+                        List item with a
+                        <a href="https://www.example.com/a-link">link</a>
+                        and more content
+                    </li>
+                </ul>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\n• List item with a [LINK: link](https://www.example.com/a-link) and more content\n\n`);
+    });
+
+    test('should extract link with markdown formatting within a paragraph', async ({ page }) => {
+        await page.setContent('<main><p>See <a href="https://example.com">Example Link</a>.</p></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\nSee [LINK: Example Link](https://example.com/) .\n\n`);
+    });
+
+    test('should handle mixed content in a paragraph', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <p>
+                    First part.
+                    <a href="https://test.com">Test Link</a>
+                          Second part.
+                </p>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\nFirst part. [LINK: Test Link](https://test.com/) Second part.\n\n`);
+    });
+
+    test('should handle multiple child nodes in a paragraph', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <p>
+                    <span>Span one.</span>
+                    <span>Span two.</span>
+                    <span>Span three.</span>
+                </p>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toBe(`[PAGE TITLE: ${defaultTitle}]\n\nSpan one. Span two. Span three.\n\n`);
+    });
+
+    test('ignores certain elements', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <p>Visible text before.</p>
+                <label>Ignore this label</label>
+                <option value="1">Ignore this option</option>
+                <script>alert('ignore me')</script>
+                <style>body { color: red; }</style>
+                <p>Visible text after.</p>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('Visible text before.\n\n');
+        expect(textContent).toContain('Visible text after.\n\n');
+
+        expect(textContent).not.toContain('Ignore this label');
+        expect(textContent).not.toContain('Ignore this option');
+        expect(textContent).not.toContain('ignore me');
+        expect(textContent).not.toContain('body { color: red; }');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nVisible text before.\n\nVisible text after.\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('ignores elements with certain classes', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <p>Visible text before.</p>
+                <div class="govuk-visually-hidden">Ignore visually hidden</div>
+                <div class="govuk-hint">Ignore hint</div>
+                <div class="govuk-!-display-none">Ignore display none</div>
+                <div class="app-dialog">Ignore dialog</div>
+                <div class="govuk-warning-text__icon">Ignore warning icon</div>
+                <p>Visible text after.</p>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('Visible text before.\n\n');
+        expect(textContent).toContain('Visible text after.\n\n');
+
+        expect(textContent).not.toContain('Ignore visually hidden');
+        expect(textContent).not.toContain('Ignore hint');
+        expect(textContent).not.toContain('Ignore display none');
+        expect(textContent).not.toContain('Ignore dialog');
+        expect(textContent).not.toContain('Ignore warning icon');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nVisible text before.\n\nVisible text after.\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+
+    test('handles buttons and button-like elements', async ({ page }) => {
+        await page.setContent('<main><button>Click Me</button><input type="button" value="Submit"><a href="#" role="button">Go</a></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('[BUTTON: Click Me]\n\n');
+        expect(textContent).toContain('[BUTTON: Submit]\n\n');
+        expect(textContent).toContain('[BUTTON: Go]\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\n[BUTTON: Click Me]\n\n[BUTTON: Submit]\n\n[BUTTON: Go]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles radio and checkbox elements', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <div>
+                    <input type="radio" id="radio1" checked>
+                    <label for="radio1">Option 1</label>
+                </div>
+                 <div>
+                    <input type="checkbox" id="checkbox1">
+                    <label for="checkbox1">Option 2</label>
+                </div>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain("[RADIO (checked): Option 1]\n\n");
+        expect(textContent).toContain("[CHECKBOX (unchecked): Option 2]\n\n");
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\n[RADIO (checked): Option 1]\n\n[CHECKBOX (unchecked): Option 2]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles selects', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <select name="mySelect">
+                    <option value="a">Option A</option>
+                    <option value="b" selected>Option B</option>
+                    <option value="c">Option C</option>
+                </select>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain("[SELECT: mySelect]\nOption A\n> Option B\nOption C\n\n");
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\n[SELECT: mySelect]\nOption A\n> Option B\nOption C\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles text inputs with label and hint', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="myInput">Enter Name</label>
+                    <div class="govuk-hint">Your full name</div>
+                    <input class="govuk-input" id="myInput" type="text" value="John Doe">
+                </div>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain("Enter Name\nYour full name\n[INPUT: John Doe]\n\n");
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nEnter Name\nYour full name\n[INPUT: John Doe]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles textareas with label and hint', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="myTextarea">Your Message</label>
+                    <div class="govuk-hint">Keep it concise</div>
+                    <textarea class="govuk-textarea" id="myTextarea">Hello World</textarea>
+                </div>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain("Your Message\nKeep it concise\n[TEXTAREA: Hello World]\n\n");
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nYour Message\nKeep it concise\n[TEXTAREA: Hello World]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+
+    test('ignores hidden inputs', async ({ page }) => {
+        await page.setContent('<main><p>Visible content.</p><input type="hidden" value="A value"></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('Visible content.\n\n');
+        expect(textContent).not.toContain('A value');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nVisible content.\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles headers 1-6', async ({ page }) => {
+        await page.setContent(`
+            <main>
+                <h1>  Header 1 content  </h1>
+                <h2>Header 2</h2>
+                <h3>Header 3 <span class="govuk-summary-card__title">with span content </span></h3>
+                <h4>Header 4</h4>
+                <h5>Header 5</h5>
+                <h6>Header 6</h6>
+            </main>
+        `);
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('Header 1 content\n\n');
+        expect(textContent).toContain('Header 2\n\n');
+        expect(textContent).toContain('Header 3 with span content\n\n');
+        expect(textContent).toContain('Header 4\n\n');
+        expect(textContent).toContain('Header 5\n\n');
+        expect(textContent).toContain('Header 6\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nHeader 1 content\n\nHeader 2\n\nHeader 3 with span content\n\nHeader 4\n\nHeader 5\n\nHeader 6\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles error elements', async ({ page }) => {
+        await page.setContent('<main><div class="govuk-error-message">  Error message </div></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('[ERROR: Error message]\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\n[ERROR: Error message]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles warning elements', async ({ page }) => {
+        await page.setContent('<main><div class="govuk-warning-text">    <strong class="govuk-warning-text__text">   Content  </strong></div></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain('[WARNING: Content]\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\n[WARNING: Content]\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles other elements with direct text nodes', async ({ page }) => {
+        await page.setContent('<main><div>  Some text </div></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain(`[PAGE TITLE: ${defaultTitle}]`);
+        expect(textContent).toContain('Some text\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nSome text\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+
+    test('handles other elements with child text nodes', async ({ page }) => {
+        await page.setContent('<main><div><span>  Some text </span></div></main>');
+        const defaultTitle = await page.title();
+        const textContent = await extractTextFromMainAndSave(page);
+
+        expect(textContent).toContain(`[PAGE TITLE: ${defaultTitle}]`);
+        expect(textContent).toContain('Some text\n\n');
+
+        const expectedText = `[PAGE TITLE: ${defaultTitle}]\n\nSome text\n\n`;
+        expect(textContent).toBe(expectedText);
+    });
+});

--- a/web/template/donor/your_legal_rights_and_responsibilities.gohtml
+++ b/web/template/donor/your_legal_rights_and_responsibilities.gohtml
@@ -11,12 +11,12 @@
       
       {{ trHtml .App (printf "yourLegalRightsAndResponsibilitiesContent:%s" .Donor.Type.String) }}
 
-      <p class="govuk-button-group govuk-!-margin-top-8">
+      <div class="govuk-button-group govuk-!-margin-top-8">
         <a href="{{ if .Donor.Donor.CanSign.IsYes }}{{ link .App (global.Paths.SignYourLpa.Format .App.LpaID) }}{{ else }}{{ link .App (global.Paths.SignTheLpaOnBehalf.Format .App.LpaID) }}{{ end }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
           {{ tr .App "continueToSigningPage" }}
         </a>
         <a href="{{ link .App (global.Paths.TaskList.Format .App.LpaID) }}" class="govuk-button govuk-button--secondary">{{ tr .App "returnToTaskList" }}</a>
-      </p>
+      </div>
     </div>
   </div>
 {{ end }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,13 @@
   dependencies:
     tslib "^2.3.1"
 
+"@axe-core/playwright@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.10.1.tgz#c811ba8bfa244833cce422c4131e0043828c42cc"
+  integrity sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==
+  dependencies:
+    axe-core "~4.10.2"
+
 "@babel/runtime@^7.16.0":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
@@ -326,6 +333,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.52.0":
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.52.0.tgz#267ec595b43a8f4fa5e444ea503689629e91a5b8"
+  integrity sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==
+  dependencies:
+    playwright "1.52.0"
+
 "@smithy/fetch-http-handler@^4.1.0":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz#fc590dea2470d32559ae298306f1277729d24aa9"
@@ -602,7 +616,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.0.tgz#d9b802e9bb9c248d7be5f7f5ef178dc3684e9dcc"
   integrity sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==
 
-axe-core@4.10.3:
+axe-core@4.10.3, axe-core@~4.10.2:
   version "4.10.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
@@ -1282,6 +1296,11 @@ fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -1938,6 +1957,20 @@ pify@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+
+playwright-core@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.52.0.tgz#238f1f0c3edd4ebba0434ce3f4401900319a3dca"
+  integrity sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==
+
+playwright@1.52.0, playwright@^1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.52.0.tgz#26cb9a63346651e1c54c8805acfd85683173d4bd"
+  integrity sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==
+  dependencies:
+    playwright-core "1.52.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
# Purpose

I tried a couple of approaches here.

Firstly, trying to utilise existing handler unit tests would have been a way to make the tests part of the app code but it required some clunky setup and (as you'll see from the screenshot) needs a populated LPA/template data to work and so lots of extra scaffolding in all tests so I've disregarded this.

Then I tried to extract the content using a custom text extractor script. Its not pretty but its got things in the format I was looking for.

Lastly I bought in a 3rd party package to try extracting it as markdown.

You can see the results of both in zips on the ticket for a comparison of the formatting or run yourself with the new commands added to package.json.

Fixes MLPAB-2975
