### PR TITLE
MLPAB-3086 - use secret for CLIENT_ID

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -181,6 +181,16 @@ data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id" {
   provider = aws.region
 }
 
+data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id" {
+  name     = "rum-monitor-identity-pool-id-${data.aws_region.current.name}"
+  provider = aws.region
+}
+
+data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
+  name     = "gov-one-login-mrlpa-client-id"
+  provider = aws.region
+}
+
 data "aws_iam_policy_document" "task_role_access_policy" {
   policy_id = "${local.policy_region_prefix}task_role_access_policy"
   statement {
@@ -275,6 +285,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
       data.aws_secretsmanager_secret.os_postcode_lookup_api_key.arn,
       data.aws_secretsmanager_secret.private_jwt_key.arn,
       data.aws_secretsmanager_secret.lpa_store_jwt_key.arn,
+      data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn,
     ]
   }
 
@@ -386,6 +397,10 @@ locals {
         {
           name      = "AWS_RUM_APPLICATION_ID",
           valueFrom = var.rum_monitor_application_id_secretsmanager_secret_arn
+        },
+        {
+          name      = "CLIENT_ID",
+          valueFrom = data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn
         }
       ],
       environment = [
@@ -396,10 +411,6 @@ locals {
         {
           name  = "APP_PORT",
           value = tostring(var.container_port)
-        },
-        {
-          name  = "CLIENT_ID",
-          value = "kr4jYy8X1CovT5KvhbwXb_DoMFo"
         },
         {
           name  = "ISSUER",

--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -181,11 +181,6 @@ data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id" {
   provider = aws.region
 }
 
-data "aws_secretsmanager_secret" "rum_monitor_identity_pool_id" {
-  name     = "rum-monitor-identity-pool-id-${data.aws_region.current.name}"
-  provider = aws.region
-}
-
 data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
   name     = "gov-one-login-mrlpa-client-id"
   provider = aws.region


### PR DESCRIPTION
# Purpose

Treat client id as a secret

Fixes MLPAB-3086

## Approach

- use a secret for client id in ecs app
- TODO: use a secret for client id in ecs mock one login
