### PR TITLE
MLPAB-3705 - Explicitely fail merge queue when jobs fail

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -80,7 +80,7 @@ jobs:
             name: make-and-register-lpa-mainstream-content
             path: ./docker/mainstream-content/Dockerfile
             service_path: ./docker/mainstream-content
-            snyk_policy_path: docker/mainstream-content/.snyk
+            snyk_policy_path: ./docker/mainstream-content/.snyk
             scan_id: make_and_register_lpa_mainstream_content
             platforms: linux/arm64
 

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -149,7 +149,7 @@ jobs:
           sarif_filepath: ./test-results
           sarif_filename: ${{ matrix.scan_id }}_snyk.sarif
           snyk_policy_path: ${{ github.workspace }}/${{ matrix.snyk_policy_path }}
-          snyk_test_args: --severity-threshold=high --file=${{ matrix.path }}
+          snyk_test_args: --severity-threshold=high
 
       - name: Format undefined severity values
         if: always() && hashFiles(format('./test-results/{0}_snyk.sarif',

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -149,7 +149,7 @@ jobs:
           sarif_filepath: ./test-results
           sarif_filename: ${{ matrix.scan_id }}_snyk.sarif
           snyk_policy_path: ${{ github.workspace }}/${{ matrix.snyk_policy_path }}
-          snyk_test_args: --severity-threshold=high
+          snyk_test_args: --severity-threshold=high --file=${{ matrix.path }}
 
       - name: Format undefined severity values
         if: always() && hashFiles(format('./test-results/{0}_snyk.sarif',

--- a/.github/workflows/workflow_merge_queue.yml
+++ b/.github/workflows/workflow_merge_queue.yml
@@ -100,15 +100,44 @@ jobs:
       test_onelogin_totp_key: ${{ secrets.TEST_ONELOGIN_TOTP_KEY }}
       test_onelogin_password: ${{ secrets.TEST_ONELOGIN_PASSWORD }}
 
+  # end_of_workflow:
+  #   name: End of Workflow
+  #   runs-on: ubuntu-latest
+  #   environment: preproduction
+  #   needs: [ui_tests_preproduction_env]
+  #   steps:
+  #     - name: Complete
+  #       run: |
+  #         echo "preproduction environment tested, built and deployed"
   end_of_workflow:
     name: End of Workflow
     runs-on: ubuntu-latest
-    environment: preproduction
-    needs: [ui_tests_preproduction_env]
+    needs:
+      - go_unit_tests
+      - go_integration_tests
+      - docker_build_scan_push
+      - terraform_account_workflow_preproduction
+      - preproduction_deploy
+      - ui_tests_preproduction_env
+    environment:
+      name: "preproduction"
     steps:
-      - name: Complete
+      - name: End of Workflow
         run: |
-          echo "preproduction environment tested, built and deployed"
+          if ${{ contains(needs.go_unit_tests.result, 'success')}} &&
+            ${{ contains(needs.go_integration_tests.result, 'success')}} &&
+            ${{ contains(needs.docker_build_scan_push.result, 'success')}} &&
+            ${{ contains(needs.terraform_account_workflow_preproduction.result, 'success')}} &&
+            ${{ contains(needs.preproduction_deploy.result, 'success')}} &&
+            ${{ contains(needs.ui_tests_preproduction_env.result, 'success')}}; then
+            echo "Preproduction environment tested, built and deployed"
+            echo "Tag Deployed: integration-${{ needs.create_tags.outputs.version_tag }}"
+            exit 0
+          else
+            echo "Previous jobs in pipeline failed."
+            exit 1
+          fi
+    if: always()
 
   always_remove_ingress:
     name: Remove CI ingress from environment

--- a/.github/workflows/workflow_merge_queue.yml
+++ b/.github/workflows/workflow_merge_queue.yml
@@ -100,19 +100,11 @@ jobs:
       test_onelogin_totp_key: ${{ secrets.TEST_ONELOGIN_TOTP_KEY }}
       test_onelogin_password: ${{ secrets.TEST_ONELOGIN_PASSWORD }}
 
-  # end_of_workflow:
-  #   name: End of Workflow
-  #   runs-on: ubuntu-latest
-  #   environment: preproduction
-  #   needs: [ui_tests_preproduction_env]
-  #   steps:
-  #     - name: Complete
-  #       run: |
-  #         echo "preproduction environment tested, built and deployed"
   end_of_workflow:
     name: End of Workflow
     runs-on: ubuntu-latest
     needs:
+      - create_tags
       - go_unit_tests
       - go_integration_tests
       - docker_build_scan_push

--- a/.github/workflows/workflow_merge_queue.yml
+++ b/.github/workflows/workflow_merge_queue.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/terraform_environment_job.yml
     with:
       workspace_name: preproduction
-      version_tag: ${{ needs.create_tags.outputs.version_tag }}
+      version_tag: integration-${{ needs.create_tags.outputs.version_tag }}
       oidc_role_arn: ${{ vars.OIDC_TERRAFORM_ROLE_PREPRODUCTION }}
     secrets:
       ssh_deploy_key: ${{ secrets.OPG_MODERNISING_LPA_DEPLOY_KEY_PRIVATE_KEY }}

--- a/docker/mainstream-content/.snyk
+++ b/docker/mainstream-content/.snyk
@@ -35,5 +35,5 @@ ignore:
   SNYK-JS-BRACEEXPANSION-16755174:
     - "*":
         reason: None Given
-        expires: 2026-05-19T12:23:47.000Z
-        created: 2026-06-19T12:23:47.000Z
+        expires: 2026-06-19T12:23:47.000Z
+        created: 2026-05-19T12:23:47.000Z

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -83,12 +83,18 @@ resource "aws_dynamodb_resource_policy" "lpas_table_replica" {
   resource_arn = aws_dynamodb_table_replica.lpas_table[0].arn
   policy       = data.aws_iam_policy_document.lpas_table.json
   provider     = aws.eu_west_2
+  depends_on = [
+    module.global
+  ]
 }
 
 resource "aws_dynamodb_resource_policy" "lpas_table" {
   resource_arn = aws_dynamodb_table.lpas_table.arn
   policy       = data.aws_iam_policy_document.lpas_table.json
   provider     = aws.eu_west_1
+  depends_on = [
+    module.global
+  ]
 }
 
 data "aws_iam_policy_document" "lpas_table" {
@@ -259,12 +265,18 @@ resource "aws_dynamodb_resource_policy" "sessions_table_replica" {
   resource_arn = aws_dynamodb_table_replica.sessions_table[0].arn
   policy       = data.aws_iam_policy_document.sessions_table.json
   provider     = aws.eu_west_2
+  depends_on = [
+    module.global
+  ]
 }
 
 resource "aws_dynamodb_resource_policy" "sessions_table" {
   resource_arn = aws_dynamodb_table.sessions_table.arn
   policy       = data.aws_iam_policy_document.sessions_table.json
   provider     = aws.eu_west_1
+  depends_on = [
+    module.global
+  ]
 }
 
 data "aws_iam_policy_document" "sessions_table" {

--- a/terraform/environment/trigger_pr
+++ b/terraform/environment/trigger_pr
@@ -1,1 +1,0 @@
-this file is to trigger a mergable PR to test the merge queue


### PR DESCRIPTION
# Purpose

Merge queue was merging PR when End of Workflow job was skipped.

Fixes MLPAB-3705

## Approach

- Check all jobs passed or exit 1 on End of Workflow job
- Make sure that IAM roles are created before using them in DynamoDB resource policies
- Remove empty doc linting workflow
- Ignore mainstream content Snyk finding

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Modernising LPA service
