### PR TITLE
reduce schedule to hourly

### DIFF
--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -59,8 +59,8 @@ data "aws_iam_policy_document" "s3_create_batch_replication_jobs" {
   provider = aws.region
 }
 
-resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
-  name = "invoke-lambda-every-2-minutes-${data.aws_default_tags.current.tags.environment-name}"
+resource "aws_scheduler_schedule" "invoke_lambda_every_x_minutes" {
+  name = "invoke-lambda-every-60-minutes-${data.aws_default_tags.current.tags.environment-name}"
 
   flexible_time_window {
     mode = "OFF"

--- a/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/lambda.tf
@@ -66,7 +66,7 @@ resource "aws_scheduler_schedule" "invoke_lambda_every_15_minutes" {
     mode = "OFF"
   }
 
-  schedule_expression = "rate(20 minutes)"
+  schedule_expression = "rate(60 minutes)"
   state               = var.s3_replication.enable_s3_batch_job_replication_scheduler ? "ENABLED" : "DISABLED"
 
   target {


### PR DESCRIPTION
# Purpose

Save costs while there are far fewer objects to replicate

## Approach

- set lamdab trigger schedule to 1 hourly