### PR TITLE
MLPAB-3028 - clear tfsec ignore

### DIFF
--- a/terraform/environment/region/modules/event_received/data_sources.tf
+++ b/terraform/environment/region/modules/event_received/data_sources.tf
@@ -11,6 +11,11 @@ data "aws_kms_alias" "cloudwatch_application_logs_encryption" {
   provider = aws.region
 }
 
+data "aws_kms_alias" "event_received_sqs" {
+  name     = "alias/${data.aws_default_tags.current.tags.application}_event_received_sqs_secret_encryption_key"
+  provider = aws.region
+}
+
 data "aws_secretsmanager_secret" "gov_uk_notify_api_key" {
   name     = "gov-uk-notify-api-key"
   provider = aws.region

--- a/terraform/environment/region/modules/event_received/main.tf
+++ b/terraform/environment/region/modules/event_received/main.tf
@@ -37,12 +37,6 @@ module "event_received" {
   }
 }
 
-data "aws_kms_alias" "event_received_sqs" {
-  name     = "alias/${data.aws_default_tags.current.tags.application}_event_received_sqs_secret_encryption_key"
-  provider = aws.region
-}
-
-#tfsec:ignore:aws-sqs-enable-queue-encryption:exp:2024-11-24
 resource "aws_sqs_queue" "receive_events_queue" {
   name                              = "${data.aws_default_tags.current.tags.environment-name}-receive-events-queue"
   kms_master_key_id                 = data.aws_kms_alias.event_received_sqs.target_key_id
@@ -87,7 +81,6 @@ data "aws_iam_policy_document" "receive_events_queue_policy" {
   }
 }
 
-#tfsec:ignore:aws-sqs-enable-queue-encryption:exp:2024-11-24
 resource "aws_sqs_queue" "receive_events_deadletter" {
   name                              = "${data.aws_default_tags.current.tags.environment-name}-receive-events-deadletter"
   kms_master_key_id                 = data.aws_kms_alias.event_received_sqs.target_key_id


### PR DESCRIPTION
# Purpose

There was a tfsec ignore for queue encryption. The queue is now encrypted, so we can remove the ignore.

Fixes MLPAB-3028

## Approach

- move data source in to data_sources.tf
- remove ignores

## Learning

- https://aquasecurity.github.io/tfsec/v1.28.1/guides/configuration/ignores/
