### PR TITLE
MLPAB-3084 - reuse sqlite solution from event-received

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,6 @@ test-schedule-runner: add-scheduled-tasks run-schedule-runner ##@scheduler seeds
 	docker compose -f docker/docker-compose.yml exec localstack awslocal cloudwatch get-metric-data \
 		--endpoint-url=http://localhost:4566 \
 		--region eu-west-1 \
-		--metric-data-queries file://schedule-runner-metrics-query.json \
+		--metric-data-queries file:///usr/schedule-runner-metrics-query.json \
 		--start-time "$(shell date -v-1H -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--end-time "$(shell date -v+1M -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/docker/schedule-runner/.trivyignore.yaml
+++ b/docker/schedule-runner/.trivyignore.yaml
@@ -1,6 +1,8 @@
 misconfigurations:
   - id: AVD-DS-0002
     statement: Lambda creates a docker USER with least-privilege permissions.
+  - id: AVD-DS-0017
+    statement: Package manager update should always have install
 vulnerabilities:
   - id: CVE-2022-49043
     statement: Patched version of libxml2 unavailable in latest image

--- a/docker/schedule-runner/Dockerfile
+++ b/docker/schedule-runner/Dockerfile
@@ -19,6 +19,14 @@ COPY --link  docker/install_lambda_insights.sh /app/
 RUN chmod +x "/app/install_lambda_insights.sh" \
   && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
 
+# Switch DNF to the latest AL2023.7 release (2023.7.20250512) and update SQLite packages
+#Add trivy ignore on this issues as we are updating not installing.
+RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
+dnf clean all && \
+dnf -y update sqlite-libs libxml2 && \
+dnf clean all
+
+
 COPY --from=build /app/schedule-runner ./schedule-runner
 COPY --link lang ./lang
 COPY --link ./docker/adot-collector/ /opt


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-3084

## Approach

- reuse solution for resolving sqlite vuln in event-received
- add trivy ignore
- location of metric query for test-schedule-runner make target has changed

I checked this with the test-schedule-runner make target
