### PR TITLE
MLPAB-3282 - Use OIDC role for workspace cleanup

### DIFF
--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -3,7 +3,7 @@ name: "[Workflow] Cleanup PR Workspaces"
 on:
   schedule:
     # every hour
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
 
 permissions:
   actions: none
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1
 
@@ -49,14 +49,14 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - name: Install aws-curl
         run: pip install awscurl==v0.36
 
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::653761790766:role/modernising-lpa-github-actions-pr-env-cleanup
+          role-to-assume: ${{ secrets.WORKSPACE_CLEANUP_OIDC_ROLE }}
           aws-region: eu-west-1
           role-duration-seconds: 3600
           role-session-name: MRLPAPREnvCleanupGithubAction


### PR DESCRIPTION
# Purpose

Add permissions for all workspace cleanup tasks

Fixes MLPAB-3282

## Approach

- Use github actions secret for oidc role to avoid having to make new PRs for updates