### PR TITLE
MLPAB-3201 - Protect our domain from being spoofed in emails

### DIFF
--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -84,3 +84,62 @@ resource "aws_route53_record" "mainstream_content" {
     create_before_destroy = true
   }
 }
+
+# internal facing domain SPF and DMARC Records
+resource "aws_route53_record" "spf_app_modernising_lpa" {
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
+  name     = "${local.dns_namespace_for_environment}app.${data.aws_route53_zone.modernising_lpa.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "spf_app_modernising_lpa_redirect" {
+  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
+  name     = data.aws_route53_zone.modernising_lpa.name
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "dmarc_app_modernising_lpa" {
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
+  name     = "_dmarc.${local.dns_namespace_for_environment}app.${data.aws_route53_zone.modernising_lpa.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}
+
+resource "aws_route53_record" "dmarc_app_modernising_lpa_redirect" {
+  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
+  name     = "_dmarc.${data.aws_route53_zone.modernising_lpa.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -86,60 +86,14 @@ resource "aws_route53_record" "mainstream_content" {
 }
 
 # internal facing domain SPF and DMARC Records
-resource "aws_route53_record" "spf_app_modernising_lpa" {
-  provider = aws.management
-  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
-  name     = "${local.dns_namespace_for_environment}app.${data.aws_route53_zone.modernising_lpa.name}"
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=spf1 -all",
-  ]
-
-  lifecycle {
-    create_before_destroy = true
+module "dkim_app_modernising_lpa" {
+  source   = "./modules/dns_email_no_send"
+  dns_name = "${local.dns_namespace_for_environment}app."
+  aws_route53_zone = {
+    name    = data.aws_route53_zone.modernising_lpa.name
+    zone_id = data.aws_route53_zone.modernising_lpa.zone_id
   }
-}
-
-resource "aws_route53_record" "spf_app_modernising_lpa_redirect" {
-  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
-  provider = aws.management
-  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
-  name     = data.aws_route53_zone.modernising_lpa.name
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=spf1 -all",
-  ]
-
-  lifecycle {
-    create_before_destroy = true
+  providers = {
+    aws.management = aws.management
   }
-}
-
-resource "aws_route53_record" "dmarc_app_modernising_lpa" {
-  provider = aws.management
-  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
-  name     = "_dmarc.${local.dns_namespace_for_environment}app.${data.aws_route53_zone.modernising_lpa.name}"
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
-  ]
-}
-
-resource "aws_route53_record" "dmarc_app_modernising_lpa_redirect" {
-  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
-  provider = aws.management
-  zone_id  = data.aws_route53_zone.modernising_lpa.zone_id
-  name     = "_dmarc.${data.aws_route53_zone.modernising_lpa.name}"
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
-  ]
 }

--- a/terraform/environment/region/modules/dns_email_no_send/data_sources.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/data_sources.tf
@@ -1,0 +1,3 @@
+data "aws_default_tags" "current" {
+  provider = aws.region
+}

--- a/terraform/environment/region/modules/dns_email_no_send/data_sources.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/data_sources.tf
@@ -1,3 +1,0 @@
-data "aws_default_tags" "current" {
-  provider = aws.region
-}

--- a/terraform/environment/region/modules/dns_email_no_send/main.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/main.tf
@@ -1,0 +1,58 @@
+# internal facing domain SPF and DMARC Records
+resource "aws_route53_record" "spf" {
+  provider = aws.management
+  zone_id  = var.aws_route53_zone.zone_id
+  name     = "${var.dns_name}${var.aws_route53_zone.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "spf_redirect" {
+  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = var.aws_route53_zone.zone_id
+  name     = var.aws_route53_zone.name
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "dmarc" {
+  provider = aws.management
+  zone_id  = var.aws_route53_zone.zone_id
+  name     = "_dmarc.${var.dns_name}${var.aws_route53_zone.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}
+
+resource "aws_route53_record" "dmarc_redirect" {
+  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = var.aws_route53_zone.zone_id
+  name     = "_dmarc.${var.aws_route53_zone.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}

--- a/terraform/environment/region/modules/dns_email_no_send/main.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/main.tf
@@ -15,40 +15,10 @@ resource "aws_route53_record" "spf" {
   }
 }
 
-resource "aws_route53_record" "spf_redirect" {
-  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
-  provider = aws.management
-  zone_id  = var.aws_route53_zone.zone_id
-  name     = var.aws_route53_zone.name
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=spf1 -all",
-  ]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_route53_record" "dmarc" {
   provider = aws.management
   zone_id  = var.aws_route53_zone.zone_id
   name     = "_dmarc.${var.dns_name}${var.aws_route53_zone.name}"
-  type     = "TXT"
-  ttl      = "300"
-
-  records = [
-    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
-  ]
-}
-
-resource "aws_route53_record" "dmarc_redirect" {
-  count    = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
-  provider = aws.management
-  zone_id  = var.aws_route53_zone.zone_id
-  name     = "_dmarc.${var.aws_route53_zone.name}"
   type     = "TXT"
   ttl      = "300"
 

--- a/terraform/environment/region/modules/dns_email_no_send/variables.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/variables.tf
@@ -1,0 +1,12 @@
+variable "aws_route53_zone" {
+  type = object({
+    zone_id = string
+    name    = string
+  })
+  description = "A Route53 Hosted zone_id and name"
+}
+
+variable "dns_name" {
+  type        = string
+  description = "prefix part of the service url for example $${local.dns_namespace_for_environment}app."
+}

--- a/terraform/environment/region/modules/dns_email_no_send/versions.tf
+++ b/terraform/environment/region/modules/dns_email_no_send/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.44.0"
+      configuration_aliases = [
+        aws.management,
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Purpose

> Criminals can use unprotected domains for email spoofing and phishing, making it easier to commit fraud and damage trust in your organisation. 

from https://www.gov.uk/guidance/protect-domains-that-dont-send-email

Fixes MLPAB-3201

## Approach

- add an SPF record that says you do not have any sending servers
- add a DMARC record to reject any email from your domain

## Learning

- https://www.cloudflare.com/en-gb/learning/dns/dns-records/dns-dkim-record/
- https://www.gov.uk/guidance/protect-domains-that-dont-send-email
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record
- https://github.com/ministryofjustice/opg-lpa/blob/main/terraform/environment/modules/dns/main.tf
