### PR TITLE
MLPAB-3174 - Enable route53 dns resolver logs

### DIFF
--- a/terraform/account/region/route53_resolver_query_logs.tf
+++ b/terraform/account/region/route53_resolver_query_logs.tf
@@ -1,12 +1,14 @@
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key:exp:2025-08-30
-resource "aws_cloudwatch_log_group" "main" {
-  name     = "${data.aws_default_tags.current.tags.account-name}-route53-resolver-logs-${data.aws_region.current.name}"
-  provider = aws.region
+resource "aws_cloudwatch_log_group" "route_53_resolver_logs" {
+  name              = "${data.aws_default_tags.current.tags.account-name}-route53-resolver-logs-${data.aws_region.current.name}"
+  retention_in_days = 400
+  provider          = aws.region
 }
 
 resource "aws_route53_resolver_query_log_config" "main" {
   name            = "main"
-  destination_arn = aws_cloudwatch_log_group.main.arn
+  destination_arn = aws_cloudwatch_log_group.route_53_resolver_logs.arn
+  provider        = aws.region
 }
 
 resource "aws_route53_resolver_query_log_config_association" "main" {


### PR DESCRIPTION
# Purpose

Log DNS queries originating inside the VPC.

Fixes MLPAB-3174

## Approach

- add a cloudwatch log group
- add route53 resolver query log config and associate with VPC

## Learning

- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config_association
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
- https://aquasecurity.github.io/tfsec/v1.28.1/guides/configuration/ignores/
