### PR TITLE
explicitely disable point in time recovery

### DIFF
--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -230,6 +230,11 @@ resource "aws_dynamodb_table" "sessions_table" {
     enabled        = true
   }
 
+  #tfsec:ignore:aws-dynamodb-enable-recovery
+  point_in_time_recovery {
+    enabled = false
+  }
+
   lifecycle {
     ignore_changes = [replica]
   }


### PR DESCRIPTION
# Purpose

Resolve tfsec finding in code scanning results

## Approach

- set point in time recover to false
- ignore tfsec finding for point in time recovery

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#point_in_time_recovery-1
- https://aquasecurity.github.io/tfsec/v1.28.1/guides/configuration/ignores/
