### PR TITLE
MLPAB-3237 - use renovate for vulnerability updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,6 @@
         "minimumReleaseAge": "3 days"
     },
     "vulnerabilityAlerts": {
-        "enabled": false
+        "enabled": true
     }
 }


### PR DESCRIPTION
# Purpose

Use Revonvate for vulnerability alerts

Fixes MLPAB-##

## Approach

- Enable vulnerabilityAlerts

## Learning

I'm leaving dependabot vulnerability PRs as they are at the moment while testing renovate's handling.
