### PR TITLE
Use scratch as base layer for lambdas

### DIFF
--- a/docker/create-s3-replication-job/Dockerfile
+++ b/docker/create-s3-replication-job/Dockerfile
@@ -10,20 +10,11 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o create-s3-replication-job ./cmd/create-s3-replication-job
 
-FROM public.ecr.aws/lambda/provided:al2023.2026.02.18.07@sha256:059ed067a8e796d891100888928e32cde75d63d459617260a7901e217a7249d6 AS production
+FROM scratch AS production
 
 WORKDIR /app
-COPY --link  docker/install_lambda_insights.sh /app/
 
-RUN chmod +x "/app/install_lambda_insights.sh" \
-  && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
-
-# Switch DNF to the latest AL2023.10 release (2023.10.20260202) and update SQLite packages
-RUN echo "2023.10.20260202" > /etc/dnf/vars/releasever && \
-    dnf clean all && \
-    dnf -y update sqlite-libs libxml2 && \
-    dnf clean all
-
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/create-s3-replication-job ./create-s3-replication-job
 COPY --link lang ./lang
 

--- a/docker/event-received/Dockerfile
+++ b/docker/event-received/Dockerfile
@@ -10,20 +10,11 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o event-received ./cmd/event-received
 
-FROM public.ecr.aws/lambda/provided:al2023.2026.02.18.07@sha256:059ed067a8e796d891100888928e32cde75d63d459617260a7901e217a7249d6 AS production
+FROM scratch AS production
 
 WORKDIR /app
-COPY --link  docker/install_lambda_insights.sh /app/
 
-RUN chmod +x /app/install_lambda_insights.sh \
-  && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
-
-# Switch DNF to the latest AL2023.10 release (2023.10.20260202) and update SQLite packages
-RUN echo "2023.10.20260202" > /etc/dnf/vars/releasever && \
-    dnf clean all && \
-    dnf -y update sqlite-libs libxml2 && \
-    dnf clean all
-
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/event-received ./event-received
 COPY --link lang ./lang
 

--- a/docker/schedule-runner/Dockerfile
+++ b/docker/schedule-runner/Dockerfile
@@ -10,21 +10,11 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags="-X main.Tag=${TAG}" -o schedule-runner ./cmd/schedule-runner
 
-FROM public.ecr.aws/lambda/provided:al2023.2026.02.18.07@sha256:059ed067a8e796d891100888928e32cde75d63d459617260a7901e217a7249d6 AS production
+FROM scratch AS production
 
 WORKDIR /app
 
-COPY --link  docker/install_lambda_insights.sh /app/
-
-RUN chmod +x "/app/install_lambda_insights.sh" \
-  && /app/install_lambda_insights.sh "${TARGETPLATFORM}"
-
-# Switch DNF to the latest AL2023.10 release (2023.10.20260202) and update SQLite packages
-RUN echo "2023.10.20260202" > /etc/dnf/vars/releasever && \
-    dnf clean all && \
-    dnf -y update sqlite-libs libxml2 && \
-    dnf clean all
-
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/schedule-runner ./schedule-runner
 COPY --link lang ./lang
 

--- a/docker/scheduled-task-adder/Dockerfile
+++ b/docker/scheduled-task-adder/Dockerfile
@@ -10,10 +10,11 @@ COPY --link internal ./internal
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o scheduled-task-adder ./cmd/main.go
 
-FROM public.ecr.aws/lambda/provided:al2023.2026.02.18.07@sha256:059ed067a8e796d891100888928e32cde75d63d459617260a7901e217a7249d6 AS production
+FROM scratch AS production
 
 WORKDIR /app
 
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/scheduled-task-adder /var/task/scheduled-task-adder
 
 ENTRYPOINT ["./scheduled-task-adder"]


### PR DESCRIPTION
Cons: we lose whatever lambda insights was doings / Pros: we don't have so many issues raised for the base layer.