### PR TITLE
MLPAB-3701 - block customer provided keys for bucket encryption

### DIFF
--- a/terraform/account/region/load_balancer_access_logs_athena.tf
+++ b/terraform/account/region/load_balancer_access_logs_athena.tf
@@ -46,6 +46,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "athena_results" {
   bucket = aws_s3_bucket.athena_results[0].id
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"
       kms_master_key_id = var.athena_s3_target_key_id

--- a/terraform/account/region/load_balancer_access_logs_s3.tf
+++ b/terraform/account/region/load_balancer_access_logs_s3.tf
@@ -8,6 +8,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
   provider = aws.region
   bucket   = aws_s3_bucket.access_log.id
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
     apply_server_side_encryption_by_default {
       # Access logging for ALBs only supports Amazon S3 Managed Encryption Keys (SSE-S3)
       sse_algorithm = "aws:kms"

--- a/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
+++ b/terraform/account/region/modules/dynamodb_exports_s3_bucket/main.tf
@@ -26,6 +26,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   bucket = aws_s3_bucket.bucket.bucket
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
     apply_server_side_encryption_by_default {
       kms_master_key_id = var.s3_bucket_server_side_encryption_key_id
       sse_algorithm     = "aws:kms"

--- a/terraform/account/region/modules/s3_batch_manifests/s3.tf
+++ b/terraform/account/region/modules/s3_batch_manifests/s3.tf
@@ -6,6 +6,8 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"
       kms_master_key_id = data.aws_kms_alias.s3_encryption_kms_key_alias.target_key_id

--- a/terraform/environment/region/modules/uploads_s3_bucket/main.tf
+++ b/terraform/environment/region/modules/uploads_s3_bucket/main.tf
@@ -25,6 +25,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   bucket = aws_s3_bucket.bucket.bucket
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
     apply_server_side_encryption_by_default {
       kms_master_key_id = data.aws_kms_alias.reduced_fees_uploads_s3_encryption.target_key_id
       sse_algorithm     = "aws:kms"


### PR DESCRIPTION
# Purpose

Block use of customer provided keys for bucket encryption.

Fixes MLPAB-3701

## Approach

- block SSE-C use

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration#blocked_encryption_types-1
