### PR TITLE
MLPRAB-3282 - set role to use for aws cli commands

### DIFF
--- a/scripts/workspace_cleanup.sh
+++ b/scripts/workspace_cleanup.sh
@@ -31,6 +31,7 @@ do
       if ! terraform destroy -auto-approve; then
         TF_EXIT_CODE=1
       fi
+      export AWS_ROLE_ARN="arn:aws:iam::653761790766:role/modernising-lpa-ci"
       echo "deleting opensearch index..."
       response=$(awscurl \
         "${DEVELOPMENT_OPENSEARCH_COLLECTION_ENDPOINT}/lpas_v2_$workspace" \
@@ -49,6 +50,7 @@ do
       aws logs delete-log-group --region eu-west-1 --log-group-name /aws/ecs/containerinsights/"$workspace"/performance
       terraform workspace select default
       terraform workspace delete "$workspace"
+      export AWS_ROLE_ARN=""
       ;;
   esac
 done


### PR DESCRIPTION
# Purpose

Cleanup job fails because it isn't using an assume role

Fixes MLPAB-3282

## Approach

- set assume role arn with env var

## Learning

aws cli supports this env var, but I can't tell if awscurl does. So if this doesn't work I'll look at using a profile (I wanted to avoid putting a profile file in the correct place).

- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list
