### PR TITLE
Set dependabot branch names seperator to dashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
# Purpose

To try to fix the failing dependabot PRs as it looks like slashes in the branch name could be problematic.
