### PR TITLE
MLPAB-3172 - add anomaly detection to each application log group

### DIFF
--- a/terraform/environment/region/cloudwatch_events.tf
+++ b/terraform/environment/region/cloudwatch_events.tf
@@ -89,3 +89,13 @@ resource "aws_cloudwatch_metric_alarm" "ecs_failed_deployment" {
   treat_missing_data        = "notBreaching"
   provider                  = aws.region
 }
+
+resource "aws_cloudwatch_log_anomaly_detector" "events" {
+  detector_name           = "${data.aws_default_tags.current.tags.environment-name}_events"
+  log_group_arn_list      = [aws_cloudwatch_log_group.events.arn]
+  anomaly_visibility_time = 30
+  evaluation_frequency    = "TEN_MIN"
+  kms_key_id              = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
+  enabled                 = "true"
+  provider                = aws.region
+}

--- a/terraform/environment/region/modules/application_logs/cloudwatch_log_group.tf
+++ b/terraform/environment/region/modules/application_logs/cloudwatch_log_group.tf
@@ -33,3 +33,13 @@ fields @timestamp, level, msg, err, concat(req.method, " ", req.uri) as request
 EOF
   provider     = aws.region
 }
+
+resource "aws_cloudwatch_log_anomaly_detector" "application_logs" {
+  detector_name           = "${data.aws_default_tags.current.tags.environment-name}_application_logs"
+  log_group_arn_list      = [aws_cloudwatch_log_group.application_logs.arn]
+  anomaly_visibility_time = 30
+  evaluation_frequency    = "TEN_MIN"
+  kms_key_id              = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
+  enabled                 = "true"
+  provider                = aws.region
+}

--- a/terraform/environment/region/modules/event_bus/main.tf
+++ b/terraform/environment/region/modules/event_bus/main.tf
@@ -221,3 +221,14 @@ fields @timestamp, @message, @logStream, @log
 EOF
   provider     = aws.region
 }
+
+resource "aws_cloudwatch_log_anomaly_detector" "events_emitted" {
+  count                   = var.log_emitted_events ? 1 : 0
+  detector_name           = "${data.aws_default_tags.current.tags.environment-name}_events_emitted"
+  log_group_arn_list      = [aws_cloudwatch_log_group.events_emitted[0].arn]
+  anomaly_visibility_time = 30
+  evaluation_frequency    = "TEN_MIN"
+  kms_key_id              = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
+  enabled                 = "true"
+  provider                = aws.region
+}

--- a/terraform/environment/region/modules/lambda/main.tf
+++ b/terraform/environment/region/modules/lambda/main.tf
@@ -61,3 +61,13 @@ fields @timestamp, type, record.status as status, @xrayTraceId, @message, record
 EOF
   provider     = aws.region
 }
+
+resource "aws_cloudwatch_log_anomaly_detector" "main" {
+  detector_name           = "${var.environment}_${var.lambda_name}"
+  log_group_arn_list      = [aws_cloudwatch_log_group.lambda.arn]
+  anomaly_visibility_time = 30
+  evaluation_frequency    = "TEN_MIN"
+  kms_key_id              = var.kms_key
+  enabled                 = "true"
+  provider                = aws.region
+}


### PR DESCRIPTION
# Purpose

Use anomaly detection in application logs

Fixes MLPAB-3172

## Approach

- add a log anomaly detector to each application log group 
- use cmk for detector

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_anomaly_detector
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_AnalyzeLogData_Patterns.html
