### PR TITLE
MLPAB-3282 - remove clearing of iam role

### DIFF
--- a/scripts/workspace_cleanup.sh
+++ b/scripts/workspace_cleanup.sh
@@ -49,7 +49,6 @@ do
       aws logs delete-log-group --region eu-west-1 --log-group-name /aws/ecs/containerinsights/"$workspace"/performance
       terraform workspace select default
       terraform workspace delete "$workspace"
-      export AWS_ROLE_ARN=""
       ;;
   esac
 done


### PR DESCRIPTION
# Purpose

Script fails because it clears IAM role at the end of the first workspace

Fixes MLPAB-3282

## Approach

- don't clear or set iam role
