### PR TITLE
MLPAB-3700 - replace deprecated hash and range for key_schema

### DIFF
--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -18,15 +18,24 @@ resource "aws_dynamodb_table" "lpas_table" {
   range_key                   = "SK"
 
   global_secondary_index {
-    name            = "SKUpdatedAtIndex"
-    hash_key        = "SK"
-    range_key       = "UpdatedAt"
+    name = "SKUpdatedAtIndex"
+    key_schema {
+      attribute_name = "SK"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "UpdatedAt"
+      key_type       = "RANGE"
+    }
     projection_type = "ALL"
   }
 
   global_secondary_index {
-    name            = "LpaUIDIndex"
-    hash_key        = "LpaUID"
+    name = "LpaUIDIndex"
+    key_schema {
+      attribute_name = "LpaUID"
+      key_type       = "HASH"
+    }
     projection_type = "KEYS_ONLY"
   }
 


### PR DESCRIPTION
# Purpose

Multi-attribute keys for GSIs use the key_schema block instead of hash_key/range_key. The hash_key and range_key arguments are deprecated in favor of key_schema.

Fixes MLPAB-3700

## Approach

- replace deprecated hash and range keys with key_schema

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#basic-example-containing-global-secondary-indexes-using-multi-attribute-keys-pattern
