### PR TITLE
MLPAB-3129: Update preproduction cypress smoke test

### DIFF
--- a/cypress/smoke/smoke.cy.js
+++ b/cypress/smoke/smoke.cy.js
@@ -41,8 +41,8 @@ describe('Smoke tests', () => {
                     cy.wait(10000);
                 });
 
-                cy.url().should('contain', '/dashboard');
-                cy.contains('Manage your LPAs');
+                cy.url().should('contain', '/make-or-add-an-lpa');
+                cy.contains('Make or add an LPA');
             } else {
                 cy.contains('a', 'Start');
             }


### PR DESCRIPTION
# Purpose

As this assertion only runs on preproduction it wasn't caught in the PR smoke test.

Fixes MLPAB-3129