### PR TITLE
Bump lambda/provided image to latest

### DIFF
--- a/docker/create-s3-replication-job/Dockerfile
+++ b/docker/create-s3-replication-job/Dockerfile
@@ -10,7 +10,7 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o create-s3-replication-job ./cmd/create-s3-replication-job
 
-FROM public.ecr.aws/lambda/provided:al2023.2025.02.18.01@sha256:edcd0b012f44ce1e87bf865addb662d4be0d62b3a9d8ee72e3c4284a733343b6 AS production
+FROM public.ecr.aws/lambda/provided:al2023.2025.05.04.04@sha256:fed9eb1f995d9c1f714794e3c2223fd5a97990022eedbab6f6f0d711ba888ac6 AS production
 
 WORKDIR /app
 COPY --link  docker/install_lambda_insights.sh /app/

--- a/docker/event-received/Dockerfile
+++ b/docker/event-received/Dockerfile
@@ -10,7 +10,7 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o event-received ./cmd/event-received
 
-FROM public.ecr.aws/lambda/provided:al2023.2025.02.18.01@sha256:edcd0b012f44ce1e87bf865addb662d4be0d62b3a9d8ee72e3c4284a733343b6 AS production
+FROM public.ecr.aws/lambda/provided:al2023.2025.05.04.04@sha256:fed9eb1f995d9c1f714794e3c2223fd5a97990022eedbab6f6f0d711ba888ac6 AS production
 
 WORKDIR /app
 COPY --link  docker/install_lambda_insights.sh /app/

--- a/docker/schedule-runner/Dockerfile
+++ b/docker/schedule-runner/Dockerfile
@@ -10,7 +10,7 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags="-X main.Tag=${TAG}" -o schedule-runner ./cmd/schedule-runner
 
-FROM public.ecr.aws/lambda/provided:al2023.2025.02.18.01@sha256:edcd0b012f44ce1e87bf865addb662d4be0d62b3a9d8ee72e3c4284a733343b6 AS production
+FROM public.ecr.aws/lambda/provided:al2023.2025.05.04.04@sha256:fed9eb1f995d9c1f714794e3c2223fd5a97990022eedbab6f6f0d711ba888ac6 AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
# Purpose

To upgrade various vulnerable packages

#patch

## Approach

Used latest release of lambda/provided and its hash

## Learning

AWS doesn't seem to publish hashes on their directory so I had to fetch it locally