### PR TITLE
MLPAB-3167 - Obscure CIDR ranges

### DIFF
--- a/terraform/environment/region/modules/app/variables.tf
+++ b/terraform/environment/region/modules/app/variables.tf
@@ -62,6 +62,7 @@ variable "app_allowed_api_arns" {
 variable "ingress_allow_list_cidr" {
   type        = list(string)
   description = "List of CIDR ranges permitted to access the service"
+  sensitive   = true
 }
 
 variable "alb_deletion_protection_enabled" {

--- a/terraform/environment/region/modules/mock_pay/variables.tf
+++ b/terraform/environment/region/modules/mock_pay/variables.tf
@@ -54,6 +54,7 @@ variable "container_version" {
 variable "ingress_allow_list_cidr" {
   type        = list(string)
   description = "List of CIDR ranges permitted to access the service"
+  sensitive   = true
 }
 
 variable "alb_deletion_protection_enabled" {

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -20,7 +20,7 @@ data "aws_ecr_image" "mock_onelogin" {
 }
 
 module "allow_list" {
-  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.0.5"
+  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.4.3"
 }
 
 module "eu_west_1" {


### PR DESCRIPTION
# Purpose

Obscure allowed CIDR ranges from github actions logs

Fixes MLPAB-3167

## Approach

- make cidr range input variables sensitive

## Learning

- https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output
