### PR TITLE
MLPAB-3127 - add resource policy to main table

### DIFF
--- a/terraform/environment/data_sources.tf
+++ b/terraform/environment/data_sources.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "global" {
+  provider = aws.global
+}

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -73,7 +73,6 @@ resource "aws_dynamodb_table_replica" "lpas_table" {
   provider               = aws.eu_west_2
 }
 
-
 resource "aws_dynamodb_resource_policy" "lpas_table" {
   resource_arn = aws_dynamodb_table.lpas_table.arn
   policy       = data.aws_iam_policy_document.lpas_table.json

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -72,3 +72,97 @@ resource "aws_dynamodb_table_replica" "lpas_table" {
   point_in_time_recovery = true
   provider               = aws.eu_west_2
 }
+
+
+resource "aws_dynamodb_resource_policy" "lpas_table" {
+  resource_arn = aws_dynamodb_table.lpas_table.arn
+  policy       = data.aws_iam_policy_document.lpas_table.json
+  provider     = aws.eu_west_1
+}
+
+data "aws_iam_role" "aws_backup_role" {
+  name     = "aws-backup-role"
+  provider = aws.global
+}
+
+data "aws_iam_policy_document" "lpas_table" {
+  statement {
+    sid    = "AllowAccessForAppAndEventsReceived"
+    effect = "Allow"
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [aws_dynamodb_table.lpas_table.arn]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.global.iam_roles.app_ecs_task_role.arn,
+        module.global.iam_roles.event_received_lambda.arn,
+        data.aws_iam_role.aws_backup_role.arn,
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowAccessForScheduleRunner"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [aws_dynamodb_table.lpas_table.arn]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.global.iam_roles.schedule_runner_lambda.arn,
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowReadAccessForUserRoles"
+    effect = "Allow"
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [aws_dynamodb_table.lpas_table.arn]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/data-access",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowAccessForBreakglass"
+    effect = "Allow"
+    actions = [
+      "dynamodb:*",
+    ]
+    resources = [aws_dynamodb_table.lpas_table.arn]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/breakglass"
+      ]
+    }
+  }
+  provider = aws.region
+}

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -73,6 +73,13 @@ resource "aws_dynamodb_table_replica" "lpas_table" {
   provider               = aws.eu_west_2
 }
 
+resource "aws_dynamodb_resource_policy" "lpas_table_replica" {
+  count        = local.environment.dynamodb.region_replica_enabled ? 1 : 0
+  resource_arn = aws_dynamodb_table_replica.lpas_table[0].arn
+  policy       = data.aws_iam_policy_document.lpas_table.json
+  provider     = aws.eu_west_2
+}
+
 resource "aws_dynamodb_resource_policy" "lpas_table" {
   resource_arn = aws_dynamodb_table.lpas_table.arn
   policy       = data.aws_iam_policy_document.lpas_table.json
@@ -92,7 +99,7 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:Scan",
       "dynamodb:UpdateItem",
     ]
-    resources = [aws_dynamodb_table.lpas_table.arn]
+    resources = ["*"]
 
     principals {
       type = "AWS"
@@ -114,7 +121,7 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:Query",
       "dynamodb:UpdateItem",
     ]
-    resources = [aws_dynamodb_table.lpas_table.arn]
+    resources = ["*"]
 
     principals {
       type = "AWS"
@@ -132,7 +139,7 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:DescribeContinuousBackups",
       "dynamodb:ExportTableToPointInTime",
     ]
-    resources = [aws_dynamodb_table.lpas_table.arn]
+    resources = ["*"]
 
     principals {
       type = "AWS"
@@ -149,7 +156,7 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:DescribeExport",
     ]
     resources = [
-      "${aws_dynamodb_table.lpas_table.arn}/export/*",
+      "*",
     ]
     principals {
       type = "AWS"
@@ -168,7 +175,7 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:Query",
       "dynamodb:Scan",
     ]
-    resources = [aws_dynamodb_table.lpas_table.arn]
+    resources = ["*"]
 
     principals {
       type = "AWS"
@@ -184,7 +191,7 @@ data "aws_iam_policy_document" "lpas_table" {
     actions = [
       "dynamodb:*",
     ]
-    resources = [aws_dynamodb_table.lpas_table.arn]
+    resources = ["*"]
 
     principals {
       type = "AWS"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -139,7 +139,7 @@ data "aws_iam_policy_document" "lpas_table" {
     principals {
       type = "AWS"
       identifiers = [
-        local.account.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/data-access",
+        local.environment.account_name == "development" ? "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/operator" : "arn:aws:iam::${data.aws_caller_identity.global.account_id}:role/data-access",
       ]
     }
   }

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -159,5 +159,5 @@ data "aws_iam_policy_document" "lpas_table" {
       ]
     }
   }
-  provider = aws.region
+  provider = aws.global
 }

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -152,6 +152,12 @@ data "aws_iam_policy_document" "lpas_table" {
     resources = [
       "${aws_dynamodb_table.lpas_table.arn}/export/*",
     ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.global.iam_roles.opensearch_pipeline.arn,
+      ]
+    }
   }
 
   statement {
@@ -165,6 +171,12 @@ data "aws_iam_policy_document" "lpas_table" {
     resources = [
       "${aws_dynamodb_table.lpas_table.arn}/stream/*",
     ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.global.iam_roles.opensearch_pipeline.arn,
+      ]
+    }
   }
 
   statement {

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -131,7 +131,6 @@ data "aws_iam_policy_document" "lpas_table" {
       "dynamodb:DescribeTable",
       "dynamodb:DescribeContinuousBackups",
       "dynamodb:ExportTableToPointInTime",
-      "dynamodb:ListExports",
     ]
     resources = [aws_dynamodb_table.lpas_table.arn]
 
@@ -142,6 +141,22 @@ data "aws_iam_policy_document" "lpas_table" {
       ]
     }
   }
+
+  # statement {
+  #   sid    = "AllowAccessForOpensearchPipeline2"
+  #   effect = "Allow"
+  #   actions = [
+  #     "dynamodb:ListExports",
+  #   ]
+
+  #   principals {
+  #     type = "AWS"
+  #     identifiers = [
+  #       module.global.iam_roles.opensearch_pipeline.arn,
+  #     ]
+  #   }
+  #   resources = [aws_dynamodb_table.lpas_table.arn]
+  # }
 
   statement {
     sid    = "DescribeExports"
@@ -160,24 +175,24 @@ data "aws_iam_policy_document" "lpas_table" {
     }
   }
 
-  statement {
-    sid    = "allowReadFromStream"
-    effect = "Allow"
-    actions = [
-      "dynamodb:DescribeStream",
-      "dynamodb:GetRecords",
-      "dynamodb:GetShardIterator",
-    ]
-    resources = [
-      "${aws_dynamodb_table.lpas_table.arn}/stream/*",
-    ]
-    principals {
-      type = "AWS"
-      identifiers = [
-        module.global.iam_roles.opensearch_pipeline.arn,
-      ]
-    }
-  }
+  # statement {
+  #   sid    = "allowReadFromStream"
+  #   effect = "Allow"
+  #   actions = [
+  #     "dynamodb:DescribeStream",
+  #     "dynamodb:GetRecords",
+  #     "dynamodb:GetShardIterator",
+  #   ]
+  #   resources = [
+  #     "${aws_dynamodb_table.lpas_table.arn}/stream/*",
+  #   ]
+  #   principals {
+  #     type = "AWS"
+  #     identifiers = [
+  #       module.global.iam_roles.opensearch_pipeline.arn,
+  #     ]
+  #   }
+  # }
 
   statement {
     sid    = "AllowReadAccessForUserRoles"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -125,6 +125,49 @@ data "aws_iam_policy_document" "lpas_table" {
   }
 
   statement {
+    sid    = "AllowAccessForOpensearchPipeline"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:DescribeContinuousBackups",
+      "dynamodb:ExportTableToPointInTime",
+      "dynamodb:ListExports",
+    ]
+    resources = [aws_dynamodb_table.lpas_table.arn]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.global.iam_roles.opensearch_pipeline.arn,
+      ]
+    }
+  }
+
+  statement {
+    sid    = "DescribeExports"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeExport",
+    ]
+    resources = [
+      "${aws_dynamodb_table.lpas_table.arn}/export/*",
+    ]
+  }
+
+  statement {
+    sid    = "allowReadFromStream"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeStream",
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+    ]
+    resources = [
+      "${aws_dynamodb_table.lpas_table.arn}/stream/*",
+    ]
+  }
+
+  statement {
     sid    = "AllowReadAccessForUserRoles"
     effect = "Allow"
     actions = [

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -80,11 +80,6 @@ resource "aws_dynamodb_resource_policy" "lpas_table" {
   provider     = aws.eu_west_1
 }
 
-data "aws_iam_role" "aws_backup_role" {
-  name     = "aws-backup-role"
-  provider = aws.global
-}
-
 data "aws_iam_policy_document" "lpas_table" {
   statement {
     sid    = "AllowAccessForAppAndEventsReceived"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -142,22 +142,6 @@ data "aws_iam_policy_document" "lpas_table" {
     }
   }
 
-  # statement {
-  #   sid    = "AllowAccessForOpensearchPipeline2"
-  #   effect = "Allow"
-  #   actions = [
-  #     "dynamodb:ListExports",
-  #   ]
-
-  #   principals {
-  #     type = "AWS"
-  #     identifiers = [
-  #       module.global.iam_roles.opensearch_pipeline.arn,
-  #     ]
-  #   }
-  #   resources = [aws_dynamodb_table.lpas_table.arn]
-  # }
-
   statement {
     sid    = "DescribeExports"
     effect = "Allow"
@@ -174,25 +158,6 @@ data "aws_iam_policy_document" "lpas_table" {
       ]
     }
   }
-
-  # statement {
-  #   sid    = "allowReadFromStream"
-  #   effect = "Allow"
-  #   actions = [
-  #     "dynamodb:DescribeStream",
-  #     "dynamodb:GetRecords",
-  #     "dynamodb:GetShardIterator",
-  #   ]
-  #   resources = [
-  #     "${aws_dynamodb_table.lpas_table.arn}/stream/*",
-  #   ]
-  #   principals {
-  #     type = "AWS"
-  #     identifiers = [
-  #       module.global.iam_roles.opensearch_pipeline.arn,
-  #     ]
-  #   }
-  # }
 
   statement {
     sid    = "AllowReadAccessForUserRoles"


### PR DESCRIPTION
# Purpose

Use resource policies to control who can access customer data

Fixes MLPAB-3127

## Approach

- add a resource policy to DynamoDB table

## Learning

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html