### PR TITLE
MLPAB-3706: Run Cypress tests in two runners

### DIFF
--- a/.github/workflows/ui_test_job.yml
+++ b/.github/workflows/ui_test_job.yml
@@ -135,8 +135,9 @@ jobs:
           CYPRESS_TEST_ONELOGIN_TOTP_KEY: ${{ secrets.test_onelogin_totp_key }}
           CYPRESS_TEST_ONELOGIN_PASSWORD: ${{ secrets.test_onelogin_password }}
           GITHUB_TOKEN: ${{ secrets.github_access_token }}
-        run:
-          npm run cypress:parallel-with-specs -- --spec ${{ inputs.specs }} ${{ inputs.dev_mode != '1' && '--env grepTags=-@dev,grepFilterSpecs=true' || '' }}
+        run: |
+          shopt -s globstar # makes ** in glob patterns match zero or more directories recursively
+          eval "npm run cypress:parallel-with-specs -- --spec ${{ inputs.specs }} ${{ inputs.dev_mode != '1' && '--env grepTags=-@dev,grepFilterSpecs=true' || '' }}"
 
       - name: Persist Cypress failure screenshots as artifacts
         if: failure()

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -75,8 +75,8 @@ jobs:
     secrets:
       pagerduty_api_key: ${{ secrets.PAGERDUTY_API_KEY }}
 
-  ui_tests_image:
-    name: Run Cypress UI Tests On Images
+  ui_tests_image_donor:
+    name: Run Cypress UI Tests On Images (Donor)
     if: needs.detect_changes.outputs.changes_detected == 'true' &&
       (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped')
     uses: ./.github/workflows/ui_test_job.yml
@@ -84,7 +84,23 @@ jobs:
     with:
       run_against_image: true
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      specs: "cypress/e2e/**/*.cy.js"
+      specs: "cypress/e2e/donor/*.cy.js"
+      dev_mode: "1"
+      ingress_management_oidc_role_arn: ${{ vars.OIDC_INGRESS_MANAGEMENT_DEVELOPMENT }}
+    secrets:
+      cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  ui_tests_image_remaining:
+    name: Run Cypress UI Tests On Images (Remaining)
+    if: needs.detect_changes.outputs.changes_detected == 'true' &&
+      (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped')
+    uses: ./.github/workflows/ui_test_job.yml
+    needs: [ docker_build_scan_push, create_tags ]
+    with:
+      run_against_image: true
+      tag: ${{ needs.create_tags.outputs.version_tag }}
+      specs: "cypress/e2e/accessibility/**/*.cy.js cypress/e2e/attorney/**/*.cy.js cypress/e2e/certificate-provider/**/*.cy.js cypress/e2e/supporter/**/*.cy.js cypress/e2e/voucher/**/*.cy.js cypress/e2e/*.cy.js"
       dev_mode: "1"
       ingress_management_oidc_role_arn: ${{ vars.OIDC_INGRESS_MANAGEMENT_DEVELOPMENT }}
     secrets:
@@ -96,8 +112,9 @@ jobs:
     if: always() &&
       (needs.go_unit_tests.result == 'success' || needs.go_unit_tests.result == 'skipped') &&
       (needs.docker_build_scan_push.result == 'success' || needs.docker_build_scan_push.result == 'skipped') &&
-      (needs.ui_tests_image.result == 'success' || needs.ui_tests_image.result == 'skipped')
-    needs: [create_tags, go_unit_tests, docker_build_scan_push, ui_tests_image]
+      (needs.ui_tests_image_donor.result == 'success' || needs.ui_tests_image_donor.result == 'skipped') &&
+      (needs.ui_tests_image_remaining.result == 'success' || needs.ui_tests_image_remaining.result == 'skipped')
+    needs: [create_tags, go_unit_tests, docker_build_scan_push, ui_tests_image_donor, ui_tests_image_remaining]
     uses: ./.github/workflows/terraform_environment_job.yml
     with:
       workspace_name: ${{ needs.create_tags.outputs.environment_workspace_name }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -100,7 +100,7 @@ jobs:
     with:
       run_against_image: true
       tag: ${{ needs.create_tags.outputs.version_tag }}
-      specs: "cypress/e2e/accessibility/**/*.cy.js cypress/e2e/attorney/**/*.cy.js cypress/e2e/certificate-provider/**/*.cy.js cypress/e2e/supporter/**/*.cy.js cypress/e2e/voucher/**/*.cy.js cypress/e2e/*.cy.js"
+      specs: "cypress/e2e/accessibility/**/*.cy.js cypress/e2e/attorney/**/*.cy.js cypress/e2e/certificate-provider/**/*.cy.js cypress/e2e/donor/long-running/**/*.cy.js cypress/e2e/supporter/**/*.cy.js cypress/e2e/voucher/**/*.cy.js cypress/e2e/*.cy.js"
       dev_mode: "1"
       ingress_management_oidc_role_arn: ${{ vars.OIDC_INGRESS_MANAGEMENT_DEVELOPMENT }}
     secrets:

--- a/cypress/e2e/donor/long-running/choose-replacement-attorneys-task.cy.js
+++ b/cypress/e2e/donor/long-running/choose-replacement-attorneys-task.cy.js
@@ -1,4 +1,4 @@
-import { AddressFormAssertions, TestEmail } from "../../support/e2e";
+import { AddressFormAssertions, TestEmail } from "../../../support/e2e.js";
 
 describe('Choose replacement attorneys task', () => {
     it('is not started when no replacement attorneys are set', () => {

--- a/cypress/e2e/donor/long-running/payment.cy.js
+++ b/cypress/e2e/donor/long-running/payment.cy.js
@@ -1,4 +1,4 @@
-const { eventLoggerUrl } = require("../../support/e2e");
+const { eventLoggerUrl } = require("../../../support/e2e.js");
 
 describe('Pay for LPA', { pageLoadTimeout: 8000 }, () => {
     it('can pay full fee', () => {

--- a/cypress/parallel-weights.json
+++ b/cypress/parallel-weights.json
@@ -159,7 +159,7 @@
         "time": 4272,
         "weight": 10
     },
-    "cypress/e2e/donor/choose-replacement-attorneys-task.cy.js": {
+    "cypress/e2e/donor/long-running/choose-replacement-attorneys-task.cy.js": {
         "time": 41123,
         "weight": 98
     },
@@ -259,7 +259,7 @@
         "time": 2418,
         "weight": 5
     },
-    "cypress/e2e/donor/payment.cy.js": {
+    "cypress/e2e/donor/long-running/payment.cy.js": {
         "time": 26656,
         "weight": 63
     },

--- a/web/template/voucher_start.gohtml
+++ b/web/template/voucher_start.gohtml
@@ -7,7 +7,7 @@
 
       {{ trHtml .App "voucherStartContent" }}
 
-      <p class="govuk-body">
+      <p class="govuk-body test">
         <a href="{{ link .App global.Paths.Voucher.Login.Format }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           {{ tr .App "start" }}
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/web/template/voucher_start.gohtml
+++ b/web/template/voucher_start.gohtml
@@ -7,7 +7,7 @@
 
       {{ trHtml .App "voucherStartContent" }}
 
-      <p class="govuk-body test">
+      <p class="govuk-body">
         <a href="{{ link .App global.Paths.Voucher.Login.Format }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
           {{ tr .App "start" }}
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">


### PR DESCRIPTION
# Purpose

A temporary rough breakdown of Cypress tests so we can bring down pipeline times by a few minutes. When/if we revisit our tests we can look at how we want to split them properly.

Fixes MLPAB-3706
