### PR TITLE
MLPAB-3211 - fix go app redirects

### DIFF
--- a/terraform/environment/region/modules/app/ecs.tf
+++ b/terraform/environment/region/modules/app/ecs.tf
@@ -356,7 +356,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 }
 
 locals {
-  app_url = "https://${data.aws_default_tags.current.tags.environment-name}.app.modernising.opg.service.justice.gov.uk"
+  app_url = data.aws_default_tags.current.tags.account-name != "production" ? "https://${data.aws_default_tags.current.tags.environment-name}.app.modernising.opg.service.justice.gov.uk" : "https://app.modernising.opg.service.justice.gov.uk"
 
   app = jsonencode(
     {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -240,9 +240,9 @@
             "app": {
                 "env": {
                     "app_public_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
-                    "donor_start_url": "https://mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/make-lpa",
-                    "certificate_provider_start_url": "https://mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/certificate-provider",
-                    "attorney_start_url": "https://mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/attorney",
+                    "donor_start_url": "https://demo.mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/make-lpa",
+                    "certificate_provider_start_url": "https://demo.mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/certificate-provider",
+                    "attorney_start_url": "https://demo.mainstreamcontent.modernising.opg.service.justice.gov.uk/register-lasting-power-of-attorney/attorney",
                     "auth_redirect_base_url": "https://demo.app.modernising.opg.service.justice.gov.uk",
                     "notify_is_production": "",
                     "onelogin_url": "https://home.integration.account.gov.uk",


### PR DESCRIPTION
# Purpose

Domain root of demo environment redirects to production guidance

Fixes MLPAB-3211

## Approach

- fix env vars for when no input is given for start urls
- fix tfvars for demo env