### PR TITLE
MLPAB-3227: Add translation keys test profile, fix voucher specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ scripts/sbom_exporter/tmp.*.json
 /playwright-report/*
 /test-results/*
 /playwright/screenshots/*
+/playwright/translation-keys-state.json

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -220,6 +220,7 @@ func TestWithAppData(t *testing.T) {
 	testcases := map[string]struct {
 		url                 string
 		cookieName          string
+		cookieValue         string
 		cookieConsentSet    bool
 		showTranslationKeys bool
 		contentType         string
@@ -227,6 +228,7 @@ func TestWithAppData(t *testing.T) {
 		"with cookie consent": {
 			url:              "/path?a=b",
 			cookieName:       "cookies-consent",
+			cookieValue:      "1",
 			cookieConsentSet: true,
 		},
 		"without cookie consent": {
@@ -240,6 +242,18 @@ func TestWithAppData(t *testing.T) {
 		"without translation keys": {
 			url: "/path?a=b",
 		},
+		"with translation keys cookie": {
+			url:                 "/path?a=b",
+			cookieName:          "show-keys",
+			cookieValue:         "1",
+			showTranslationKeys: true,
+		},
+		"disable translation keys cookie": {
+			url:                 "/path?a=b&showTranslationKeys=0",
+			cookieName:          "show-keys",
+			cookieValue:         "0",
+			showTranslationKeys: false,
+		},
 		"with translation keys and multipart form": {
 			url:                 "/path?a=b&showTranslationKeys=1",
 			showTranslationKeys: false,
@@ -251,7 +265,7 @@ func TestWithAppData(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			r, _ := http.NewRequest(http.MethodGet, tc.url, nil)
-			r.AddCookie(&http.Cookie{Name: tc.cookieName, Value: "1"})
+			r.AddCookie(&http.Cookie{Name: tc.cookieName, Value: tc.cookieValue})
 			if tc.contentType != "" {
 				r.Header.Set("Content-Type", tc.contentType)
 			}
@@ -262,7 +276,8 @@ func TestWithAppData(t *testing.T) {
 
 			query := url.Values{"a": {"b"}}
 			if strings.Contains(tc.url, "showTranslationKeys") {
-				query.Add("showTranslationKeys", "1")
+				value := strings.SplitAfter(tc.url, "showTranslationKeys=")
+				query.Add("showTranslationKeys", value[1])
 			}
 
 			handler := http.HandlerFunc(func(hw http.ResponseWriter, hr *http.Request) {

--- a/internal/localize/localizer.go
+++ b/internal/localize/localizer.go
@@ -71,7 +71,11 @@ func (l *defaultLocalizer) FormatCount(messageID string, count int, data map[str
 
 func (l *defaultLocalizer) translate(translation, messageID string) string {
 	if l.showTranslationKeys {
-		return fmt.Sprintf("{%s} [%s]", translation, messageID)
+		if strings.HasPrefix(translation, "<") {
+			return fmt.Sprintf("<div class=\"app-translated-text\">{%s}</div> <div class=\"app-translation-key\">[%s]</div>", translation, messageID)
+		} else {
+			return fmt.Sprintf("{%s} [%s]", translation, messageID)
+		}
 	} else {
 		return translation
 	}

--- a/internal/sesh/sesh.go
+++ b/internal/sesh/sesh.go
@@ -217,7 +217,8 @@ func (s *Store) SetCsrf(r *http.Request, w http.ResponseWriter, csrfSession *Csr
 }
 
 type LpaDataSession struct {
-	LpaID string
+	LpaID               string
+	ShowTranslationKeys bool
 }
 
 func (s LpaDataSession) Valid() bool {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "cypress:parallel": "cypress-parallel -s cypress:run -t 6 --spec cypress/e2e/**/*.cy.js cypress/smoke/*.cy.js",
         "cypress:parallel-with-specs": "cypress-parallel -s cypress:run -t 2",
         "test": "jest",
-        "playwright": "npx playwright test --headed",
+        "playwright:run": "npx playwright test --headed",
+        "playwright:withTranslationKeys": "npx playwright test --headed --project=withTranslationKeys",
         "playwright:record": "npx playwright codegen https://demo.app.modernising.opg.service.justice.gov.uk/fixtures"
     },
     "license": "MIT",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -49,6 +49,21 @@ export default defineConfig({
             name: 'chromium',
             use: {...devices['Desktop Chrome']},
         },
+        {
+            name: 'setup-translation-keys',
+            testMatch: /translation-keys-setup\.js/,
+            use: {
+                baseURL: 'http://localhost:5050',
+            },
+        },
+        {
+            name: 'withTranslationKeys',
+            use: {
+                baseURL: 'http://localhost:5050',
+                storageState: 'playwright/translation-keys-state.json',
+            },
+            dependencies: ['setup-translation-keys'],
+        },
 
         // {
         //   name: 'firefox',

--- a/playwright/complete-donor-flow.spec.js
+++ b/playwright/complete-donor-flow.spec.js
@@ -480,7 +480,7 @@ test('donor happy path', async ({ page }) => {
     await expect(page).toHaveURL(/\/view-lpa/);
     await screenshot(page)
     await extractTextFromMainAndSave(page)
-    await page.getByRole('link', { name: 'Manage your LPAs' }).click();
+    await page.getByRole('link', { name: 'Manage LPAs' }).click();
 
     await expect(page).toHaveURL(/\/dashboard/);
     await page.getByRole('button', { name: 'Actions' }).click();

--- a/playwright/donor/pfa-lpa-flow.spec.js
+++ b/playwright/donor/pfa-lpa-flow.spec.js
@@ -11,7 +11,7 @@ test('donor property and affairs full journey', async ({page}) => {
     await page.getByRole('button', {name: /Start|Start now/}).click();
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    await expect(page.locator('h1')).toContainText('Manage your LPAs');
+    await expect(page.locator('h1')).toContainText('Manage LPAs');
     await screenshot(page)
     await extractTextFromMainAndSave(page)
     await page.getByRole('button', {name: /Start|Start now/}).click();

--- a/playwright/e2e.js
+++ b/playwright/e2e.js
@@ -1,5 +1,5 @@
 import AxeBuilder from '@axe-core/playwright';
-import { expect } from '@playwright/test';
+import {expect} from '@playwright/test';
 
 export const
     TestEmail = 'simulate-delivered@notifications.service.gov.uk',
@@ -10,7 +10,7 @@ export function randomAccessCode() {
     const characters = 'abcdefghijklmnpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789'
     let result = [];
 
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 8; i++) {
         result.push(characters.charAt(Math.floor(Math.random() * characters.length)));
     }
 

--- a/playwright/textExtractor.js
+++ b/playwright/textExtractor.js
@@ -6,7 +6,9 @@ function browserTextExtractorLogic() {
     function parseChildrenNodes(element) {
         const isSummaryList = element.classList.contains('govuk-summary-list__row');
         const isListItem = element.tagName.toLowerCase() === 'li';
+
         let prependChar = '';
+        let textParts = [];
 
         if (isSummaryList) {
             prependChar = '|';
@@ -14,14 +16,12 @@ function browserTextExtractorLogic() {
             prependChar = '•';
         }
 
-        let textParts = [];
-
         function processNode(node) {
             if (node.nodeType === Node.ELEMENT_NODE) {
                 if (node.tagName.toLowerCase() === 'a') {
                     textParts.push(`[LINK: ${node.textContent.trim()}](${node.href})`)
                 } else if (node.tagName.toLowerCase() === 'span') {
-                    textParts.push(`${node.textContent.trim()}`)
+                    textParts.push(node.textContent.trim())
                 } else {
                     Array.from(node.childNodes).forEach(processNode)
                 }
@@ -72,16 +72,21 @@ function browserTextExtractorLogic() {
         const classList = element.classList;
         let text = '';
 
+        if (classList.contains('app-translation-key')) {
+            return `${element.textContent.trim()}\n\n`
+        }
+
+        if ( ['p', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tagName) ||
+            classList.contains('govuk-summary-list__row') ||
+            classList.contains('app-translated-text')) {
+            return parseChildrenNodes(element);
+        }
+
         if ( ['label', 'option', 'script', 'style'].includes(tagName) ||
             ['govuk-visually-hidden', 'govuk-hint', 'govuk-!-display-none', 'app-dialog', 'govuk-warning-text__icon'].some(
                 cls => element.classList.contains(cls))
         ) {
             return '';
-        }
-
-        if ( ['p', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tagName) ||
-            classList.contains('govuk-summary-list__row')) {
-            return parseChildrenNodes(element);
         }
 
         switch (true) {

--- a/playwright/translation-keys-setup.js
+++ b/playwright/translation-keys-setup.js
@@ -1,0 +1,7 @@
+import {test as setup} from '@playwright/test';
+
+setup('enable translation keys', async ({ page }) => {
+    await page.goto('/fixtures');
+    await page.getByRole('link', {name: 'Toggle translation keys'}).click();
+    await page.context().storageState({ path: './playwright/translation-keys-state.json' });
+});

--- a/playwright/voucher/voucher-cant-id.spec.js
+++ b/playwright/voucher/voucher-cant-id.spec.js
@@ -7,7 +7,6 @@ test('voucher cannot confirm their identity', async ({page}) => {
     await page.getByRole('link', {name: 'Voucher'}).click();
     await page.getByRole('radio', {name: 'Verify donor details'}).check();
     await page.getByRole('button', {name: /Start|Start now/}).click();
-    await page.getByRole('tab', {name: 'I’m vouching for someone'}).click();
     await page.getByRole('link', {name: 'Go to task list'}).click();
     await page.getByRole('link', {name: 'Confirm your identity'}).click();
     await page.getByRole('button', {name: 'Continue'}).click();

--- a/playwright/voucher/voucher-cant-vouch.spec.js
+++ b/playwright/voucher/voucher-cant-vouch.spec.js
@@ -7,7 +7,6 @@ test('voucher confirms donors details do not match their identity', async ({page
     await page.getByRole('link', {name: 'Voucher'}).click();
     await page.getByRole('radio', {name: 'Confirm your name'}).check();
     await page.getByRole('button', {name: /Start|Start now/}).click();
-    await page.getByRole('tab', {name: 'I’m vouching for someone'}).click();
     await page.getByRole('link', {name: 'Go to task list'}).click();
     await page.getByRole('link', {name: 'Verify Sam Smith’s identity'}).click();
     await page.getByRole('radio', {name: 'No'}).check();

--- a/playwright/voucher/vouching-journey-2.spec.js
+++ b/playwright/voucher/vouching-journey-2.spec.js
@@ -1,6 +1,6 @@
-import { expect, test } from '@playwright/test';
-import { randomAccessCode, screenshot, TestEmail, TestMobile } from '../e2e.js';
-import { extractTextFromMainAndSave } from "../textExtractor.js";
+import {expect, test} from '@playwright/test';
+import {randomAccessCode, screenshot, TestEmail, TestMobile} from '../e2e.js';
+import {extractTextFromMainAndSave} from "../textExtractor.js";
 
 test('voucher completes their journey', async ({ page }) => {
     const accessCode = randomAccessCode()
@@ -15,12 +15,13 @@ test('voucher completes their journey', async ({ page }) => {
     await page.getByRole('heading', { name: 'Vouch for someone' }).click();
 
     await expect(page.locator('h1')).toContainText('Vouch for someone');
-    await page.getByRole('textbox', { name: 'Enter code' }).fill(accessCode);
+    await page.getByRole('textbox', { name: 'Donor’s last name' }).fill('Smith');
+    await page.getByRole('textbox', { name: 'Access code' }).fill(accessCode);
     await screenshot(page)
     await extractTextFromMainAndSave(page)
     await page.getByRole('button', { name: 'Save and continue' }).click();
 
-    await expect(page.locator('#main-content')).toContainText('Vouch for someone’s identity Your task list');
+    await expect(page.locator('#main-content')).toContainText('Vouch for someone’s identity');
     await screenshot(page)
     await extractTextFromMainAndSave(page)
     await page.getByRole('link', { name: 'Confirm your name' }).click();
@@ -28,7 +29,7 @@ test('voucher completes their journey', async ({ page }) => {
     await expect(page.locator('h1')).toContainText('Confirm your name');
     await screenshot(page)
     await extractTextFromMainAndSave(page)
-    await page.getByRole('link', { name: 'Change   last name' }).click();
+    await page.getByRole('link', { name: /Change.*Last name/i }).click();
 
     await expect(page.locator('h1')).toContainText('Your name');
     await page.getByRole('textbox', { name: 'Last name' }).fill('Smith');
@@ -65,8 +66,7 @@ test('voucher completes their journey', async ({ page }) => {
     await page.getByRole('textbox', { name: 'Town or city' }).fill('Birmingham');
     await page.getByRole('textbox', { name: 'Postcode' }).fill('B73 6PE');
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.getByRole('radio', { name: 'Yes' }).check();
-    await page.getByRole('button', { name: 'Continue' }).click();
+    await page.getByRole('link', { name: 'Continue' }).click();
     await page.getByRole('link', { name: 'Sign the declaration' }).click();
 
     await expect(page.locator('h1')).toContainText('Your declaration');

--- a/playwright/voucher/vouching-journey.spec.js
+++ b/playwright/voucher/vouching-journey.spec.js
@@ -8,14 +8,13 @@ test('voucher completes their journey', async ({page}) => {
     await page.getByRole('link', {name: 'Voucher'}).click();
     await page.getByRole('radio', {name: 'Confirm your name'}).check();
     await page.getByRole('button', {name: /Start|Start now/}).click();
-    await page.getByRole('tab', {name: 'I’m vouching for someone'}).click();
     await page.getByRole('link', {name: 'Go to task list'}).click();
     await page.getByRole('link', {name: 'Confirm your name'}).click();
 
     await expect(page.locator('h1')).toContainText('Confirm your name');
     await screenshot(page)
     await extractTextFromMainAndSave(page)
-    await page.getByRole('link', {name: 'Change   last name'}).click();
+    await page.getByRole('link', {name: /Change.*Last name/i}).click();
 
     await expect(page.locator('h1')).toContainText('Your name');
     await page.getByRole('textbox', {name: 'Last name'}).click();
@@ -53,11 +52,8 @@ test('voucher completes their journey', async ({page}) => {
     await page.getByRole('textbox', {name: 'Postcode'}).fill('LE12 6AL');
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    await expect(page.locator('#main-content')).toContainText('Confirm that you are allowed to vouch');
-    await page.getByRole('radio', {name: 'Yes'}).check();
-    await screenshot(page)
-    await extractTextFromMainAndSave(page)
-    await page.getByRole('button', {name: 'Continue'}).click();
+    await page.getByRole('link', {name: 'Continue'}).click();
+
     await page.getByRole('link', {name: 'Sign the declaration'}).click();
 
     await expect(page.locator('h1')).toContainText('Your declaration');
@@ -69,7 +65,7 @@ test('voucher completes their journey', async ({page}) => {
     await screenshot(page)
     await extractTextFromMainAndSave(page)
 
-    await page.getByRole('link', {name: 'Manage your LPAs'}).click();
+    await page.getByRole('link', {name: 'Manage LPAs'}).click();
     await screenshot(page)
     await extractTextFromMainAndSave(page)
 });

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -201,7 +201,7 @@
                                     </a>
                                 </li>
                                 {{ if global.DevMode }}<li class="govuk-footer__inline-list-item">
-                                    <a class="govuk-footer__link" href="{{ if .App.Localizer.ShowTranslationKeys }}{{ link .App .App.Page }}{{ else }}{{ link .App .App.Page }}?showTranslationKeys=1{{ end }}">
+                                    <a class="govuk-footer__link" href="{{ if .App.Localizer.ShowTranslationKeys }}{{ link .App .App.Page }}?showTranslationKeys=0{{ else }}{{ link .App .App.Page }}?showTranslationKeys=1{{ end }}">
                                         {{ tr .App "toggleTransKeys" }}
                                     </a>
                                 </li>{{ end }}


### PR DESCRIPTION
# Purpose

There has been some drift in the app content/logic and the playwright content extraction tests (as was expected). I've fixed up the voucher tests as a start but when we come to pull content again there will be some more work to do (or make a call on looking at migration options). 

Fixes MLPAB-3277
