### PR TITLE
Allow specifying which attorney recieves sharecode email

### DIFF
--- a/internal/page/fixtures/attorney.go
+++ b/internal/page/fixtures/attorney.go
@@ -477,6 +477,28 @@ func Attorney(
 			lpa.LpaKey = donorDetails.PK
 			lpa.LpaOwnerKey = donorDetails.SK
 
+			if isTrustCorporation && isReplacement {
+				lpa.Attorneys = lpadata.Attorneys{}
+				lpa.ReplacementAttorneys = lpadata.Attorneys{
+					TrustCorporation: lpa.ReplacementAttorneys.TrustCorporation,
+				}
+			} else if isTrustCorporation {
+				lpa.Attorneys = lpadata.Attorneys{
+					TrustCorporation: lpa.Attorneys.TrustCorporation,
+				}
+				lpa.ReplacementAttorneys = lpadata.Attorneys{}
+			} else if isReplacement {
+				lpa.Attorneys = lpadata.Attorneys{}
+				lpa.ReplacementAttorneys = lpadata.Attorneys{
+					Attorneys: lpa.ReplacementAttorneys.Attorneys,
+				}
+			} else {
+				lpa.Attorneys = lpadata.Attorneys{
+					Attorneys: lpa.Attorneys.Attorneys,
+				}
+				lpa.ReplacementAttorneys = lpadata.Attorneys{}
+			}
+
 			shareCodeSender.SendAttorneys(donorCtx, appcontext.Data{
 				SessionID: donorSessionID,
 				LpaID:     donorDetails.LpaID,


### PR DESCRIPTION
# Purpose

We were contacting every attorney every time an email was provided. This made it difficult/impossible to use the access code of a specific attorney as the sharecode needs to be unique so is only used once. Now we can filter by who we want to receive the email and log in as.
